### PR TITLE
Ensure bip39 validation rejects non-lowercase seed phrases

### DIFF
--- a/src/derivers/bip39.ts
+++ b/src/derivers/bip39.ts
@@ -4,7 +4,7 @@ import bip39 from 'bip39';
 const ROOT_BASE_SECRET = Buffer.from('Bitcoin seed', 'utf8');
 
 export function bip39MnemonicToMultipath(mnemonic: string): string {
-  return `bip39:${mnemonic.trim()}`;
+  return `bip39:${mnemonic.toLowerCase().trim()}`;
 }
 
 // this creates a child key using bip39, ignoring the parent key

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,14 +58,14 @@ const BIP_32_PATH_REGEX = /^bip32:\d+'?$/u;
  *
  * The seed phrase must consist of 12 <= 24 words.
  */
-const BIP_39_PATH_REGEX = /^bip39:(\w+){1}( \w+){11,23}$/u;
+const BIP_39_PATH_REGEX = /^bip39:([a-z]+){1}( [a-z]+){11,23}$/u;
 
 /**
  * e.g.
  * -  bip32:44'/bip32:60'/bip32:0'/bip32:0/bip32:0
  * -  bip39:<SPACE_DELMITED_SEED_PHRASE>/bip32:44'/bip32:60'/bip32:0'/bip32:0/bip32:0
  */
-const MULTI_PATH_REGEX = /^(bip39:(\w+){1}( \w+){11,23}\/)?(bip32:\d+'?\/){0,4}(bip32:\d+'?)$/u;
+const MULTI_PATH_REGEX = /^(bip39:([a-z]+){1}( [a-z]+){11,23}\/)?(bip32:\d+'?\/){0,4}(bip32:\d+'?)$/u;
 
 function validateDeriveKeyParams(pathSegment: string, parentKey: Buffer) {
   // The path segment must be one of the following:

--- a/test/index.js
+++ b/test/index.js
@@ -90,6 +90,11 @@ test('deriveKeyPath - input validation', (t) => {
     deriveKeyFromPath(multipath.replace(/'/u, `"`));
   }, /Invalid HD path segment\./u);
 
+  // bip39 seed phrase component must be completely lowercase
+  t.throws(() => {
+    deriveKeyFromPath(bip39Part.replace('r', 'R'));
+  }, /Invalid HD path segment\./u);
+
   // Multipaths that start with bip39 segment require _no_ parentKey
   t.throws(() => {
     deriveKeyFromPath(bip39Part, parentKey);


### PR DESCRIPTION
Fixes a bug in input validation where BIP-39 seed phrases could contain non-lowercase letters.