### PR TITLE
Add input validation, minor refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
 # @metamask/key-tree
 
-```
+```text
 yarn add @metamask/key-tree
 ```
 
-An interface over bip32 + bip39 key derivation paths.
+An interface over BIP-32 and BIP-39 key derivation paths.
 
+## References
 
-
-### references
-- Bitcoin: BIP-0032 https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
-- Bitcoin: BIP-0039 https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki
-- Bitcoin: BIP-0044 https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
-- SatoshiLabs: SLIP-0044 https://github.com/satoshilabs/slips/blob/master/slip-0044.md
-- Network Working Group: "Key Derivation Functions and their Uses" https://trac.tools.ietf.org/html/draft-irtf-cfrg-kdf-uses-00
+- Bitcoin: [BIP-0032](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki)
+- Bitcoin: [BIP-0039](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki)
+- Bitcoin: [BIP-0044](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki)
+- SatoshiLabs: [SLIP-0044](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)
+- Network Working Group: ["Key Derivation Functions and their Uses"](https://trac.tools.ietf.org/html/draft-irtf-cfrg-kdf-uses-00)

--- a/src/derivers/bip32.js
+++ b/src/derivers/bip32.js
@@ -5,7 +5,6 @@ const assert = require('assert')
 const secp256k1 = require('secp256k1')
 const createKeccakHash = require('keccak')
 
-const ROOT_BASE_SECRET = Buffer.from('Bitcoin seed', 'utf8')
 const HARDENED_OFFSET = 0x80000000
 
 module.exports = {
@@ -17,7 +16,7 @@ module.exports = {
 }
 
 function bip32PathToMultipath(bip32Path) {
-  let pathParts = bip32Path.split('/')
+  let pathParts = bip32Path.trim().split('/')
   // strip "m" noop
   if (pathParts[0].toLowerCase() === 'm') pathParts = pathParts.slice(1)
   const multipath = pathParts.map(part => 'bip32:' + part).join('/')

--- a/src/derivers/bip39.js
+++ b/src/derivers/bip39.js
@@ -13,11 +13,11 @@ module.exports = {
 }
 
 function bip39MnemonicToMultipath(mnemonic) {
-  return `bip39:${mnemonic}`
+  return `bip39:${mnemonic.trim()}`
 }
 
 // this creates a child key using bip39, ignoring the parent key
-function deriveChildKey (parentKey, pathPart) {
+function deriveChildKey (_parentKey, pathPart) {
   const mnemonic = pathPart
   const seedBuffer = bip39.mnemonicToSeed(mnemonic)
   const entropy = crypto.createHmac('sha512', ROOT_BASE_SECRET).update(seedBuffer).digest()

--- a/src/derivers/index.js
+++ b/src/derivers/index.js
@@ -1,0 +1,7 @@
+const bip32 = require('./bip32')
+const bip39 = require('./bip39')
+
+module.exports = {
+  bip32,
+  bip39,
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,5 @@
 declare module "@metamask/key-tree" {
-  export function deriveKeyFromPath(pathSegment: string, parentKey: Buffer | null): Buffer;
+  export function deriveKeyFromPath(pathSegment: string, parentKey?: Buffer): Buffer;
   export function isValidFullPath(fullPath: string): boolean;
 }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,6 @@
 declare module "@metamask/key-tree" {
-  export function deriveKeyFromPath(key: Buffer | null, fullPath: String): Buffer;
+  export function deriveKeyFromPath(pathSegment: string, parentKey: Buffer | null): Buffer;
+  export function isValidFullPath(fullPath: string): boolean;
 }
 
 export interface Buffer {

--- a/test/index.js
+++ b/test/index.js
@@ -37,7 +37,7 @@ test('ethereum key test - full path', (t) => {
     const bip39Part = bip39MnemonicToMultipath(mnemonic)
     const multipath = `${bip39Part}/${bip32Part}`
     t.equal(multipath, `bip39:${mnemonic}/bip32:44'/bip32:60'/bip32:0'/bip32:0/bip32:${index}`, 'matches expected multipath')
