### PR TITLE
Fix multipath RegEx

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ const BIP_39_PATH_REGEX = /^bip39:(\w+){1}( \w+){11,23}$/u;
  * -  bip32:44'/bip32:60'/bip32:0'/bip32:0/bip32:0
  * -  bip39:<SPACE_DELMITED_SEED_PHRASE>/bip32:44'/bip32:60'/bip32:0'/bip32:0/bip32:0
  */
-const MULTI_PATH_REGEX = /^(bip39:(\w+){1}( \w+){11,23}\/)?(bip32:\d+'?\/){3,4}(bip32:\d+'?)$/u;
+const MULTI_PATH_REGEX = /^(bip39:(\w+){1}( \w+){11,23}\/)?(bip32:\d+'?\/){0,4}(bip32:\d+'?)$/u;
 
 function validateDeriveKeyParams(pathSegment, parentKey) {
   // The path segment must be one of the following:

--- a/test/index.js
+++ b/test/index.js
@@ -37,7 +37,7 @@ test('deriveKeyPath - full path', (t) => {
     t.strictEqual(
       multipath,
       `bip39:${mnemonic}/bip32:44'/bip32:60'/bip32:0'/bip32:0/bip32:${index}`,
-      'matches expected multipath'
+      'matches expected multipath',
     );
     return deriveKeyFromPath(multipath);
   });
@@ -106,7 +106,7 @@ test('deriveKeyPath - input validation', (t) => {
       deriveKeyFromPath('bip32:1', parentKey.toString('utf8'));
     },
     { message: 'Parent key must be a Buffer if specified.' },
-    'should throw expected error'
+    'should throw expected error',
   );
 
   t.end();
@@ -117,7 +117,7 @@ test('ethereum key test - direct derive', (t) => {
   let parentKey = null;
   parentKey = bip39Derive(
     parentKey,
-    `romance hurry grit huge rifle ordinary loud toss sound congress upset twist`
+    `romance hurry grit huge rifle ordinary loud toss sound congress upset twist`,
   );
   parentKey = bip32Derive(parentKey, `44'`);
   parentKey = bip32Derive(parentKey, `60'`);

--- a/test/index.js
+++ b/test/index.js
@@ -1,22 +1,20 @@
 const test = require('tape');
 
-const {
-  deriveKeyFromPath,
-} = require('../src');
+const { deriveKeyFromPath } = require('../src');
 const {
   bip32: {
     deriveChildKey: bip32Derive,
     bip32PathToMultipath,
     privateKeyToEthAddress,
   },
-  bip39: {
-    deriveChildKey: bip39Derive,
-    bip39MnemonicToMultipath,
-  },
+  bip39: { deriveChildKey: bip39Derive, bip39MnemonicToMultipath },
 } = require('../src/derivers');
 
 const defaultEthereumPath = `m/44'/60'/0'/0`;
-const mnemonic = 'romance hurry grit huge rifle ordinary loud toss sound congress upset twist';
+
+const mnemonic =
+  'romance hurry grit huge rifle ordinary loud toss sound congress upset twist';
+
 const expectedAddresses = [
   '5df603999c3d5ca2ab828339a9883585b1bce11b',
   '441c07e32a609afd319ffbb66432b424058bcfe9',
@@ -30,25 +28,29 @@ const expectedAddresses = [
   '7b99c781cbfff075229314ccbdc7f6d9e8440ad9',
 ];
 
-test('ethereum key test - full path', (t) => {
+test('deriveKeyPath - full path', (t) => {
   // generate keys
   const keys = expectedAddresses.map((_, index) => {
     const bip32Part = bip32PathToMultipath(`${defaultEthereumPath}/${index}`);
     const bip39Part = bip39MnemonicToMultipath(mnemonic);
     const multipath = `${bip39Part}/${bip32Part}`;
-    t.equal(multipath, `bip39:${mnemonic}/bip32:44'/bip32:60'/bip32:0'/bip32:0/bip32:${index}`, 'matches expected multipath');
+    t.strictEqual(
+      multipath,
+      `bip39:${mnemonic}/bip32:44'/bip32:60'/bip32:0'/bip32:0/bip32:${index}`,
+      'matches expected multipath'
+    );
     return deriveKeyFromPath(multipath);
   });
   // validate addresses
   keys.forEach((key, index) => {
     const address = privateKeyToEthAddress(key);
-    t.equal(address.toString('hex'), expectedAddresses[index]);
+    t.strictEqual(address.toString('hex'), expectedAddresses[index]);
   });
 
   t.end();
 });
 
-test('ethereum key test - parent key reuse', (t) => {
+test('deriveKeyPath - parent key reuse', (t) => {
   // generate parent key
   const bip32Part = bip32PathToMultipath(`${defaultEthereumPath}`);
   const bip39Part = bip39MnemonicToMultipath(mnemonic);
@@ -61,8 +63,51 @@ test('ethereum key test - parent key reuse', (t) => {
   // validate addresses
   keys.forEach((key, index) => {
     const address = privateKeyToEthAddress(key);
-    t.equal(address.toString('hex'), expectedAddresses[index]);
+    t.strictEqual(address.toString('hex'), expectedAddresses[index]);
   });
+
+  t.end();
+});
+
+test('deriveKeyPath - input validation', (t) => {
+  // generate parent key
+  const bip32Part = bip32PathToMultipath(`${defaultEthereumPath}`);
+  const bip39Part = bip39MnemonicToMultipath(mnemonic);
+  const multipath = `${bip39Part}/${bip32Part}`;
+  const parentKey = deriveKeyFromPath(multipath);
+
+  // Malformed multipaths are disallowed
+  t.throws(() => {
+    deriveKeyFromPath(multipath.replace(/bip39/u, `foo`));
+  }, /Invalid HD path segment\./u);
+  t.throws(() => {
+    deriveKeyFromPath(multipath.replace(/bip32/u, `bar`));
+  }, /Invalid HD path segment\./u);
+  t.throws(() => {
+    deriveKeyFromPath(multipath.replace(/44'/u, `xyz'`));
+  }, /Invalid HD path segment\./u);
+  t.throws(() => {
+    deriveKeyFromPath(multipath.replace(/'/u, `"`));
+  }, /Invalid HD path segment\./u);
+
+  // Multipaths that start with bip39 segment require _no_ parentKey
+  t.throws(() => {
+    deriveKeyFromPath(bip39Part, parentKey);
+  }, /May not specify parent key and BIP-39 path segment\./u);
+
+  // Multipaths that start with bip32 segment require parentKey
+  t.throws(() => {
+    deriveKeyFromPath('bip32:1');
+  }, /Must specify parent key/u);
+
+  // parentKey must be a buffer if specified
+  t.throws(
+    () => {
+      deriveKeyFromPath('bip32:1', parentKey.toString('utf8'));
+    },
+    { message: 'Parent key must be a Buffer if specified.' },
+    'should throw expected error'
+  );
 
   t.end();
 });
@@ -70,7 +115,10 @@ test('ethereum key test - parent key reuse', (t) => {
 test('ethereum key test - direct derive', (t) => {
   // generate parent key
   let parentKey = null;
-  parentKey = bip39Derive(parentKey, `romance hurry grit huge rifle ordinary loud toss sound congress upset twist`);
+  parentKey = bip39Derive(
+    parentKey,
+    `romance hurry grit huge rifle ordinary loud toss sound congress upset twist`
+  );
   parentKey = bip32Derive(parentKey, `44'`);
   parentKey = bip32Derive(parentKey, `60'`);
   parentKey = bip32Derive(parentKey, `0'`);
@@ -81,7 +129,7 @@ test('ethereum key test - direct derive', (t) => {
   // validate addresses
   keys.forEach((key, index) => {
     const address = privateKeyToEthAddress(key);
-    t.equal(address.toString('hex'), expectedAddresses[index]);
+    t.strictEqual(address.toString('hex'), expectedAddresses[index]);
   });
 
   t.end();

--- a/test/index.js
+++ b/test/index.js
@@ -112,7 +112,7 @@ test('deriveKeyPath - input validation', (t) => {
   t.end();
 });
 
-test('ethereum key test - direct derive', (t) => {
+test('bip32Derive', (t) => {
   // generate parent key
   let parentKey = null;
   parentKey = bip39Derive(


### PR DESCRIPTION
This updates the multipath validation to allow for a broader range of sub-paths, and adds unit tests for the input validation. Paths starting with `bip32` segments will still require a `parentKey` to be specified, and paths starting with `bip39` will still require that **no** `parentKey` is specified. Paths longer than 5 `bip32` segments will not be accepted, because [BIP-44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki) only defines paths of length 5, excluding the seed.

Specifically, we change the quantifier for intermediate `bip32` path segments of the multipath RegEx from `{3,4}` to `{0,4}`. In conjunction with the other RegEx validators, this means that the following multipaths will now be accepted:
```
bip32:44'/bip32:60'/bip32:0'/bip32:0/bip32:0
bip32:44'/bip32:60'/bip32:0'/bip32:0
bip32:44'/bip32:60'/bip32:0'
bip32:44'/bip32:60'
bip32:44'

bip39:a b c d e f g h i j k l/bip32:44'/bip32:60'/bip32:0'/bip32:0/bip32:0
bip39:a b c d e f g h i j k l/bip32:44'/bip32:60'/bip32:0'/bip32:0
bip39:a b c d e f g h i j k l/bip32:44'/bip32:60'/bip32:0'
bip39:a b c d e f g h i j k l/bip32:44'/bip32:60'
bip39:a b c d e f g h i j k l/bip32:44'
bip39:a b c d e f g h i j k l
```

_Prior to this PR_, only the following multipaths were accepted:
```
bip32:44'/bip32:60'/bip32:0'/bip32:0/bip32:0
bip32:44'/bip32:60'/bip32:0'/bip32:0
bip32:44'

bip39:a b c d e f g h i j k l/bip32:44'/bip32:60'/bip32:0'/bip32:0/bip32:0
bip39:a b c d e f g h i j k l/bip32:44'/bip32:60'/bip32:0'/bip32:0
bip39:a b c d e f g h i j k l
```