-    return deriveKeyFromPath(multipath, null)
+    return deriveKeyFromPath(multipath)
   })
   // validate addresses
   keys.map((key, index) => {
@@ -53,7 +53,7 @@ test('ethereum key test - parent key reuse', (t) => {
   const bip32Part = bip32PathToMultipath(`${defaultEthereumPath}`)
   const bip39Part = bip39MnemonicToMultipath(mnemonic)
   const multipath = `${bip39Part}/${bip32Part}`
-  const parentKey = deriveKeyFromPath(multipath, null)
+  const parentKey = deriveKeyFromPath(multipath)
   const keys = expectedAddresses.map((_, index) => {
     return deriveKeyFromPath(`bip32:${index}`, parentKey)
   })

--- a/test/index.js
+++ b/test/index.js
@@ -2,16 +2,18 @@ const test = require('tape')
 
 const {
   deriveKeyFromPath,
-} = require('../src/index')
+} = require('../src')
 const {
-  deriveChildKey: bip32Derive,
-  bip32PathToMultipath,
-  privateKeyToEthAddress,
-} = require('../src/derivers/bip32')
-const {
-  deriveChildKey: bip39Derive,
-  bip39MnemonicToMultipath,
-} = require('../src/derivers/bip39')
+  bip32: {
+    deriveChildKey: bip32Derive,
+    bip32PathToMultipath,
+    privateKeyToEthAddress,
+  },
+  bip39: {
+    deriveChildKey: bip39Derive,
+    bip39MnemonicToMultipath,
+  }
+} = require('../src/derivers')
 
 const defaultEthereumPath = `m/44'/60'/0'/0`
 const mnemonic = 'romance hurry grit huge rifle ordinary loud toss sound congress upset twist'
@@ -35,7 +37,7 @@ test('ethereum key test - full path', (t) => {
     const bip39Part = bip39MnemonicToMultipath(mnemonic)
     const multipath = `${bip39Part}/${bip32Part}`
     t.equal(multipath, `bip39:${mnemonic}/bip32:44'/bip32:60'/bip32:0'/bip32:0/bip32:${index}`, 'matches expected multipath')
-    return deriveKeyFromPath(null, multipath)
+    return deriveKeyFromPath(multipath, null)
   })
   // validate addresses
   keys.map((key, index) => {
@@ -51,10 +53,11 @@ test('ethereum key test - parent key reuse', (t) => {
   const bip32Part = bip32PathToMultipath(`${defaultEthereumPath}`)
   const bip39Part = bip39MnemonicToMultipath(mnemonic)
   const multipath = `${bip39Part}/${bip32Part}`
-  const parentKey = deriveKeyFromPath(null, multipath)
+  const parentKey = deriveKeyFromPath(multipath, null)
   const keys = expectedAddresses.map((_, index) => {
-    return deriveKeyFromPath(parentKey, `bip32:${index}`)
+    return deriveKeyFromPath(`bip32:${index}`, parentKey)
   })
+
   // validate addresses
   keys.map((key, index) => {
     const address = privateKeyToEthAddress(key)


### PR DESCRIPTION
This PR adds input validation to ensure that only properly formatted paths are processed by `deriveKeyFromPath`. Aside from internal import/export refactoring, the only functional change is the added input validation, and the tests, which are functionally unchanged, pass.

This PR is intended as the first entry before a major version bump, due to this package's anticipated production use. Therefore, the following breaking, but not cryptographically relevant changes, are made:
- `deriveKeyFromPath`: Change the order of parameters
  - The first parameter was often `null`, which is unergonomic
- Add `index.js` file to `derivers` directory, re-export individual derivers from there
  - We (I?) love being agnostic of directory structure when importing!
- Update readme
- Delete dead code