### PR TITLE
@metamask/key-tree 3.0

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,6 +38,24 @@ module.exports = {
       files: ['*.test.ts', '*.test.js'],
       extends: ['@metamask/eslint-config-jest'],
     },
+
+    // Allow expect(value).toMatchSnapshot in this file only
+    {
+      files: ['./test/reference-implementations.test.ts'],
+      rules: {
+        'jest/no-restricted-matchers': [
+          'error',
+          {
+            resolves: 'Use `expect(await promise)` instead.',
+            toBeFalsy: 'Avoid `toBeFalsy`',
+            toBeTruthy: 'Avoid `toBeTruthy`',
+            // toMatchSnapshot: ...
+            toThrowErrorMatchingSnapshot:
+              'Use `toThrowErrorMatchingInlineSnapshot()` instead',
+          },
+        ],
+      },
+    },
   ],
 
   ignorePatterns: ['!.eslintrc.js', '!.prettierrc.js', 'dist/'],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,16 @@ module.exports = {
 
   extends: ['@metamask/eslint-config'],
 
+  rules: {
+    camelcase: [
+      'error',
+      {
+        properties: 'never',
+        allow: ['^UNSAFE_', 'coin_type', 'address_index'],
+      },
+    ],
+  },
+
   overrides: [
     {
       files: ['*.d.ts'],

--- a/README.md
+++ b/README.md
@@ -38,13 +38,11 @@ const coinType = 60;
 // the user's mnemonic.
 const mnemonic = getMnemonic();
 
-const coinTypeNode = new BIP44Node({
-  derivationPath: [
-    `bip39:${mnemonic}`,
-    `bip32:44'`, // By BIP-44, the "purpose" node must be "44'"
-    `bip32:${coinType}'`,
-  ],
-});
+const coinTypeNode = new BIP44CoinTypeNode([
+  `bip39:${mnemonic}`,
+  `bip32:44'`, // By BIP-44, the "purpose" node must be "44'"
+  `bip32:${coinType}'`,
+]);
 
 // Imagine that this is some Node.js stream, but it could be anything that
 // can transmit JSON messages, such as window.postMessage.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,112 @@
 # @metamask/key-tree
 
-```text
-yarn add @metamask/key-tree
+An interface over [BIP-44] key derivation paths.
+
+## Installation
+
+`yarn add @metamask/key-tree`
+
+or
+
+`npm install @metamask/key-tree`
+
+## Usage
+
+This package is designed to accommodate the creation of keys for any level of a BIP-44 path.
+Recall that a BIP-44 HD tree path consists of the following nodes (and depths):
+
+> `m / 44' / coin_type' / account' / change / address_index`
+>
+> `0 / 1 / 2 / 3 / 4 / 5`
+
+Where `m` is the "master" or seed node, `coin_type` indicates the protocol for which deeper keys are intended,
+and `address_index` usually furnishes key pairs intended for user addresses / accounts.
+For details, refer to the [BIP-44] specification.
+For the authoritative list of protocol `coin_type` indices, see [SLIP-44].
+
+This package exports two classes intended to facilitate the creation of keys in contexts with different privileges.
+They are used as follows.
+
+```typescript
+import { BIP44CoinTypeNode } from '@metamask/key-tree';
+
+// Per SLIP-44, Ethereum has a coin_type of 60.
+// Ethereum is only used by way of example.
+const coinType = 60;
+
+// Imagine that this takes place in some privileged context with access to
+// the user's mnemonic.
+const mnemonic = getMnemonic();
+
+const coinTypeNode = new BIP44Node({
+  derivationPath: [
+    `bip39:${mnemonic}`,
+    `bip32:44'`, // By BIP-44, the "purpose" node must be "44'"
+    `bip32:${coinType}'`,
+  ],
+});
+
+// Imagine that this is some Node.js stream, but it could be anything that
+// can transmit JSON messages, such as window.postMessage.
+stream.write(coinTypeNode.toJSON());
+
+//===============================
+// Then, on the receiving end...
+//===============================
+
+import { getBIP44AddressKeyDeriver } from '@metamask/key-tree';
+
+// Get the node sent from the privileged context.
+// It will have the following shape:
+//   {
+//     key, // A Base64 string of the coin_type key
+//     depth, // The number 2, which is the depth of coin_type nodes
+//     coin_type, // In this case, the number 60
+//     path, // For visualization only. In this case: m / 44' / 60'
+//   }
+const coinTypeNode = await getCoinTypeNode();
+
+// Get an address key deriver for the coin_type node.
+// In this case, its path will be: m / 44' / 60' / 0' / 0 / address_index
+const addressKeyDeriver = getBIP44AddressKeyDeriver(coinTypeNode);
+
+// These are Node.js Buffer representations of the extended private keys for
+// the respective addresses.
+
+// m / 44' / 60' / 0' / 0 / 0
+const addressKey0 = addressKeyDeriver(0);
+
+// m / 44' / 60' / 0' / 0 / 1
+const addressKey1 = addressKeyDeriver(1);
+
+// Now, the extended private keys can be used to derive the corresponding public
+// keys and protocol addresses.
 ```
 
-An interface over BIP-32 and BIP-39 key derivation paths.
+There are other ways of deriving keys in addition to the above example.
+See the docstrings in the [BIP44Node](./src/BIP44Node.ts) and [BIP44CoinTypeNode](./src/BIP44CoinTypeNode.ts) files for details.
 
-## References
+### Internals
 
-- Bitcoin: [BIP-0032](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki)
-- Bitcoin: [BIP-0039](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki)
-- Bitcoin: [BIP-0044](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki)
-- SatoshiLabs: [SLIP-0044](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)
+This package also has methods for deriving arbitrary BIP-32 keys, and generating seeds from BIP-39 mnemonics.
+These methods do not constitute a safe key derivation API, and their use is **strongly discouraged**.
+Nevertheless, since those methods were the main exports of this package prior to version `3.0.0`, consumers can
+still access them by importing `@metamask/key-tree/derivation`.
+
+## Security
+
+This package is rigorously tested against reference implementations and the [BIP-32] specification.
+See the [reference implementation tests](./test/reference-implementations.test.ts) for details.
+
+## Further Reading
+
+- [BIP-32]
+- [BIP-39]
+- [BIP-44]
+- [SLIP-44]
 - Network Working Group: ["Key Derivation Functions and their Uses"](https://trac.tools.ietf.org/html/draft-irtf-cfrg-kdf-uses-00)
+
+[bip-32]: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
+[bip-39]: https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki
+[bip-44]: https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
+[slip-44]: https://github.com/satoshilabs/slips/blob/master/slip-0044.md

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,6 +13,11 @@ module.exports = {
   //     statements: 100,
   //   },
   // },
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.test.json',
+    },
+  },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],
   preset: 'ts-jest',
   // "resetMocks" resets all mocks, including mocked modules, to jest.fn(),

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,15 +4,14 @@ module.exports = {
   // ones.
   collectCoverageFrom: ['./src/**/*.ts'],
   coverageReporters: ['text', 'html'],
-  // TODO
-  // coverageThreshold: {
-  //   global: {
-  //     branches: 100,
-  //     functions: 100,
-  //     lines: 100,
-  //     statements: 100,
-  //   },
-  // },
+  coverageThreshold: {
+    global: {
+      branches: 100,
+      functions: 100,
+      lines: 100,
+      statements: 100,
+    },
+  },
   globals: {
     'ts-jest': {
       tsconfig: 'tsconfig.test.json',

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "eslint-plugin-jsdoc": "^36.1.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.0.0",
+    "ethereumjs-wallet": "^1.0.2",
     "jest": "^27.2.5",
     "prettier": "^2.4.1",
     "prettier-plugin-packagejson": "^2.2.13",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "eslint-plugin-jsdoc": "^36.1.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.0.0",
+    "eth-hd-keyring": "^3.6.0",
     "ethereumjs-wallet": "^1.0.2",
     "jest": "^27.2.5",
     "prettier": "^2.4.1",

--- a/src/BIP44CoinTypeNode.test.ts
+++ b/src/BIP44CoinTypeNode.test.ts
@@ -1,0 +1,47 @@
+import fixtures from '../test/fixtures';
+import { BIP44CoinTypeNode } from './BIP44CoinTypeNode';
+import { BIP44PurposeNode } from './constants';
+
+const defaultBip39Node = `bip39:${fixtures.local.mnemonic}` as const;
+
+describe('BIP44CoinTypeNode', () => {
+  describe('constructor', () => {
+    it('initializes a BIP44CoinTypeNode', () => {
+      const node = new BIP44CoinTypeNode([
+        defaultBip39Node,
+        BIP44PurposeNode,
+        `bip32:60'`,
+      ]);
+      const expectedCoinType = 60;
+      const expectedPath = `m / bip32:44' / bip32:${expectedCoinType}'`;
+
+      expect(node.coin_type).toStrictEqual(expectedCoinType);
+      expect(node.depth).toStrictEqual(2);
+      expect(node.key).toHaveLength(88);
+      expect(node.path).toStrictEqual(expectedPath);
+
+      expect(node.toJSON()).toStrictEqual({
+        coin_type: expectedCoinType,
+        depth: 2,
+        key: node.key,
+        path: expectedPath,
+      });
+    });
+  });
+
+  describe('deriveBIP44Address', () => {
+    it.todo('derives an address key');
+  });
+
+  describe('toJSON', () => {
+    it.todo('returns a JSON-compatible representation of the node');
+  });
+});
+
+describe('deriveBIP44AddressKey', () => {
+  it.todo('derives a BIP-44 address key');
+});
+
+describe('getBIP44AddressKeyDeriver', () => {
+  it.todo('returns a BIP-44 address key deriver function');
+});

--- a/src/BIP44CoinTypeNode.test.ts
+++ b/src/BIP44CoinTypeNode.test.ts
@@ -154,7 +154,7 @@ describe('BIP44CoinTypeNode', () => {
     });
   });
 
-  describe('deriveBIP44Address', () => {
+  describe('deriveBIP44AddressKey', () => {
     const coinTypePath = [
       defaultBip39Node,
       BIP44PurposeNode,
@@ -173,7 +173,9 @@ describe('BIP44CoinTypeNode', () => {
       ]);
 
       expect(
-        coinTypeNode.deriveBIP44Address({ address_index: 0 }).key,
+        coinTypeNode
+          .deriveBIP44AddressKey({ address_index: 0 })
+          .toString('base64'),
       ).toStrictEqual(expectedKey);
     });
 
@@ -189,7 +191,9 @@ describe('BIP44CoinTypeNode', () => {
       ]);
 
       expect(
-        coinTypeNode.deriveBIP44Address({ address_index: 99 }).key,
+        coinTypeNode
+          .deriveBIP44AddressKey({ address_index: 99 })
+          .toString('base64'),
       ).toStrictEqual(expectedKey);
     });
 
@@ -205,7 +209,9 @@ describe('BIP44CoinTypeNode', () => {
       ]);
 
       expect(
-        coinTypeNode.deriveBIP44Address({ account: 4, address_index: 0 }).key,
+        coinTypeNode
+          .deriveBIP44AddressKey({ account: 4, address_index: 0 })
+          .toString('base64'),
       ).toStrictEqual(expectedKey);
     });
 
@@ -221,7 +227,9 @@ describe('BIP44CoinTypeNode', () => {
       ]);
 
       expect(
-        coinTypeNode.deriveBIP44Address({ change: 3, address_index: 0 }).key,
+        coinTypeNode
+          .deriveBIP44AddressKey({ change: 3, address_index: 0 })
+          .toString('base64'),
       ).toStrictEqual(expectedKey);
     });
 
@@ -237,11 +245,13 @@ describe('BIP44CoinTypeNode', () => {
       ]);
 
       expect(
-        coinTypeNode.deriveBIP44Address({
-          account: 4,
-          change: 3,
-          address_index: 0,
-        }).key,
+        coinTypeNode
+          .deriveBIP44AddressKey({
+            account: 4,
+            change: 3,
+            address_index: 0,
+          })
+          .toString('base64'),
       ).toStrictEqual(expectedKey);
     });
   });

--- a/src/BIP44CoinTypeNode.test.ts
+++ b/src/BIP44CoinTypeNode.test.ts
@@ -3,19 +3,19 @@ import {
   BIP_44_COIN_TYPE_DEPTH,
   BIP44Node,
   BIP44CoinTypeNode,
-  BIP44PurposeNode,
+  BIP44PurposeNodeToken,
   deriveBIP44AddressKey,
   getBIP44AddressKeyDeriver,
 } from '.';
 
-const defaultBip39Node = `bip39:${fixtures.local.mnemonic}` as const;
+const defaultBip39NodeToken = `bip39:${fixtures.local.mnemonic}` as const;
 
 describe('BIP44CoinTypeNode', () => {
   describe('constructor', () => {
     it('initializes a BIP44CoinTypeNode (derivation path)', () => {
       const node = new BIP44CoinTypeNode([
-        defaultBip39Node,
-        BIP44PurposeNode,
+        defaultBip39NodeToken,
+        BIP44PurposeNodeToken,
         `bip32:60'`,
       ]);
       const coinType = 60;
@@ -37,7 +37,11 @@ describe('BIP44CoinTypeNode', () => {
 
     it('initializes a BIP44CoinTypeNode (BIP44Node)', () => {
       const bip44Node = new BIP44Node({
-        derivationPath: [defaultBip39Node, BIP44PurposeNode, `bip32:60'`],
+        derivationPath: [
+          defaultBip39NodeToken,
+          BIP44PurposeNodeToken,
+          `bip32:60'`,
+        ],
       });
 
       const coinType = 60;
@@ -60,7 +64,11 @@ describe('BIP44CoinTypeNode', () => {
 
     it('initializes a BIP44CoinTypeNode (serialized BIP44Node)', () => {
       const bip44Node = new BIP44Node({
-        derivationPath: [defaultBip39Node, BIP44PurposeNode, `bip32:60'`],
+        derivationPath: [
+          defaultBip39NodeToken,
+          BIP44PurposeNodeToken,
+          `bip32:60'`,
+        ],
       });
 
       const coinType = 60;
@@ -85,7 +93,7 @@ describe('BIP44CoinTypeNode', () => {
       expect(
         () =>
           new BIP44CoinTypeNode(
-            [defaultBip39Node, BIP44PurposeNode, `bip32:60'`],
+            [defaultBip39NodeToken, BIP44PurposeNodeToken, `bip32:60'`],
             60,
           ),
       ).toThrow(
@@ -95,8 +103,8 @@ describe('BIP44CoinTypeNode', () => {
 
     it('throws if derivation path has invalid depth', () => {
       [
-        [defaultBip39Node, BIP44PurposeNode],
-        [defaultBip39Node, BIP44PurposeNode, `bip32:60'`, `bip32:0'`],
+        [defaultBip39NodeToken, BIP44PurposeNodeToken],
+        [defaultBip39NodeToken, BIP44PurposeNodeToken, `bip32:60'`, `bip32:0'`],
       ].forEach((invalidDerivationPath) => {
         expect(
           () => new BIP44CoinTypeNode(invalidDerivationPath as any),
@@ -141,7 +149,11 @@ describe('BIP44CoinTypeNode', () => {
 
     it('throws if coin type is invalid', () => {
       const jsonNode = new BIP44Node({
-        derivationPath: [defaultBip39Node, BIP44PurposeNode, `bip32:60'`],
+        derivationPath: [
+          defaultBip39NodeToken,
+          BIP44PurposeNodeToken,
+          `bip32:60'`,
+        ],
       }).toJSON();
 
       ['60', 1.1, -1, {}].forEach((invalidCoinType) => {
@@ -156,8 +168,8 @@ describe('BIP44CoinTypeNode', () => {
 
   describe('deriveBIP44AddressKey', () => {
     const coinTypePath = [
-      defaultBip39Node,
-      BIP44PurposeNode,
+      defaultBip39NodeToken,
+      BIP44PurposeNodeToken,
       `bip32:60'`,
     ] as const;
 
@@ -167,8 +179,8 @@ describe('BIP44CoinTypeNode', () => {
       }).key;
 
       const coinTypeNode = new BIP44CoinTypeNode([
-        defaultBip39Node,
-        BIP44PurposeNode,
+        defaultBip39NodeToken,
+        BIP44PurposeNodeToken,
         `bip32:60'`,
       ]);
 
@@ -185,8 +197,8 @@ describe('BIP44CoinTypeNode', () => {
       }).key;
 
       const coinTypeNode = new BIP44CoinTypeNode([
-        defaultBip39Node,
-        BIP44PurposeNode,
+        defaultBip39NodeToken,
+        BIP44PurposeNodeToken,
         `bip32:60'`,
       ]);
 
@@ -203,8 +215,8 @@ describe('BIP44CoinTypeNode', () => {
       }).key;
 
       const coinTypeNode = new BIP44CoinTypeNode([
-        defaultBip39Node,
-        BIP44PurposeNode,
+        defaultBip39NodeToken,
+        BIP44PurposeNodeToken,
         `bip32:60'`,
       ]);
 
@@ -221,8 +233,8 @@ describe('BIP44CoinTypeNode', () => {
       }).key;
 
       const coinTypeNode = new BIP44CoinTypeNode([
-        defaultBip39Node,
-        BIP44PurposeNode,
+        defaultBip39NodeToken,
+        BIP44PurposeNodeToken,
         `bip32:60'`,
       ]);
 
@@ -239,8 +251,8 @@ describe('BIP44CoinTypeNode', () => {
       }).key;
 
       const coinTypeNode = new BIP44CoinTypeNode([
-        defaultBip39Node,
-        BIP44PurposeNode,
+        defaultBip39NodeToken,
+        BIP44PurposeNodeToken,
         `bip32:60'`,
       ]);
 
@@ -260,8 +272,8 @@ describe('BIP44CoinTypeNode', () => {
     it('returns a JSON-compatible representation of the node', () => {
       const coinType = 60;
       const node = new BIP44CoinTypeNode([
-        defaultBip39Node,
-        BIP44PurposeNode,
+        defaultBip39NodeToken,
+        BIP44PurposeNodeToken,
         `bip32:${coinType}'`,
       ]);
       const pathString = `m / bip32:44' / bip32:${coinType}'`;
@@ -295,15 +307,15 @@ describe('deriveBIP44AddressKey', () => {
   it('derives a BIP-44 address key (default inputs)', () => {
     const coinType = 60;
     const parentNode = new BIP44CoinTypeNode([
-      defaultBip39Node,
-      BIP44PurposeNode,
+      defaultBip39NodeToken,
+      BIP44PurposeNodeToken,
       `bip32:${coinType}'`,
     ]);
 
     const expectedKey = new BIP44Node({
       derivationPath: [
-        defaultBip39Node,
-        BIP44PurposeNode,
+        defaultBip39NodeToken,
+        BIP44PurposeNodeToken,
         `bip32:${coinType}'`,
         `bip32:0'`,
         `bip32:0`,
@@ -321,15 +333,15 @@ describe('deriveBIP44AddressKey', () => {
   it('derives an address_index key (default inputs, different address_index)', () => {
     const coinType = 60;
     const parentNode = new BIP44CoinTypeNode([
-      defaultBip39Node,
-      BIP44PurposeNode,
+      defaultBip39NodeToken,
+      BIP44PurposeNodeToken,
       `bip32:${coinType}'`,
     ]);
 
     const expectedKey = new BIP44Node({
       derivationPath: [
-        defaultBip39Node,
-        BIP44PurposeNode,
+        defaultBip39NodeToken,
+        BIP44PurposeNodeToken,
         `bip32:${coinType}'`,
         `bip32:0'`,
         `bip32:0`,
@@ -347,15 +359,15 @@ describe('deriveBIP44AddressKey', () => {
   it('derives a BIP-44 address key (non-default account value)', () => {
     const coinType = 60;
     const parentNode = new BIP44CoinTypeNode([
-      defaultBip39Node,
-      BIP44PurposeNode,
+      defaultBip39NodeToken,
+      BIP44PurposeNodeToken,
       `bip32:${coinType}'`,
     ]);
 
     const expectedKey = new BIP44Node({
       derivationPath: [
-        defaultBip39Node,
-        BIP44PurposeNode,
+        defaultBip39NodeToken,
+        BIP44PurposeNodeToken,
         `bip32:${coinType}'`,
         `bip32:3'`,
         `bip32:0`,
@@ -374,15 +386,15 @@ describe('deriveBIP44AddressKey', () => {
   it('derives a BIP-44 address key (non-default change value)', () => {
     const coinType = 60;
     const parentNode = new BIP44CoinTypeNode([
-      defaultBip39Node,
-      BIP44PurposeNode,
+      defaultBip39NodeToken,
+      BIP44PurposeNodeToken,
       `bip32:${coinType}'`,
     ]);
 
     const expectedKey = new BIP44Node({
       derivationPath: [
-        defaultBip39Node,
-        BIP44PurposeNode,
+        defaultBip39NodeToken,
+        BIP44PurposeNodeToken,
         `bip32:${coinType}'`,
         `bip32:0'`,
         `bip32:9`,
@@ -401,15 +413,15 @@ describe('deriveBIP44AddressKey', () => {
   it('derives a BIP-44 address key (non-default account and change values)', () => {
     const coinType = 60;
     const parentNode = new BIP44CoinTypeNode([
-      defaultBip39Node,
-      BIP44PurposeNode,
+      defaultBip39NodeToken,
+      BIP44PurposeNodeToken,
       `bip32:${coinType}'`,
     ]);
 
     const expectedKey = new BIP44Node({
       derivationPath: [
-        defaultBip39Node,
-        BIP44PurposeNode,
+        defaultBip39NodeToken,
+        BIP44PurposeNodeToken,
         `bip32:${coinType}'`,
         `bip32:3'`,
         `bip32:9`,
@@ -429,15 +441,15 @@ describe('deriveBIP44AddressKey', () => {
   it('derives a BIP-44 address key (JSON node)', () => {
     const coinType = 60;
     const parentNode = new BIP44CoinTypeNode([
-      defaultBip39Node,
-      BIP44PurposeNode,
+      defaultBip39NodeToken,
+      BIP44PurposeNodeToken,
       `bip32:${coinType}'`,
     ]).toJSON();
 
     const expectedKey = new BIP44Node({
       derivationPath: [
-        defaultBip39Node,
-        BIP44PurposeNode,
+        defaultBip39NodeToken,
+        BIP44PurposeNodeToken,
         `bip32:${coinType}'`,
         `bip32:0'`,
         `bip32:0`,
@@ -455,15 +467,15 @@ describe('deriveBIP44AddressKey', () => {
   it('derives a BIP-44 address key (string key)', () => {
     const coinType = 60;
     const parentKey = new BIP44CoinTypeNode([
-      defaultBip39Node,
-      BIP44PurposeNode,
+      defaultBip39NodeToken,
+      BIP44PurposeNodeToken,
       `bip32:${coinType}'`,
     ]).key;
 
     const expectedKey = new BIP44Node({
       derivationPath: [
-        defaultBip39Node,
-        BIP44PurposeNode,
+        defaultBip39NodeToken,
+        BIP44PurposeNodeToken,
         `bip32:${coinType}'`,
         `bip32:0'`,
         `bip32:0`,
@@ -479,8 +491,8 @@ describe('deriveBIP44AddressKey', () => {
   it('throws if a node value is invalid', () => {
     const coinType = 60;
     const parentNode = new BIP44CoinTypeNode([
-      defaultBip39Node,
-      BIP44PurposeNode,
+      defaultBip39NodeToken,
+      BIP44PurposeNodeToken,
       `bip32:${coinType}'`,
     ]);
 
@@ -504,8 +516,8 @@ describe('getBIP44AddressKeyDeriver', () => {
   it('returns the expected BIP-44 address key deriver function (default inputs)', () => {
     const coinType = 60;
     const parentNode = new BIP44CoinTypeNode([
-      defaultBip39Node,
-      BIP44PurposeNode,
+      defaultBip39NodeToken,
+      BIP44PurposeNodeToken,
       `bip32:${coinType}'`,
     ]);
     const expectedPath = `m / bip32:44' / bip32:${coinType}' / bip32:0' / bip32:0`;
@@ -516,8 +528,8 @@ describe('getBIP44AddressKeyDeriver', () => {
 
     const expectedKey = new BIP44Node({
       derivationPath: [
-        defaultBip39Node,
-        BIP44PurposeNode,
+        defaultBip39NodeToken,
+        BIP44PurposeNodeToken,
         `bip32:${coinType}'`,
         `bip32:0'`,
         `bip32:0`,
@@ -531,8 +543,8 @@ describe('getBIP44AddressKeyDeriver', () => {
   it('returns the expected BIP-44 address key deriver function (different coin_type)', () => {
     const coinType = 8129837;
     const parentNode = new BIP44CoinTypeNode([
-      defaultBip39Node,
-      BIP44PurposeNode,
+      defaultBip39NodeToken,
+      BIP44PurposeNodeToken,
       `bip32:${coinType}'`,
     ]);
     const expectedPath = `m / bip32:44' / bip32:${coinType}' / bip32:0' / bip32:0`;
@@ -543,8 +555,8 @@ describe('getBIP44AddressKeyDeriver', () => {
 
     const expectedKey = new BIP44Node({
       derivationPath: [
-        defaultBip39Node,
-        BIP44PurposeNode,
+        defaultBip39NodeToken,
+        BIP44PurposeNodeToken,
         `bip32:${coinType}'`,
         `bip32:0'`,
         `bip32:0`,
@@ -558,8 +570,8 @@ describe('getBIP44AddressKeyDeriver', () => {
   it('returns the expected BIP-44 address key deriver function (default inputs, different address_index)', () => {
     const coinType = 60;
     const parentNode = new BIP44CoinTypeNode([
-      defaultBip39Node,
-      BIP44PurposeNode,
+      defaultBip39NodeToken,
+      BIP44PurposeNodeToken,
       `bip32:${coinType}'`,
     ]);
     const expectedPath = `m / bip32:44' / bip32:${coinType}' / bip32:0' / bip32:0`;
@@ -570,8 +582,8 @@ describe('getBIP44AddressKeyDeriver', () => {
 
     const expectedKey = new BIP44Node({
       derivationPath: [
-        defaultBip39Node,
-        BIP44PurposeNode,
+        defaultBip39NodeToken,
+        BIP44PurposeNodeToken,
         `bip32:${coinType}'`,
         `bip32:0'`,
         `bip32:0`,
@@ -585,8 +597,8 @@ describe('getBIP44AddressKeyDeriver', () => {
   it('returns the expected BIP-44 address key deriver function (non-default account value)', () => {
     const coinType = 60;
     const parentNode = new BIP44CoinTypeNode([
-      defaultBip39Node,
-      BIP44PurposeNode,
+      defaultBip39NodeToken,
+      BIP44PurposeNodeToken,
       `bip32:${coinType}'`,
     ]);
     const expectedPath = `m / bip32:44' / bip32:${coinType}' / bip32:46' / bip32:0`;
@@ -597,8 +609,8 @@ describe('getBIP44AddressKeyDeriver', () => {
 
     const expectedKey = new BIP44Node({
       derivationPath: [
-        defaultBip39Node,
-        BIP44PurposeNode,
+        defaultBip39NodeToken,
+        BIP44PurposeNodeToken,
         `bip32:${coinType}'`,
         `bip32:46'`,
         `bip32:0`,
@@ -612,8 +624,8 @@ describe('getBIP44AddressKeyDeriver', () => {
   it('returns the expected BIP-44 address key deriver function (non-default change value)', () => {
     const coinType = 60;
     const parentNode = new BIP44CoinTypeNode([
-      defaultBip39Node,
-      BIP44PurposeNode,
+      defaultBip39NodeToken,
+      BIP44PurposeNodeToken,
       `bip32:${coinType}'`,
     ]);
     const expectedPath = `m / bip32:44' / bip32:${coinType}' / bip32:0' / bip32:2`;
@@ -624,8 +636,8 @@ describe('getBIP44AddressKeyDeriver', () => {
 
     const expectedKey = new BIP44Node({
       derivationPath: [
-        defaultBip39Node,
-        BIP44PurposeNode,
+        defaultBip39NodeToken,
+        BIP44PurposeNodeToken,
         `bip32:${coinType}'`,
         `bip32:0'`,
         `bip32:2`,
@@ -639,8 +651,8 @@ describe('getBIP44AddressKeyDeriver', () => {
   it('returns the expected BIP-44 address key deriver function (non-default account and change values)', () => {
     const coinType = 60;
     const parentNode = new BIP44CoinTypeNode([
-      defaultBip39Node,
-      BIP44PurposeNode,
+      defaultBip39NodeToken,
+      BIP44PurposeNodeToken,
       `bip32:${coinType}'`,
     ]);
     const expectedPath = `m / bip32:44' / bip32:${coinType}' / bip32:46' / bip32:2`;
@@ -654,8 +666,8 @@ describe('getBIP44AddressKeyDeriver', () => {
 
     const expectedKey = new BIP44Node({
       derivationPath: [
-        defaultBip39Node,
-        BIP44PurposeNode,
+        defaultBip39NodeToken,
+        BIP44PurposeNodeToken,
         `bip32:${coinType}'`,
         `bip32:46'`,
         `bip32:2`,
@@ -669,8 +681,8 @@ describe('getBIP44AddressKeyDeriver', () => {
   it('returns the expected BIP-44 address key deriver function (JSON node)', () => {
     const coinType = 60;
     const parentNode = new BIP44CoinTypeNode([
-      defaultBip39Node,
-      BIP44PurposeNode,
+      defaultBip39NodeToken,
+      BIP44PurposeNodeToken,
       `bip32:${coinType}'`,
     ]).toJSON();
     const expectedPath = `m / bip32:44' / bip32:${coinType}' / bip32:0' / bip32:0`;
@@ -681,8 +693,8 @@ describe('getBIP44AddressKeyDeriver', () => {
 
     const expectedKey = new BIP44Node({
       derivationPath: [
-        defaultBip39Node,
-        BIP44PurposeNode,
+        defaultBip39NodeToken,
+        BIP44PurposeNodeToken,
         `bip32:${coinType}'`,
         `bip32:0'`,
         `bip32:0`,
@@ -696,8 +708,8 @@ describe('getBIP44AddressKeyDeriver', () => {
   it('throws if a node value is invalid', () => {
     const coinType = 60;
     const parentNode = new BIP44CoinTypeNode([
-      defaultBip39Node,
-      BIP44PurposeNode,
+      defaultBip39NodeToken,
+      BIP44PurposeNodeToken,
       `bip32:${coinType}'`,
     ]);
 
@@ -717,8 +729,8 @@ describe('getBIP44AddressKeyDeriver', () => {
   it('deriver throws if address_index value is invalid', () => {
     const coinType = 60;
     const parentNode = new BIP44CoinTypeNode([
-      defaultBip39Node,
-      BIP44PurposeNode,
+      defaultBip39NodeToken,
+      BIP44PurposeNodeToken,
       `bip32:${coinType}'`,
     ]);
 

--- a/src/BIP44CoinTypeNode.test.ts
+++ b/src/BIP44CoinTypeNode.test.ts
@@ -1,47 +1,662 @@
 import fixtures from '../test/fixtures';
-import { BIP44CoinTypeNode } from './BIP44CoinTypeNode';
-import { BIP44PurposeNode } from './constants';
+import {
+  BIP_44_COIN_TYPE_DEPTH,
+  BIP44Node,
+  BIP44CoinTypeNode,
+  BIP44PurposeNode,
+  deriveBIP44AddressKey,
+  getBIP44AddressKeyDeriver,
+} from '.';
 
 const defaultBip39Node = `bip39:${fixtures.local.mnemonic}` as const;
 
 describe('BIP44CoinTypeNode', () => {
   describe('constructor', () => {
-    it('initializes a BIP44CoinTypeNode', () => {
+    it('initializes a BIP44CoinTypeNode (derivation path)', () => {
       const node = new BIP44CoinTypeNode([
         defaultBip39Node,
         BIP44PurposeNode,
         `bip32:60'`,
       ]);
-      const expectedCoinType = 60;
-      const expectedPath = `m / bip32:44' / bip32:${expectedCoinType}'`;
+      const coinType = 60;
+      const pathString = `m / bip32:44' / bip32:${coinType}'`;
 
-      expect(node.coin_type).toStrictEqual(expectedCoinType);
+      expect(node.coin_type).toStrictEqual(coinType);
       expect(node.depth).toStrictEqual(2);
       expect(node.key).toHaveLength(88);
-      expect(node.path).toStrictEqual(expectedPath);
+      expect(node.keyBuffer.toString('base64')).toStrictEqual(node.key);
+      expect(node.path).toStrictEqual(pathString);
 
       expect(node.toJSON()).toStrictEqual({
-        coin_type: expectedCoinType,
+        coin_type: coinType,
         depth: 2,
         key: node.key,
-        path: expectedPath,
+        path: pathString,
+      });
+    });
+
+    it('initializes a BIP44CoinTypeNode (BIP44Node)', () => {
+      const bip44Node = new BIP44Node({
+        derivationPath: [defaultBip39Node, BIP44PurposeNode, `bip32:60'`],
+      });
+
+      const coinType = 60;
+      const pathString = `m / bip32:44' / bip32:${coinType}'`;
+      const node = new BIP44CoinTypeNode(bip44Node, coinType);
+
+      expect(node.coin_type).toStrictEqual(coinType);
+      expect(node.depth).toStrictEqual(2);
+      expect(node.key).toHaveLength(88);
+      expect(node.keyBuffer.toString('base64')).toStrictEqual(node.key);
+      expect(node.path).toStrictEqual(pathString);
+
+      expect(node.toJSON()).toStrictEqual({
+        coin_type: coinType,
+        depth: 2,
+        key: node.key,
+        path: pathString,
+      });
+    });
+
+    it('initializes a BIP44CoinTypeNode (serialized BIP44Node)', () => {
+      const bip44Node = new BIP44Node({
+        derivationPath: [defaultBip39Node, BIP44PurposeNode, `bip32:60'`],
+      });
+
+      const coinType = 60;
+      const pathString = `m / bip32:44' / bip32:${coinType}'`;
+      const node = new BIP44CoinTypeNode(bip44Node.toJSON(), coinType);
+
+      expect(node.coin_type).toStrictEqual(coinType);
+      expect(node.depth).toStrictEqual(2);
+      expect(node.key).toHaveLength(88);
+      expect(node.keyBuffer.toString('base64')).toStrictEqual(node.key);
+      expect(node.path).toStrictEqual(pathString);
+
+      expect(node.toJSON()).toStrictEqual({
+        coin_type: coinType,
+        depth: 2,
+        key: node.key,
+        path: pathString,
+      });
+    });
+
+    it('throws if both coin type and derivation path are specified', () => {
+      expect(
+        () =>
+          new BIP44CoinTypeNode(
+            [defaultBip39Node, BIP44PurposeNode, `bip32:60'`],
+            60,
+          ),
+      ).toThrow(
+        'Invalid parameters: May not specify both coin type and a derivation path. The coin type will be computed from the derivation path.',
+      );
+    });
+
+    it('throws if derivation path has invalid depth', () => {
+      [
+        [defaultBip39Node, BIP44PurposeNode],
+        [defaultBip39Node, BIP44PurposeNode, `bip32:60'`, `bip32:0'`],
+      ].forEach((invalidDerivationPath) => {
+        expect(
+          () => new BIP44CoinTypeNode(invalidDerivationPath as any),
+        ).toThrow(
+          `Invalid depth: Coin type nodes must be of depth ${BIP_44_COIN_TYPE_DEPTH}. Received: "${
+            invalidDerivationPath.length - 1
+          }"`,
+        );
+      });
+    });
+
+    it('throws if node has invalid depth', () => {
+      const arbitraryCoinType = 78;
+
+      [
+        { key: 'foo', depth: 1 },
+        { key: 'foo', depth: 3 },
+      ].forEach((invalidNode) => {
+        expect(
+          () => new BIP44CoinTypeNode(invalidNode as any, arbitraryCoinType),
+        ).toThrow(
+          `Invalid depth: Coin type nodes must be of depth ${BIP_44_COIN_TYPE_DEPTH}. Received: "${invalidNode.depth}"`,
+        );
+      });
+    });
+
+    it('throws if node has invalid key', () => {
+      const arbitraryCoinType = 78;
+
+      [
+        { key: 'foo', depth: 2 },
+        { key: 1, depth: 2 },
+        { key: Buffer.allocUnsafe(64).fill(1).toString('hex'), depth: 2 },
+        { key: Buffer.allocUnsafe(63).fill(1).toString('base64'), depth: 2 },
+        { key: Buffer.alloc(64).toString('base64'), depth: 2 },
+      ].forEach((invalidNode) => {
+        expect(
+          () => new BIP44CoinTypeNode(invalidNode as any, arbitraryCoinType),
+        ).toThrow('Invalid parent key: Must be a non-zero 64-byte key.');
+      });
+    });
+
+    it('throws if coin type is invalid', () => {
+      const jsonNode = new BIP44Node({
+        derivationPath: [defaultBip39Node, BIP44PurposeNode, `bip32:60'`],
+      }).toJSON();
+
+      ['60', 1.1, -1, {}].forEach((invalidCoinType) => {
+        expect(
+          () => new BIP44CoinTypeNode(jsonNode, invalidCoinType as any),
+        ).toThrow(
+          'Invalid coin type: The specified coin type must be a non-negative integer number.',
+        );
       });
     });
   });
 
   describe('deriveBIP44Address', () => {
-    it.todo('derives an address key');
+    const coinTypePath = [
+      defaultBip39Node,
+      BIP44PurposeNode,
+      `bip32:60'`,
+    ] as const;
+
+    it('derives an address_index key (default inputs)', () => {
+      const expectedKey = new BIP44Node({
+        derivationPath: [...coinTypePath, `bip32:0'`, `bip32:0`, `bip32:0`],
+      }).key;
+
+      const coinTypeNode = new BIP44CoinTypeNode([
+        defaultBip39Node,
+        BIP44PurposeNode,
+        `bip32:60'`,
+      ]);
+
+      expect(
+        coinTypeNode.deriveBIP44Address({ address_index: 0 }).key,
+      ).toStrictEqual(expectedKey);
+    });
+
+    it('derives an address_index key (default inputs, different address_index)', () => {
+      const expectedKey = new BIP44Node({
+        derivationPath: [...coinTypePath, `bip32:0'`, `bip32:0`, `bip32:99`],
+      }).key;
+
+      const coinTypeNode = new BIP44CoinTypeNode([
+        defaultBip39Node,
+        BIP44PurposeNode,
+        `bip32:60'`,
+      ]);
+
+      expect(
+        coinTypeNode.deriveBIP44Address({ address_index: 99 }).key,
+      ).toStrictEqual(expectedKey);
+    });
+
+    it('derives an address_index key (non-default account value)', () => {
+      const expectedKey = new BIP44Node({
+        derivationPath: [...coinTypePath, `bip32:4'`, `bip32:0`, `bip32:0`],
+      }).key;
+
+      const coinTypeNode = new BIP44CoinTypeNode([
+        defaultBip39Node,
+        BIP44PurposeNode,
+        `bip32:60'`,
+      ]);
+
+      expect(
+        coinTypeNode.deriveBIP44Address({ account: 4, address_index: 0 }).key,
+      ).toStrictEqual(expectedKey);
+    });
+
+    it('derives an address_index key (non-default change value)', () => {
+      const expectedKey = new BIP44Node({
+        derivationPath: [...coinTypePath, `bip32:0'`, `bip32:3`, `bip32:0`],
+      }).key;
+
+      const coinTypeNode = new BIP44CoinTypeNode([
+        defaultBip39Node,
+        BIP44PurposeNode,
+        `bip32:60'`,
+      ]);
+
+      expect(
+        coinTypeNode.deriveBIP44Address({ change: 3, address_index: 0 }).key,
+      ).toStrictEqual(expectedKey);
+    });
+
+    it('derives an address_index key (non-default account and change values)', () => {
+      const expectedKey = new BIP44Node({
+        derivationPath: [...coinTypePath, `bip32:4'`, `bip32:3`, `bip32:0`],
+      }).key;
+
+      const coinTypeNode = new BIP44CoinTypeNode([
+        defaultBip39Node,
+        BIP44PurposeNode,
+        `bip32:60'`,
+      ]);
+
+      expect(
+        coinTypeNode.deriveBIP44Address({
+          account: 4,
+          change: 3,
+          address_index: 0,
+        }).key,
+      ).toStrictEqual(expectedKey);
+    });
   });
 
   describe('toJSON', () => {
-    it.todo('returns a JSON-compatible representation of the node');
+    it('returns a JSON-compatible representation of the node', () => {
+      const coinType = 60;
+      const node = new BIP44CoinTypeNode([
+        defaultBip39Node,
+        BIP44PurposeNode,
+        `bip32:${coinType}'`,
+      ]);
+      const pathString = `m / bip32:44' / bip32:${coinType}'`;
+
+      expect(node.coin_type).toStrictEqual(coinType);
+      expect(node.depth).toStrictEqual(2);
+      expect(typeof node.key).toStrictEqual('string');
+      expect(node.key).toHaveLength(88);
+      expect(node.keyBuffer.toString('base64')).toStrictEqual(node.key);
+      expect(node.path).toStrictEqual(pathString);
+
+      const nodeJson = node.toJSON();
+      expect(nodeJson).toStrictEqual({
+        coin_type: coinType,
+        depth: 2,
+        key: node.key,
+        path: pathString,
+      });
+
+      expect(JSON.parse(JSON.stringify(nodeJson))).toStrictEqual({
+        coin_type: coinType,
+        depth: 2,
+        key: node.key,
+        path: pathString,
+      });
+    });
   });
 });
 
 describe('deriveBIP44AddressKey', () => {
-  it.todo('derives a BIP-44 address key');
+  it('derives a BIP-44 address key (default inputs)', () => {
+    const coinType = 60;
+    const parentNode = new BIP44CoinTypeNode([
+      defaultBip39Node,
+      BIP44PurposeNode,
+      `bip32:${coinType}'`,
+    ]);
+
+    const expectedKey = new BIP44Node({
+      derivationPath: [
+        defaultBip39Node,
+        BIP44PurposeNode,
+        `bip32:${coinType}'`,
+        `bip32:0'`,
+        `bip32:0`,
+        `bip32:0`,
+      ],
+    }).key;
+
+    expect(
+      deriveBIP44AddressKey(parentNode, { address_index: 0 }).toString(
+        'base64',
+      ),
+    ).toStrictEqual(expectedKey);
+  });
+
+  it('derives an address_index key (default inputs, different address_index)', () => {
+    const coinType = 60;
+    const parentNode = new BIP44CoinTypeNode([
+      defaultBip39Node,
+      BIP44PurposeNode,
+      `bip32:${coinType}'`,
+    ]);
+
+    const expectedKey = new BIP44Node({
+      derivationPath: [
+        defaultBip39Node,
+        BIP44PurposeNode,
+        `bip32:${coinType}'`,
+        `bip32:0'`,
+        `bip32:0`,
+        `bip32:3333`,
+      ],
+    }).key;
+
+    expect(
+      deriveBIP44AddressKey(parentNode, { address_index: 3333 }).toString(
+        'base64',
+      ),
+    ).toStrictEqual(expectedKey);
+  });
+
+  it('derives a BIP-44 address key (non-default account value)', () => {
+    const coinType = 60;
+    const parentNode = new BIP44CoinTypeNode([
+      defaultBip39Node,
+      BIP44PurposeNode,
+      `bip32:${coinType}'`,
+    ]);
+
+    const expectedKey = new BIP44Node({
+      derivationPath: [
+        defaultBip39Node,
+        BIP44PurposeNode,
+        `bip32:${coinType}'`,
+        `bip32:3'`,
+        `bip32:0`,
+        `bip32:0`,
+      ],
+    }).key;
+
+    expect(
+      deriveBIP44AddressKey(parentNode, {
+        account: 3,
+        address_index: 0,
+      }).toString('base64'),
+    ).toStrictEqual(expectedKey);
+  });
+
+  it('derives a BIP-44 address key (non-default change value)', () => {
+    const coinType = 60;
+    const parentNode = new BIP44CoinTypeNode([
+      defaultBip39Node,
+      BIP44PurposeNode,
+      `bip32:${coinType}'`,
+    ]);
+
+    const expectedKey = new BIP44Node({
+      derivationPath: [
+        defaultBip39Node,
+        BIP44PurposeNode,
+        `bip32:${coinType}'`,
+        `bip32:0'`,
+        `bip32:9`,
+        `bip32:0`,
+      ],
+    }).key;
+
+    expect(
+      deriveBIP44AddressKey(parentNode, {
+        change: 9,
+        address_index: 0,
+      }).toString('base64'),
+    ).toStrictEqual(expectedKey);
+  });
+
+  it('derives a BIP-44 address key (non-default account and change values)', () => {
+    const coinType = 60;
+    const parentNode = new BIP44CoinTypeNode([
+      defaultBip39Node,
+      BIP44PurposeNode,
+      `bip32:${coinType}'`,
+    ]);
+
+    const expectedKey = new BIP44Node({
+      derivationPath: [
+        defaultBip39Node,
+        BIP44PurposeNode,
+        `bip32:${coinType}'`,
+        `bip32:3'`,
+        `bip32:9`,
+        `bip32:0`,
+      ],
+    }).key;
+
+    expect(
+      deriveBIP44AddressKey(parentNode, {
+        account: 3,
+        change: 9,
+        address_index: 0,
+      }).toString('base64'),
+    ).toStrictEqual(expectedKey);
+  });
+
+  it('derives a BIP-44 address key (JSON node)', () => {
+    const coinType = 60;
+    const parentNode = new BIP44CoinTypeNode([
+      defaultBip39Node,
+      BIP44PurposeNode,
+      `bip32:${coinType}'`,
+    ]).toJSON();
+
+    const expectedKey = new BIP44Node({
+      derivationPath: [
+        defaultBip39Node,
+        BIP44PurposeNode,
+        `bip32:${coinType}'`,
+        `bip32:0'`,
+        `bip32:0`,
+        `bip32:0`,
+      ],
+    }).key;
+
+    expect(
+      deriveBIP44AddressKey(parentNode, { address_index: 0 }).toString(
+        'base64',
+      ),
+    ).toStrictEqual(expectedKey);
+  });
+
+  it('derives a BIP-44 address key (string key)', () => {
+    const coinType = 60;
+    const parentKey = new BIP44CoinTypeNode([
+      defaultBip39Node,
+      BIP44PurposeNode,
+      `bip32:${coinType}'`,
+    ]).key;
+
+    const expectedKey = new BIP44Node({
+      derivationPath: [
+        defaultBip39Node,
+        BIP44PurposeNode,
+        `bip32:${coinType}'`,
+        `bip32:0'`,
+        `bip32:0`,
+        `bip32:0`,
+      ],
+    }).key;
+
+    expect(
+      deriveBIP44AddressKey(parentKey, { address_index: 0 }).toString('base64'),
+    ).toStrictEqual(expectedKey);
+  });
 });
 
 describe('getBIP44AddressKeyDeriver', () => {
-  it.todo('returns a BIP-44 address key deriver function');
+  it('returns the expected BIP-44 address key deriver function (default inputs)', () => {
+    const coinType = 60;
+    const parentNode = new BIP44CoinTypeNode([
+      defaultBip39Node,
+      BIP44PurposeNode,
+      `bip32:${coinType}'`,
+    ]);
+    const expectedPath = `m / bip32:44' / bip32:${coinType}' / bip32:0' / bip32:0`;
+
+    const deriver = getBIP44AddressKeyDeriver(parentNode);
+    expect(deriver.coin_type).toStrictEqual(coinType);
+    expect(deriver.path).toStrictEqual(expectedPath);
+
+    const expectedKey = new BIP44Node({
+      derivationPath: [
+        defaultBip39Node,
+        BIP44PurposeNode,
+        `bip32:${coinType}'`,
+        `bip32:0'`,
+        `bip32:0`,
+        `bip32:0`,
+      ],
+    }).key;
+
+    expect(deriver(0).toString('base64')).toStrictEqual(expectedKey);
+  });
+
+  it('returns the expected BIP-44 address key deriver function (different coin_type)', () => {
+    const coinType = 8129837;
+    const parentNode = new BIP44CoinTypeNode([
+      defaultBip39Node,
+      BIP44PurposeNode,
+      `bip32:${coinType}'`,
+    ]);
+    const expectedPath = `m / bip32:44' / bip32:${coinType}' / bip32:0' / bip32:0`;
+
+    const deriver = getBIP44AddressKeyDeriver(parentNode);
+    expect(deriver.coin_type).toStrictEqual(coinType);
+    expect(deriver.path).toStrictEqual(expectedPath);
+
+    const expectedKey = new BIP44Node({
+      derivationPath: [
+        defaultBip39Node,
+        BIP44PurposeNode,
+        `bip32:${coinType}'`,
+        `bip32:0'`,
+        `bip32:0`,
+        `bip32:0`,
+      ],
+    }).key;
+
+    expect(deriver(0).toString('base64')).toStrictEqual(expectedKey);
+  });
+
+  it('returns the expected BIP-44 address key deriver function (default inputs, different address_index)', () => {
+    const coinType = 60;
+    const parentNode = new BIP44CoinTypeNode([
+      defaultBip39Node,
+      BIP44PurposeNode,
+      `bip32:${coinType}'`,
+    ]);
+    const expectedPath = `m / bip32:44' / bip32:${coinType}' / bip32:0' / bip32:0`;
+
+    const deriver = getBIP44AddressKeyDeriver(parentNode);
+    expect(deriver.coin_type).toStrictEqual(coinType);
+    expect(deriver.path).toStrictEqual(expectedPath);
+
+    const expectedKey = new BIP44Node({
+      derivationPath: [
+        defaultBip39Node,
+        BIP44PurposeNode,
+        `bip32:${coinType}'`,
+        `bip32:0'`,
+        `bip32:0`,
+        `bip32:9873`,
+      ],
+    }).key;
+
+    expect(deriver(9873).toString('base64')).toStrictEqual(expectedKey);
+  });
+
+  it('returns the expected BIP-44 address key deriver function (non-default account value)', () => {
+    const coinType = 60;
+    const parentNode = new BIP44CoinTypeNode([
+      defaultBip39Node,
+      BIP44PurposeNode,
+      `bip32:${coinType}'`,
+    ]);
+    const expectedPath = `m / bip32:44' / bip32:${coinType}' / bip32:46' / bip32:0`;
+
+    const deriver = getBIP44AddressKeyDeriver(parentNode, { account: 46 });
+    expect(deriver.coin_type).toStrictEqual(coinType);
+    expect(deriver.path).toStrictEqual(expectedPath);
+
+    const expectedKey = new BIP44Node({
+      derivationPath: [
+        defaultBip39Node,
+        BIP44PurposeNode,
+        `bip32:${coinType}'`,
+        `bip32:46'`,
+        `bip32:0`,
+        `bip32:0`,
+      ],
+    }).key;
+
+    expect(deriver(0).toString('base64')).toStrictEqual(expectedKey);
+  });
+
+  it('returns the expected BIP-44 address key deriver function (non-default change value)', () => {
+    const coinType = 60;
+    const parentNode = new BIP44CoinTypeNode([
+      defaultBip39Node,
+      BIP44PurposeNode,
+      `bip32:${coinType}'`,
+    ]);
+    const expectedPath = `m / bip32:44' / bip32:${coinType}' / bip32:0' / bip32:2`;
+
+    const deriver = getBIP44AddressKeyDeriver(parentNode, { change: 2 });
+    expect(deriver.coin_type).toStrictEqual(coinType);
+    expect(deriver.path).toStrictEqual(expectedPath);
+
+    const expectedKey = new BIP44Node({
+      derivationPath: [
+        defaultBip39Node,
+        BIP44PurposeNode,
+        `bip32:${coinType}'`,
+        `bip32:0'`,
+        `bip32:2`,
+        `bip32:0`,
+      ],
+    }).key;
+
+    expect(deriver(0).toString('base64')).toStrictEqual(expectedKey);
+  });
+
+  it('returns the expected BIP-44 address key deriver function (non-default account and change values)', () => {
+    const coinType = 60;
+    const parentNode = new BIP44CoinTypeNode([
+      defaultBip39Node,
+      BIP44PurposeNode,
+      `bip32:${coinType}'`,
+    ]);
+    const expectedPath = `m / bip32:44' / bip32:${coinType}' / bip32:46' / bip32:2`;
+
+    const deriver = getBIP44AddressKeyDeriver(parentNode, {
+      account: 46,
+      change: 2,
+    });
+    expect(deriver.coin_type).toStrictEqual(coinType);
+    expect(deriver.path).toStrictEqual(expectedPath);
+
+    const expectedKey = new BIP44Node({
+      derivationPath: [
+        defaultBip39Node,
+        BIP44PurposeNode,
+        `bip32:${coinType}'`,
+        `bip32:46'`,
+        `bip32:2`,
+        `bip32:0`,
+      ],
+    }).key;
+
+    expect(deriver(0).toString('base64')).toStrictEqual(expectedKey);
+  });
+
+  it('returns the expected BIP-44 address key deriver function (JSON node)', () => {
+    const coinType = 60;
+    const parentNode = new BIP44CoinTypeNode([
+      defaultBip39Node,
+      BIP44PurposeNode,
+      `bip32:${coinType}'`,
+    ]).toJSON();
+    const expectedPath = `m / bip32:44' / bip32:${coinType}' / bip32:0' / bip32:0`;
+
+    const deriver = getBIP44AddressKeyDeriver(parentNode);
+    expect(deriver.coin_type).toStrictEqual(coinType);
+    expect(deriver.path).toStrictEqual(expectedPath);
+
+    const expectedKey = new BIP44Node({
+      derivationPath: [
+        defaultBip39Node,
+        BIP44PurposeNode,
+        `bip32:${coinType}'`,
+        `bip32:0'`,
+        `bip32:0`,
+        `bip32:0`,
+      ],
+    }).key;
+
+    expect(deriver(0).toString('base64')).toStrictEqual(expectedKey);
+  });
 });

--- a/src/BIP44CoinTypeNode.ts
+++ b/src/BIP44CoinTypeNode.ts
@@ -39,10 +39,25 @@ export type BIP44CoinTypeNodeInterface = BIP44NodeInterface & {
   readonly path: CoinTypeHDPathString;
 };
 
+/**
+ * Used to conceal the inner {@link BIP44Node} from consumers.
+ */
 const InnerNode = Symbol('_node');
 
 /**
- * `m / purpose' / coin_type' / account' / change / address_index`
+ * A wrapper object for BIP-44 `coin_type` keys. `coin_type` is the index
+ * specifying the protocol for which deeper keys are intended. For the
+ * authoritative list of coin types, please see
+ * [SLIP-44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md).
+ * 
+ * Recall that a BIP-44 HD tree path consists of the following nodes:
+ *
+ * `m / 44' / coin_type' / account' / change / address_index`
+ *
+ * With the following depths:
+ *
+ * `0 / 1 / 2 / 3 / 4 / 5`
+ *
  */
 export class BIP44CoinTypeNode implements BIP44CoinTypeNodeInterface {
   private readonly [InnerNode]: BIP44Node;
@@ -63,6 +78,25 @@ export class BIP44CoinTypeNode implements BIP44CoinTypeNodeInterface {
 
   public readonly coin_type: number;
 
+  /**
+   * Constructs a BIP-44 `coin_type` node. `coin_type` is the index
+   * specifying the protocol for which deeper keys are intended. For the
+   * authoritative list of coin types, please see
+   * [SLIP-44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md).
+   *
+   * Recall that a BIP-44 HD tree path consists of the following nodes:
+   *
+   * `m / 44' / coin_type' / account' / change / address_index`
+   *
+   * With the following depths:
+   *
+   * `0 / 1 / 2 / 3 / 4 / 5`
+   *
+   * @param nodeOrPathTuple - The {@link BIP44Node} or derivation path for the
+   * key of this `coin_type` node.
+   * @param coin_type - The coin_type index of this node. Must be a non-negative
+   * integer.
+   */
   constructor(
     nodeOrPathTuple: CoinTypeHDPathTuple | BIP44Node | JsonBIP44Node,
     coin_type?: number,
@@ -119,16 +153,33 @@ export class BIP44CoinTypeNode implements BIP44CoinTypeNodeInterface {
   }
 
   /**
-   * `m / purpose' / coin_type' / account' / change / address_index`
+   * Derives a BIP-44 `address_index` key corresponding to the path of this
+   * node and the specified `account`, `change`, and `address_index` values.
+   * `address_index` keys are normally the keys used to generate user account
+   * addresses.
+   *
+   * Recall that a BIP-44 HD tree path consists of the following nodes:
+   *
+   * `m / 44' / coin_type' / account' / change / address_index`
+   *
+   * With the following depths:
+   *
+   * `0 / 1 / 2 / 3 / 4 / 5`
+   *
+   * @param indices - The BIP-44 index values to use in key derivation.
+   * @param indices.account - The `account` index. Default: `0`
+   * @param indices.change - The `change` index. Default: `0`
+   * @param indices.address_index - The `address_index` index.
+   * @returns
    */
-  deriveBIP44Address({
+  deriveBIP44AddressKey({
     account = 0,
     change = 0,
     address_index,
-  }: CoinTypeToAddressIndices) {
+  }: CoinTypeToAddressIndices): Buffer {
     return this[InnerNode].derive(
       getBIP44AddressPathTuple({ account, change, address_index }),
-    );
+    ).keyBuffer;
   }
 
   toJSON(): JsonBIP44CoinTypeNode {
@@ -140,6 +191,12 @@ export class BIP44CoinTypeNode implements BIP44CoinTypeNodeInterface {
   }
 }
 
+/**
+ * Validates the depth of a `coin_type` node. Simply, ensures that it is the
+ * number `2`. An error is thrown if validation fails.
+ *
+ * @param depth - The depth to validate.
+ */
 function validateCoinTypeNodeDepth(depth: number) {
   if (depth !== BIP_44_COIN_TYPE_DEPTH) {
     throw new Error(
@@ -161,7 +218,16 @@ function validateCoinTypeParentKey(parentKey: string) {
 }
 
 /**
- * `m / purpose' / coin_type' / account' / change / address_index`
+ * Derives a BIP-44 address key corresponding to the specified derivation path,
+ * given either by a {@link BIP44CoinTypeNode} or derivation path tuple.
+ *
+ * Recall that a BIP-44 HD tree path consists of the following nodes:
+ *
+ * `m / 44' / coin_type' / account' / change / address_index`
+ *
+ * With the following depths:
+ *
+ * `0 / 1 / 2 / 3 / 4 / 5`
  *
  * @param parentKeyOrNode - The `coin_type` parent key to derive from.
  * @param indices - The `account`, `change`, and `address_index` used for
@@ -197,8 +263,46 @@ export function deriveBIP44AddressKey(
   ).keyBuffer;
 }
 
+interface BIP44AddressKeyDeriver {
+  /**
+   * @param address_index - The `address_index` value.
+   * @returns The key corresponding to the path of this deriver and the
+   * specified `address_index` value.
+   */
+  (address_index: number): Buffer;
+
+  /**
+   * A human-readable representation of the derivation path of this deriver
+   * function, excluding the `address_index`, which is parameterized.
+   *
+   * Recall that a BIP-44 HD tree path consists of the following nodes:
+   *
+   * `m / 44' / coin_type' / account' / change / address_index`
+   *
+   * With the following depths:
+   *
+   * `0 / 1 / 2 / 3 / 4 / 5`
+   */
+  path: ReturnType<typeof getBIP44ChangePathString>;
+
+  /**
+   * The `coin_type` index of addresses derived by this deriver function.
+   */
+  coin_type: number;
+}
+
 /**
- * `m / purpose' / coin_type' / account' / change / address_index`
+ * Creates a function that derives BIP-44 address keys corresponding to the
+ * specified derivation path, given either by a {@link BIP44CoinTypeNode} or
+ * derivation path tuple.
+ *
+ * Recall that a BIP-44 HD tree path consists of the following nodes:
+ *
+ * `m / 44' / coin_type' / account' / change / address_index`
+ *
+ * With the following depths:
+ *
+ * `0 / 1 / 2 / 3 / 4 / 5`
  *
  * @param node - The {@link BIP44CoinTypeNode} to derive address keys from.
  * This node contains a BIP-44 key of depth 2, `coin_type`.
@@ -238,5 +342,5 @@ export function getBIP44AddressKeyDeriver(
     change,
   });
   Object.freeze(bip44AddressKeyDeriver);
-  return bip44AddressKeyDeriver;
+  return bip44AddressKeyDeriver as BIP44AddressKeyDeriver;
 }

--- a/src/BIP44CoinTypeNode.ts
+++ b/src/BIP44CoinTypeNode.ts
@@ -1,0 +1,156 @@
+import {
+  BIP39Node,
+  BIP44PurposeNode,
+  CoinTypeHDPathString,
+  HardenedBIP32Node,
+  HDTreeDepth,
+} from './constants';
+import {
+  JsonHDTreeNode,
+  HDTreeNode,
+  HDTreeNodeInterface,
+  deriveChildNode,
+} from './HDTreeNode';
+import {
+  base64StringToBuffer,
+  getBIP44AddressPathTuple,
+  getBIP44CoinTypePathString,
+  isValidBase64StringKey,
+  CoinTypeToAddressIndices,
+  getHardenedBIP32Node,
+  getUnhardenedBIP32Node,
+} from './utils';
+
+export type CoinTypeHDPathTuple = [
+  BIP39Node,
+  typeof BIP44PurposeNode,
+  HardenedBIP32Node,
+];
+export const COIN_TYPE_DEPTH = 2;
+
+export type JsonBIP44CoinTypeNode = JsonHDTreeNode & {
+  readonly coin_type: number;
+  readonly path: CoinTypeHDPathString;
+};
+
+export type BIP44CoinTypeNodeInterface = HDTreeNodeInterface & {
+  readonly coin_type: number;
+  readonly path: CoinTypeHDPathString;
+};
+
+const InnerNode = Symbol('_node');
+
+export class BIP44CoinTypeNode implements BIP44CoinTypeNodeInterface {
+  private readonly [InnerNode]: HDTreeNode;
+
+  public get depth(): HDTreeDepth {
+    return this[InnerNode].depth;
+  }
+
+  public get key(): string {
+    return this[InnerNode].key;
+  }
+
+  public readonly path: CoinTypeHDPathString;
+
+  public readonly coin_type: number;
+
+  constructor(
+    nodeOrArray: CoinTypeHDPathTuple | HDTreeNode,
+    coin_type: number,
+  ) {
+    this.path = getBIP44CoinTypePathString(coin_type);
+    this.coin_type = coin_type;
+
+    if (Array.isArray(nodeOrArray)) {
+      this[InnerNode] = new HDTreeNode({
+        depth: COIN_TYPE_DEPTH,
+        derivationPath: nodeOrArray,
+      });
+    } else {
+      validateCoinTypeNodeDepth(nodeOrArray.depth);
+      this[InnerNode] = nodeOrArray;
+    }
+
+    Object.freeze(this);
+  }
+
+  deriveBIP44AddressKey({
+    account = 0,
+    change = 0,
+    address_index,
+  }: CoinTypeToAddressIndices) {
+    return this[InnerNode].derive(
+      getBIP44AddressPathTuple({ account, change, address_index }),
+    );
+  }
+
+  toJSON(): JsonBIP44CoinTypeNode {
+    return {
+      ...this[InnerNode].toJSON(),
+      coin_type: this.coin_type,
+      path: this.path,
+    };
+  }
+}
+
+function validateCoinTypeNodeDepth(depth: number) {
+  if (depth !== COIN_TYPE_DEPTH) {
+    throw new Error(
+      `Invalid node: Coin type nodes must be of depth ${COIN_TYPE_DEPTH}. Received: "${depth}"`,
+    );
+  }
+}
+
+function validateCoinTypeParentKey(parentKey: string) {
+  if (!isValidBase64StringKey(parentKey)) {
+    throw new Error(`Invalid parent key: Must be a 64-byte Base64 string.`);
+  }
+}
+
+export function deriveBIP44AddressKey(
+  parentKeyOrNode: string | BIP44CoinTypeNode | JsonBIP44CoinTypeNode,
+  { account = 0, change = 0, address_index }: CoinTypeToAddressIndices,
+): string {
+  if (typeof parentKeyOrNode !== 'string' && 'depth' in parentKeyOrNode) {
+    validateCoinTypeNodeDepth(parentKeyOrNode.depth);
+  }
+
+  const parentKey =
+    typeof parentKeyOrNode === 'string' ? parentKeyOrNode : parentKeyOrNode.key;
+  validateCoinTypeParentKey(parentKey);
+
+  return deriveChildNode(
+    base64StringToBuffer(parentKey),
+    COIN_TYPE_DEPTH,
+    getBIP44AddressPathTuple({ account, change, address_index }),
+  ).key;
+}
+
+export function getBIP44AddressKeyDeriver(
+  node: BIP44CoinTypeNode | JsonBIP44CoinTypeNode,
+  { account = 0, change = 0 }: Omit<CoinTypeToAddressIndices, 'address_index'>,
+) {
+  const { key, depth, coin_type } = node;
+  validateCoinTypeNodeDepth(depth);
+  validateCoinTypeParentKey(key);
+
+  const accountNode = getHardenedBIP32Node(account);
+  const changeNode = getUnhardenedBIP32Node(change);
+
+  const parentKeyBuffer = base64StringToBuffer(key);
+
+  const bip44AddressKeyDeriver = (address_index: number): string => {
+    return deriveChildNode(parentKeyBuffer, COIN_TYPE_DEPTH, [
+      accountNode,
+      changeNode,
+      getUnhardenedBIP32Node(address_index),
+    ]).key;
+  };
+
+  bip44AddressKeyDeriver.coin_type = coin_type;
+  bip44AddressKeyDeriver.account = account;
+  bip44AddressKeyDeriver.change = change;
+  Object.freeze(bip44AddressKeyDeriver);
+  return bip44AddressKeyDeriver;
+}

--- a/src/BIP44CoinTypeNode.ts
+++ b/src/BIP44CoinTypeNode.ts
@@ -129,8 +129,9 @@ export function deriveBIP44AddressKey(
 
 export function getBIP44AddressKeyDeriver(
   node: BIP44CoinTypeNode | JsonBIP44CoinTypeNode,
-  { account = 0, change = 0 }: Omit<CoinTypeToAddressIndices, 'address_index'>,
+  accountAndChangeIndices?: Omit<CoinTypeToAddressIndices, 'address_index'>,
 ) {
+  const { account = 0, change = 0 } = accountAndChangeIndices || {};
   const { key, depth, coin_type } = node;
   validateCoinTypeNodeDepth(depth);
   validateCoinTypeParentKey(key);

--- a/src/BIP44CoinTypeNode.ts
+++ b/src/BIP44CoinTypeNode.ts
@@ -49,7 +49,7 @@ const InnerNode = Symbol('_node');
  * specifying the protocol for which deeper keys are intended. For the
  * authoritative list of coin types, please see
  * [SLIP-44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md).
- * 
+ *
  * Recall that a BIP-44 HD tree path consists of the following nodes:
  *
  * `m / 44' / coin_type' / account' / change / address_index`

--- a/src/BIP44CoinTypeNode.ts
+++ b/src/BIP44CoinTypeNode.ts
@@ -1,6 +1,6 @@
 import {
   BIP39Node,
-  BIP44PurposeNode,
+  BIP44PurposeNodeToken,
   CoinTypeHDPathString,
   HardenedBIP32Node,
   BIP44Depth,
@@ -13,18 +13,18 @@ import {
 } from './BIP44Node';
 import {
   base64StringToBuffer,
-  getBIP44AddressPathTuple,
+  getBIP44CoinTypeToAddressPathTuple,
   getBIP44CoinTypePathString,
   isValidBase64StringKey,
   CoinTypeToAddressIndices,
-  getHardenedBIP32Node,
-  getUnhardenedBIP32Node,
+  getHardenedBIP32NodeToken,
+  getUnhardenedBIP32NodeToken,
   getBIP44ChangePathString,
 } from './utils';
 
 export type CoinTypeHDPathTuple = [
   BIP39Node,
-  typeof BIP44PurposeNode,
+  typeof BIP44PurposeNodeToken,
   HardenedBIP32Node,
 ];
 export const BIP_44_COIN_TYPE_DEPTH = 2;
@@ -178,7 +178,7 @@ export class BIP44CoinTypeNode implements BIP44CoinTypeNodeInterface {
     address_index,
   }: CoinTypeToAddressIndices): Buffer {
     return this[InnerNode].derive(
-      getBIP44AddressPathTuple({ account, change, address_index }),
+      getBIP44CoinTypeToAddressPathTuple({ account, change, address_index }),
     ).keyBuffer;
   }
 
@@ -259,7 +259,7 @@ export function deriveBIP44AddressKey(
   return deriveChildNode(
     keyBuffer,
     BIP_44_COIN_TYPE_DEPTH,
-    getBIP44AddressPathTuple({ account, change, address_index }),
+    getBIP44CoinTypeToAddressPathTuple({ account, change, address_index }),
   ).keyBuffer;
 }
 
@@ -325,14 +325,14 @@ export function getBIP44AddressKeyDeriver(
       ? node.keyBuffer
       : base64StringToBuffer(key);
 
-  const accountNode = getHardenedBIP32Node(account);
-  const changeNode = getUnhardenedBIP32Node(change);
+  const accountNode = getHardenedBIP32NodeToken(account);
+  const changeNode = getUnhardenedBIP32NodeToken(change);
 
   const bip44AddressKeyDeriver = (address_index: number): Buffer => {
     return deriveChildNode(parentKeyBuffer, BIP_44_COIN_TYPE_DEPTH, [
       accountNode,
       changeNode,
-      getUnhardenedBIP32Node(address_index),
+      getUnhardenedBIP32NodeToken(address_index),
     ]).keyBuffer;
   };
 

--- a/src/BIP44Node.test.ts
+++ b/src/BIP44Node.test.ts
@@ -1,14 +1,18 @@
 import fixtures from '../test/fixtures';
-import { BIP44Node, BIP44PurposeNode } from '.';
+import { BIP44Node, BIP44PurposeNodeToken } from '.';
 
-const defaultBip39Node = `bip39:${fixtures.local.mnemonic}` as const;
+const defaultBip39NodeToken = `bip39:${fixtures.local.mnemonic}` as const;
 
 describe('BIP44Node', () => {
   describe('constructor', () => {
     it('initializes a new node (depth, derivationPath)', () => {
       // Ethereum coin type node
       const node = new BIP44Node({
-        derivationPath: [defaultBip39Node, BIP44PurposeNode, `bip32:60'`],
+        derivationPath: [
+          defaultBip39NodeToken,
+          BIP44PurposeNodeToken,
+          `bip32:60'`,
+        ],
       });
 
       expect(node.key).toHaveLength(88);
@@ -77,7 +81,11 @@ describe('BIP44Node', () => {
 
     it('throws an error if attempting to modify the fields of a node', () => {
       const node: any = new BIP44Node({
-        derivationPath: [defaultBip39Node, BIP44PurposeNode, `bip32:60'`],
+        derivationPath: [
+          defaultBip39NodeToken,
+          BIP44PurposeNodeToken,
+          `bip32:60'`,
+        ],
       });
 
       // getter
@@ -128,7 +136,11 @@ describe('BIP44Node', () => {
         () =>
           new BIP44Node({
             depth: 2, // This is the correct depth, but it's still forbidden
-            derivationPath: [defaultBip39Node, BIP44PurposeNode, `bip32:60'`],
+            derivationPath: [
+              defaultBip39NodeToken,
+              BIP44PurposeNodeToken,
+              `bip32:60'`,
+            ],
           }),
       ).toThrow(
         'Invalid parameters: May not specify a depth if a derivation path is specified. The depth will be calculated from the path.',
@@ -146,7 +158,7 @@ describe('BIP44Node', () => {
         () =>
           new BIP44Node({
             depth: 1,
-            derivationPath: [defaultBip39Node],
+            derivationPath: [defaultBip39NodeToken],
             key: Buffer.alloc(64).fill(1),
           }),
       ).toThrow(
@@ -172,10 +184,10 @@ describe('BIP44Node', () => {
       expect(
         () =>
           new BIP44Node({
-            derivationPath: [defaultBip39Node, `bip32:43'`] as any,
+            derivationPath: [defaultBip39NodeToken, `bip32:43'`] as any,
           }),
       ).toThrow(
-        `Invalid derivation path: The "purpose" node node (depth 1) must be the string "${BIP44PurposeNode}".`,
+        `Invalid derivation path: The "purpose" node node (depth 1) must be the string "${BIP44PurposeNodeToken}".`,
       );
     });
 
@@ -184,8 +196,8 @@ describe('BIP44Node', () => {
         () =>
           new BIP44Node({
             derivationPath: [
-              defaultBip39Node,
-              BIP44PurposeNode,
+              defaultBip39NodeToken,
+              BIP44PurposeNodeToken,
               `bip32:60`,
             ] as any,
           }),
@@ -199,8 +211,8 @@ describe('BIP44Node', () => {
         () =>
           new BIP44Node({
             derivationPath: [
-              defaultBip39Node,
-              BIP44PurposeNode,
+              defaultBip39NodeToken,
+              BIP44PurposeNodeToken,
               `bip32:60'`,
               `bip32:0`,
             ] as any,
@@ -215,8 +227,8 @@ describe('BIP44Node', () => {
         () =>
           new BIP44Node({
             derivationPath: [
-              defaultBip39Node,
-              BIP44PurposeNode,
+              defaultBip39NodeToken,
+              BIP44PurposeNodeToken,
               `bip32:60'`,
               `bip32:0'`,
               `bip32:0'`,
@@ -232,8 +244,8 @@ describe('BIP44Node', () => {
         () =>
           new BIP44Node({
             derivationPath: [
-              defaultBip39Node,
-              BIP44PurposeNode,
+              defaultBip39NodeToken,
+              BIP44PurposeNodeToken,
               `bip32:60'`,
               `bip32:0'`,
               `bip32:0`,
@@ -288,11 +300,15 @@ describe('BIP44Node', () => {
     it('derives a child node', () => {
       const coinTypeNode = `bip32:40'`;
       const targetNode = new BIP44Node({
-        derivationPath: [defaultBip39Node, BIP44PurposeNode, coinTypeNode],
+        derivationPath: [
+          defaultBip39NodeToken,
+          BIP44PurposeNodeToken,
+          coinTypeNode,
+        ],
       });
 
       const childNode = new BIP44Node({
-        derivationPath: [defaultBip39Node, BIP44PurposeNode],
+        derivationPath: [defaultBip39NodeToken, BIP44PurposeNodeToken],
       }).derive([coinTypeNode]);
 
       expect(childNode).toMatchObject({
@@ -305,8 +321,8 @@ describe('BIP44Node', () => {
       expect(() =>
         new BIP44Node({
           derivationPath: [
-            defaultBip39Node,
-            BIP44PurposeNode,
+            defaultBip39NodeToken,
+            BIP44PurposeNodeToken,
             `bip32:3'`,
             `bip32:0'`,
             `bip32:0`,
@@ -320,8 +336,8 @@ describe('BIP44Node', () => {
       expect(() =>
         new BIP44Node({
           derivationPath: [
-            defaultBip39Node,
-            BIP44PurposeNode,
+            defaultBip39NodeToken,
+            BIP44PurposeNodeToken,
             `bip32:3'`,
             `bip32:0'`,
           ],
@@ -334,17 +350,17 @@ describe('BIP44Node', () => {
     it('throws if the depth 1 node of the derivation path is not the BIP-44 purpose node', () => {
       expect(() =>
         new BIP44Node({
-          derivationPath: [defaultBip39Node],
+          derivationPath: [defaultBip39NodeToken],
         }).derive([`bip32:43'`]),
       ).toThrow(
-        `Invalid derivation path: The "purpose" node node (depth 1) must be the string "${BIP44PurposeNode}".`,
+        `Invalid derivation path: The "purpose" node node (depth 1) must be the string "${BIP44PurposeNodeToken}".`,
       );
     });
 
     it('throws if the depth 2 node of the derivation path is not a hardened BIP-32 node', () => {
       expect(() =>
         new BIP44Node({
-          derivationPath: [defaultBip39Node, BIP44PurposeNode],
+          derivationPath: [defaultBip39NodeToken, BIP44PurposeNodeToken],
         }).derive([`bip32:60`]),
       ).toThrow(
         'Invalid derivation path: The "coin_type" node (depth 2) must be a hardened BIP-32 node.',
@@ -354,7 +370,11 @@ describe('BIP44Node', () => {
     it('throws if the depth 3 node of the derivation path is not a hardened BIP-32 node', () => {
       expect(() =>
         new BIP44Node({
-          derivationPath: [defaultBip39Node, BIP44PurposeNode, `bip32:60'`],
+          derivationPath: [
+            defaultBip39NodeToken,
+            BIP44PurposeNodeToken,
+            `bip32:60'`,
+          ],
         }).derive([`bip32:0`]),
       ).toThrow(
         'Invalid derivation path: The "account" node (depth 3) must be a hardened BIP-32 node.',
@@ -365,8 +385,8 @@ describe('BIP44Node', () => {
       expect(() =>
         new BIP44Node({
           derivationPath: [
-            defaultBip39Node,
-            BIP44PurposeNode,
+            defaultBip39NodeToken,
+            BIP44PurposeNodeToken,
             `bip32:60'`,
             `bip32:0'`,
           ],
@@ -380,8 +400,8 @@ describe('BIP44Node', () => {
       expect(() =>
         new BIP44Node({
           derivationPath: [
-            defaultBip39Node,
-            BIP44PurposeNode,
+            defaultBip39NodeToken,
+            BIP44PurposeNodeToken,
             `bip32:60'`,
             `bip32:0'`,
             `bip32:0`,
@@ -396,7 +416,11 @@ describe('BIP44Node', () => {
   describe('toJSON', () => {
     it('returns a JSON-compatible representation of the node', () => {
       const node = new BIP44Node({
-        derivationPath: [defaultBip39Node, BIP44PurposeNode, `bip32:60'`],
+        derivationPath: [
+          defaultBip39NodeToken,
+          BIP44PurposeNodeToken,
+          `bip32:60'`,
+        ],
       });
 
       expect(typeof node.key).toStrictEqual('string');

--- a/src/BIP44Node.test.ts
+++ b/src/BIP44Node.test.ts
@@ -28,8 +28,8 @@ describe('BIP44Node', () => {
     });
   });
 
-  describe('BIP44Node.keyAsBuffer', () => {
-    it.todo('returns the node key as a Buffer');
+  describe('BIP44Node.key', () => {
+    it.todo('returns the node key as a Base64 string');
   });
 
   describe('BIP44Node.toJSON', () => {
@@ -187,7 +187,7 @@ describe('derivation', () => {
       privateKeyToEthAddress(base64StringToBuffer(account0Key)).toString('hex'),
     ).toStrictEqual(childfixturehd.getWallet().getAddressString().slice(2));
 
-    expect(node.keyAsBuffer.slice(0, 32).toString('base64')).toStrictEqual(
+    expect(node.keyBuffer.slice(0, 32).toString('base64')).toStrictEqual(
       fixtureKey.toString('base64'),
     );
     // console.log(fixtureKey)

--- a/src/BIP44Node.test.ts
+++ b/src/BIP44Node.test.ts
@@ -1,5 +1,5 @@
 import fixtures from '../test/fixtures';
-import { BIP44Node, BIP44PurposeNode, MIN_BIP_44_DEPTH } from '.';
+import { BIP44Node, BIP44PurposeNode } from '.';
 
 const defaultBip39Node = `bip39:${fixtures.local.mnemonic}` as const;
 
@@ -164,9 +164,84 @@ describe('BIP44Node', () => {
       expect(
         () => new BIP44Node({ derivationPath: [`bip32:0'`] as any }),
       ).toThrow(
-        `Invalid HD path segment: The segment must consist of a single BIP-39 node for depths of ${MIN_BIP_44_DEPTH}. Received: "${[
-          `bip32:0'`,
-        ]}"`,
+        'Invalid derivation path: The "m" / seed node (depth 0) must be a BIP-39 node.',
+      );
+    });
+
+    it('throws if the depth 1 node of the derivation path is not the BIP-44 purpose node', () => {
+      expect(
+        () =>
+          new BIP44Node({
+            derivationPath: [defaultBip39Node, `bip32:43'`] as any,
+          }),
+      ).toThrow(
+        `Invalid derivation path: The "purpose" node node (depth 1) must be the string "${BIP44PurposeNode}".`,
+      );
+    });
+
+    it('throws if the depth 2 node of the derivation path is not a hardened BIP-32 node', () => {
+      expect(
+        () =>
+          new BIP44Node({
+            derivationPath: [
+              defaultBip39Node,
+              BIP44PurposeNode,
+              `bip32:60`,
+            ] as any,
+          }),
+      ).toThrow(
+        'Invalid derivation path: The "coin_type" node (depth 2) must be a hardened BIP-32 node.',
+      );
+    });
+
+    it('throws if the depth 3 node of the derivation path is not a hardened BIP-32 node', () => {
+      expect(
+        () =>
+          new BIP44Node({
+            derivationPath: [
+              defaultBip39Node,
+              BIP44PurposeNode,
+              `bip32:60'`,
+              `bip32:0`,
+            ] as any,
+          }),
+      ).toThrow(
+        'Invalid derivation path: The "account" node (depth 3) must be a hardened BIP-32 node.',
+      );
+    });
+
+    it('throws if the depth 4 node of the derivation path is not an unhardened BIP-32 node', () => {
+      expect(
+        () =>
+          new BIP44Node({
+            derivationPath: [
+              defaultBip39Node,
+              BIP44PurposeNode,
+              `bip32:60'`,
+              `bip32:0'`,
+              `bip32:0'`,
+            ] as any,
+          }),
+      ).toThrow(
+        'Invalid derivation path: The "change" node (depth 4) must be an unhardened BIP-32 node.',
+      );
+    });
+
+    it('throws if the depth 5 node of the derivation path is not an unhardened BIP-32 node', () => {
+      expect(
+        () =>
+          new BIP44Node({
+            derivationPath: [
+              defaultBip39Node,
+              BIP44PurposeNode,
+              `bip32:60'`,
+              `bip32:0'`,
+              `bip32:0`,
+              `bip32:0'`,
+            ] as any,
+          }),
+      ).toThrow(
+        'Invalid derivation path: The "address_index" node (depth 5) must be an unhardened BIP-32 node.',
       );
     });
 
@@ -253,6 +328,67 @@ describe('BIP44Node', () => {
         }).derive([] as any),
       ).toThrow(
         'Invalid HD tree derivation path: Deriving a path of length 0 is not defined',
+      );
+    });
+
+    it('throws if the depth 1 node of the derivation path is not the BIP-44 purpose node', () => {
+      expect(() =>
+        new BIP44Node({
+          derivationPath: [defaultBip39Node],
+        }).derive([`bip32:43'`]),
+      ).toThrow(
+        `Invalid derivation path: The "purpose" node node (depth 1) must be the string "${BIP44PurposeNode}".`,
+      );
+    });
+
+    it('throws if the depth 2 node of the derivation path is not a hardened BIP-32 node', () => {
+      expect(() =>
+        new BIP44Node({
+          derivationPath: [defaultBip39Node, BIP44PurposeNode],
+        }).derive([`bip32:60`]),
+      ).toThrow(
+        'Invalid derivation path: The "coin_type" node (depth 2) must be a hardened BIP-32 node.',
+      );
+    });
+
+    it('throws if the depth 3 node of the derivation path is not a hardened BIP-32 node', () => {
+      expect(() =>
+        new BIP44Node({
+          derivationPath: [defaultBip39Node, BIP44PurposeNode, `bip32:60'`],
+        }).derive([`bip32:0`]),
+      ).toThrow(
+        'Invalid derivation path: The "account" node (depth 3) must be a hardened BIP-32 node.',
+      );
+    });
+
+    it('throws if the depth 4 node of the derivation path is not an unhardened BIP-32 node', () => {
+      expect(() =>
+        new BIP44Node({
+          derivationPath: [
+            defaultBip39Node,
+            BIP44PurposeNode,
+            `bip32:60'`,
+            `bip32:0'`,
+          ],
+        }).derive([`bip32:0'`]),
+      ).toThrow(
+        'Invalid derivation path: The "change" node (depth 4) must be an unhardened BIP-32 node.',
+      );
+    });
+
+    it('throws if the depth 5 node of the derivation path is not an unhardened BIP-32 node', () => {
+      expect(() =>
+        new BIP44Node({
+          derivationPath: [
+            defaultBip39Node,
+            BIP44PurposeNode,
+            `bip32:60'`,
+            `bip32:0'`,
+            `bip32:0`,
+          ],
+        }).derive([`bip32:0'`]),
+      ).toThrow(
+        'Invalid derivation path: The "address_index" node (depth 5) must be an unhardened BIP-32 node.',
       );
     });
   });

--- a/src/BIP44Node.test.ts
+++ b/src/BIP44Node.test.ts
@@ -3,20 +3,18 @@ import { hdkey } from 'ethereumjs-wallet';
 import { BIP44Node } from './BIP44Node';
 import { getBIP44AddressKeyDeriver } from './BIP44CoinTypeNode';
 import { privateKeyToEthAddress } from './derivers/bip32';
-import { base64StringToBuffer } from './utils';
+import { BIP44PurposeNode, MIN_BIP_44_DEPTH } from './constants';
+
+const defaultMnemonic =
+  'romance hurry grit huge rifle ordinary loud toss sound congress upset twist';
+const defaultBip39Node = `bip39:${defaultMnemonic}` as const;
 
 describe('BIP44Node', () => {
   describe('BIP44Node.constructor', () => {
-    it('initializes a new node', () => {
-      const mnemonic =
-        'romance hurry grit huge rifle ordinary loud toss sound congress upset twist';
-
-      const bip39Node = `bip39:${mnemonic}` as const;
-
-      // ethereum coin type
+    it('initializes a new node (depth, derivationPath)', () => {
+      // Ethereum coin type node
       const node = new BIP44Node({
-        depth: 2,
-        derivationPath: [bip39Node, `bip32:44'`, `bip32:60'`],
+        derivationPath: [defaultBip39Node, BIP44PurposeNode, `bip32:60'`],
       });
 
       expect(node.key).toHaveLength(88);
@@ -26,36 +24,251 @@ describe('BIP44Node', () => {
         key: node.key,
       });
     });
-  });
 
-  describe('BIP44Node.key', () => {
-    it.todo('returns the node key as a Base64 string');
-  });
+    it('initializes a new node (depth, buffer key)', () => {
+      const node = new BIP44Node({
+        depth: 1,
+        key: Buffer.alloc(64).fill(1),
+      });
 
-  describe('BIP44Node.toJSON', () => {
-    it.todo('returns a JSON-compatible representation of the node');
+      expect(node.key).toHaveLength(88);
+      expect(node.depth).toStrictEqual(1);
+      expect(node.toJSON()).toStrictEqual({
+        depth: 1,
+        key: node.key,
+      });
+    });
+
+    it('initializes a new node (depth, Base64 string key)', () => {
+      const node = new BIP44Node({
+        depth: 3,
+        key: Buffer.alloc(64).fill(2).toString('base64'),
+      });
+
+      expect(node.key).toHaveLength(88);
+      expect(node.depth).toStrictEqual(3);
+      expect(node.toJSON()).toStrictEqual({
+        depth: 3,
+        key: node.key,
+      });
+    });
+
+    it('initializes a new node (depth, hex string key)', () => {
+      const node = new BIP44Node({
+        depth: 3,
+        key: Buffer.alloc(64).fill(2).toString('hex'),
+      });
+
+      expect(node.key).toHaveLength(88);
+      expect(node.depth).toStrictEqual(3);
+      expect(node.toJSON()).toStrictEqual({
+        depth: 3,
+        key: node.key,
+      });
+    });
+
+    it('initializes a new node (depth, 0x-prefixed hex string key)', () => {
+      const node = new BIP44Node({
+        depth: 3,
+        key: `0x${Buffer.alloc(64).fill(2).toString('hex')}`,
+      });
+
+      expect(node.key).toHaveLength(88);
+      expect(node.depth).toStrictEqual(3);
+      expect(node.toJSON()).toStrictEqual({
+        depth: 3,
+        key: node.key,
+      });
+    });
+
+    it('throws an error if attempting to modify the fields of a node', () => {
+      const node: any = new BIP44Node({
+        derivationPath: [defaultBip39Node, BIP44PurposeNode, `bip32:60'`],
+      });
+
+      // getter
+      expect(() => (node.key = 'foo')).toThrow(
+        /^Cannot set property key of .+ which has only a getter/iu,
+      );
+
+      // frozen / readonly
+      ['depth', 'keyBuffer'].forEach((property) => {
+        expect(() => (node[property] = Buffer.allocUnsafe(64).fill(1))).toThrow(
+          expect.objectContaining({
+            name: 'TypeError',
+            message: expect.stringMatching(
+              `Cannot assign to read only property '${property}' of object`,
+            ),
+          }),
+        );
+      });
+    });
+
+    it('throws if the depth is invalid', () => {
+      const validBufferKey = Buffer.alloc(64).fill(1);
+
+      [
+        -1,
+        6,
+        0.1,
+        -0.1,
+        NaN,
+        Infinity,
+        '0',
+        'zero',
+        {},
+        null,
+        undefined,
+      ].forEach((invalidDepth) => {
+        expect(
+          () =>
+            new BIP44Node({ depth: invalidDepth as any, key: validBufferKey }),
+        ).toThrow(
+          `Invalid HD tree path depth: The depth must be a positive integer N such that 0 <= N <= 5. Received: "${invalidDepth}"`,
+        );
+      });
+    });
+
+    it('throws if both a derivation path and a depth are specified', () => {
+      expect(
+        () =>
+          new BIP44Node({
+            depth: 2, // This is the correct depth, but it's still forbidden
+            derivationPath: [defaultBip39Node, BIP44PurposeNode, `bip32:60'`],
+          }),
+      ).toThrow(
+        'Invalid parameters: May not specify a depth if a derivation path is specified. The depth will be calculated from the path.',
+      );
+    });
+
+    it('throws if neither a derivation path nor a key is specified', () => {
+      expect(() => new BIP44Node({ depth: 1 })).toThrow(
+        'Invalid parameters: Must specify either key or derivation path.',
+      );
+    });
+
+    it('throws if both a derivation path and a key are specified', () => {
+      expect(
+        () =>
+          new BIP44Node({
+            depth: 1,
+            derivationPath: [defaultBip39Node],
+            key: Buffer.alloc(64).fill(1),
+          }),
+      ).toThrow(
+        'Invalid parameters: May not specify a derivation path if a key is specified. Initialize the node with just the parent key and its depth, then call BIP44Node.derive() with your desired path.',
+      );
+    });
+
+    it('throws if the derivation path is empty', () => {
+      expect(() => new BIP44Node({ derivationPath: [] as any })).toThrow(
+        'Invalid derivation path: May not specify an empty derivation path.',
+      );
+    });
+
+    it('throws if the derivation path is of depth 0 and not a single BIP-39 node', () => {
+      expect(
+        () => new BIP44Node({ derivationPath: [`bip32:0'`] as any }),
+      ).toThrow(
+        `Invalid HD path segment: The segment must consist of a single BIP-39 node for depths of ${MIN_BIP_44_DEPTH}. Received: "${[
+          `bip32:0'`,
+        ]}"`,
+      );
+    });
+
+    it('throws if the key is neither a string nor a buffer', () => {
+      expect(() => new BIP44Node({ depth: 0, key: {} as any })).toThrow(
+        'Invalid key: Must be a Buffer or string if specified. Received: "object"',
+      );
+    });
+
+    it('throws if the key is an invalid Buffer', () => {
+      const invalidLengthBuffer = Buffer.alloc(63).fill(1);
+      const zeroBuffer = Buffer.alloc(64);
+
+      [invalidLengthBuffer, zeroBuffer].forEach((bufferKey) => {
+        expect(() => new BIP44Node({ depth: 0, key: bufferKey })).toThrow(
+          'Invalid buffer key: Must be a 64-byte, non-empty Buffer.',
+        );
+      });
+    });
+
+    it('throws if the key is an invalid string', () => {
+      const hexInputs = [
+        Buffer.alloc(64).toString('hex'),
+        Buffer.alloc(63).fill(1).toString('hex'),
+      ];
+
+      [
+        // Base64
+        Buffer.alloc(64).toString('base64'),
+        Buffer.alloc(63).fill(1).toString('base64'),
+
+        // Hexadecimal
+        ...hexInputs,
+        ...hexInputs.map((input) => `0x${input}`),
+      ].forEach((stringKey) => {
+        expect(() => new BIP44Node({ depth: 0, key: stringKey })).toThrow(
+          'Invalid string key: Must be a 64-byte hexadecimal or Base64 string.',
+        );
+      });
+    });
   });
 
   describe('BIP44Node.derive', () => {
-    it.todo('derives a child node');
-  });
+    it('derives a child node', () => {
+      const coinTypeNode = `bip32:40'`;
+      const targetNode = new BIP44Node({
+        derivationPath: [defaultBip39Node, BIP44PurposeNode, coinTypeNode],
+      });
 
-  describe('deriveChildNode', () => {
-    it.todo('derives a child node');
+      const childNode = new BIP44Node({
+        derivationPath: [defaultBip39Node, BIP44PurposeNode],
+      }).derive([coinTypeNode]);
+
+      expect(childNode).toMatchObject({
+        depth: targetNode.depth,
+        key: targetNode.key,
+      });
+    });
+
+    it('throws if the parent node is already a leaf node', () => {
+      expect(() =>
+        new BIP44Node({
+          derivationPath: [
+            defaultBip39Node,
+            BIP44PurposeNode,
+            `bip32:3'`,
+            `bip32:0'`,
+            `bip32:0`,
+            `bip32:0`,
+          ],
+        }).derive([`bip32:1`]),
+      ).toThrow('Illegal operation: This HD tree node is already a leaf node.');
+    });
+
+    it('throws if the child derivation path is zero', () => {
+      expect(() =>
+        new BIP44Node({
+          derivationPath: [
+            defaultBip39Node,
+            BIP44PurposeNode,
+            `bip32:3'`,
+            `bip32:0'`,
+          ],
+        }).derive([] as any),
+      ).toThrow(
+        'Invalid HD tree derivation path: Deriving a path of length 0 is not defined',
+      );
+    });
   });
 });
 
 describe('derivation', () => {
-  it('initializes a BIP44Node', () => {
-    const mnemonic =
-      'romance hurry grit huge rifle ordinary loud toss sound congress upset twist';
-
-    const bip39Node = `bip39:${mnemonic}` as const;
-
-    // ethereum coin type
+  it('local seed phrase', () => {
+    // Ethereum coin type node
     const node = new BIP44Node({
-      depth: 2,
-      derivationPath: [bip39Node, `bip32:44'`, `bip32:60'`],
+      derivationPath: [defaultBip39Node, BIP44PurposeNode, `bip32:60'`],
     });
 
     expect(node.key).toHaveLength(88);
@@ -64,27 +277,24 @@ describe('derivation', () => {
       depth: 2,
       key: expect.any(String),
     });
-    console.log(node.toJSON());
 
     const ethereumAddressDeriver = getBIP44AddressKeyDeriver(node as any, {
       account: 0,
       change: 0,
     });
-    console.log('Deriver path:', ethereumAddressDeriver.path);
 
     const account0Key = ethereumAddressDeriver(0);
-    console.log(account0Key);
-    expect(
-      privateKeyToEthAddress(base64StringToBuffer(account0Key)).toString('hex'),
-    ).toStrictEqual('5df603999c3d5ca2ab828339a9883585b1bce11b');
-
-    expect(() => {
-      node.derive([`bip32:60'`, `bip32:0'`, `bip32:0`, `bip32:0`]);
-    }).toThrow(
-      `Invalid HD tree path depth: The depth must be a positive integer N such that 0 <= N <= 5. Received: "6"`,
+    expect(privateKeyToEthAddress(account0Key).toString('hex')).toStrictEqual(
+      '5df603999c3d5ca2ab828339a9883585b1bce11b',
     );
 
-    // const childNode = node.derive([`bip32:44'`])
+    // expect(() => {
+    //   node.derive([`bip32:60'`, `bip32:0'`, `bip32:0`, `bip32:0`]);
+    // }).toThrow(
+    //   `Invalid HD tree path depth: The depth must be a positive integer N such that 0 <= N <= 5. Received: "6"`,
+    // );
+
+    // const childNode = node.derive([BIP44PurposeNode])
     // expect(childNode.key.length).toStrictEqual(88);
     // expect(childNode.depth).toStrictEqual(1);
   });
@@ -93,15 +303,14 @@ describe('derivation', () => {
   it('eth-hd-keyring', () => {
     const sampleMnemonic =
       'finish oppose decorate face calm tragic certain desk hour urge dinosaur mango';
-    const firstAcct = '1c96099350f13d558464ec79b9be4445aa0ef579';
-    const secondAcct = '1b00aed43a693f3a957f9feb5cc08afa031e37a0';
+    const account0 = '1c96099350f13d558464ec79b9be4445aa0ef579';
+    const account1 = '1b00aed43a693f3a957f9feb5cc08afa031e37a0';
 
     const newBip39 = `bip39:${sampleMnemonic}` as const;
 
-    // ethereum coin typ
+    // Ethereum coin type node
     const node = new BIP44Node({
-      depth: 2,
-      derivationPath: [newBip39, `bip32:44'`, `bip32:60'`],
+      derivationPath: [newBip39, BIP44PurposeNode, `bip32:60'`],
     });
 
     expect(node.key).toHaveLength(88);
@@ -110,34 +319,28 @@ describe('derivation', () => {
       depth: 2,
       key: expect.any(String),
     });
-    console.log(node.toJSON());
 
     const ethereumAddressDeriver = getBIP44AddressKeyDeriver(node as any, {
       account: 0,
       change: 0,
     });
-    console.log('Deriver path:', ethereumAddressDeriver.path);
 
     const account0Key = ethereumAddressDeriver(0);
     const account1Key = ethereumAddressDeriver(1);
-    console.log(account0Key);
-    expect(
-      privateKeyToEthAddress(base64StringToBuffer(account0Key)).toString('hex'),
-    ).toStrictEqual(firstAcct);
 
-    expect(
-      privateKeyToEthAddress(base64StringToBuffer(account1Key)).toString('hex'),
-    ).toStrictEqual(secondAcct);
-
-    expect(() => {
-      node.derive([`bip32:60'`, `bip32:0'`, `bip32:0`, `bip32:0`]);
-    }).toThrow(
-      `Invalid HD tree path depth: The depth must be a positive integer N such that 0 <= N <= 5. Received: "6"`,
+    expect(privateKeyToEthAddress(account0Key).toString('hex')).toStrictEqual(
+      account0,
     );
 
-    // const childNode = node.derive([`bip32:44'`])
-    // expect(childNode.key.length).toStrictEqual(88);
-    // expect(childNode.depth).toStrictEqual(1);
+    expect(privateKeyToEthAddress(account1Key).toString('hex')).toStrictEqual(
+      account1,
+    );
+
+    // expect(() => {
+    //   node.derive([`bip32:60'`, `bip32:0'`, `bip32:0`, `bip32:0`]);
+    // }).toThrow(
+    //   `Invalid HD tree path depth: The depth must be a positive integer N such that 0 <= N <= 5. Received: "6"`,
+    // );
   });
 
   // https://github.com/ethereumjs/ethereumjs-wallet/blob/master/test/hdkey.spec.ts
@@ -155,50 +358,24 @@ describe('derivation', () => {
     const childfixturehd = fixturehd.derivePath("m/44'/0'/0/1");
     const fixtureKey = childfixturehd.getWallet().getPrivateKey();
 
-    // ethereum coin typ
     const _node = new BIP44Node({
       depth: 0,
       key: seedKey,
     });
 
-    // const node = _node.derive([`bip32:44'`, `bip32:60'`])
-    const node = _node.derive([`bip32:44'`, `bip32:0'`, `bip32:0`, `bip32:1`]);
+    const node = _node.derive([
+      BIP44PurposeNode,
+      `bip32:0'`,
+      `bip32:0`,
+      `bip32:1`,
+    ]);
 
-    expect(node.key).toHaveLength(88);
-    expect(node.depth).toStrictEqual(4);
-    expect(node.toJSON()).toStrictEqual({
-      depth: 4,
-      key: expect.any(String),
-    });
-    console.log(node.toJSON());
-
-    const account0Key = node.key;
-
-    // const ethereumAddressDeriver = getBIP44AddressKeyDeriver(node as any, {
-    //   account: 0,
-    //   change: 0,
-    // })
-    // console.log('Deriver path:', ethereumAddressDeriver.path)
-
-    // const account0Key = ethereumAddressDeriver(0)
-    console.log(account0Key);
-    // expect(account0Key).toStrictEqual(fixtureKey)
     expect(
-      privateKeyToEthAddress(base64StringToBuffer(account0Key)).toString('hex'),
+      privateKeyToEthAddress(node.keyBuffer).toString('hex'),
     ).toStrictEqual(childfixturehd.getWallet().getAddressString().slice(2));
 
     expect(node.keyBuffer.slice(0, 32).toString('base64')).toStrictEqual(
       fixtureKey.toString('base64'),
     );
-    // console.log(fixtureKey)
-    // console.log(node.keyAsBuffer.slice(32))
-
-    // expect(() => {
-    //   node.derive([`bip32:60'`, `bip32:0'`, `bip32:0`, `bip32:0`])
-    // }).toThrow(`Invalid HD tree path depth: The depth must be a positive integer N such that 0 <= N <= 5. Received: "6"`)
-
-    // const childNode = node.derive([`bip32:44'`])
-    // expect(childNode.key.length).toStrictEqual(88);
-    // expect(childNode.depth).toStrictEqual(1);
   });
 });

--- a/src/BIP44Node.test.ts
+++ b/src/BIP44Node.test.ts
@@ -1,6 +1,5 @@
 import fixtures from '../test/fixtures';
-import { BIP44Node } from './BIP44Node';
-import { BIP44PurposeNode, MIN_BIP_44_DEPTH } from './constants';
+import { BIP44Node, BIP44PurposeNode, MIN_BIP_44_DEPTH } from '.';
 
 const defaultBip39Node = `bip39:${fixtures.local.mnemonic}` as const;
 

--- a/src/BIP44Node.test.ts
+++ b/src/BIP44Node.test.ts
@@ -1,0 +1,204 @@
+import crypto from 'crypto';
+import { hdkey } from 'ethereumjs-wallet';
+import { BIP44Node } from './BIP44Node';
+import { getBIP44AddressKeyDeriver } from './BIP44CoinTypeNode';
+import { privateKeyToEthAddress } from './derivers/bip32';
+import { base64StringToBuffer } from './utils';
+
+describe('BIP44Node', () => {
+  describe('BIP44Node.constructor', () => {
+    it('initializes a new node', () => {
+      const mnemonic =
+        'romance hurry grit huge rifle ordinary loud toss sound congress upset twist';
+
+      const bip39Node = `bip39:${mnemonic}` as const;
+
+      // ethereum coin type
+      const node = new BIP44Node({
+        depth: 2,
+        derivationPath: [bip39Node, `bip32:44'`, `bip32:60'`],
+      });
+
+      expect(node.key).toHaveLength(88);
+      expect(node.depth).toStrictEqual(2);
+      expect(node.toJSON()).toStrictEqual({
+        depth: 2,
+        key: node.key,
+      });
+    });
+  });
+
+  describe('BIP44Node.keyAsBuffer', () => {
+    it.todo('returns the node key as a Buffer');
+  });
+
+  describe('BIP44Node.toJSON', () => {
+    it.todo('returns a JSON-compatible representation of the node');
+  });
+
+  describe('BIP44Node.derive', () => {
+    it.todo('derives a child node');
+  });
+
+  describe('deriveChildNode', () => {
+    it.todo('derives a child node');
+  });
+});
+
+describe('derivation', () => {
+  it('initializes a BIP44Node', () => {
+    const mnemonic =
+      'romance hurry grit huge rifle ordinary loud toss sound congress upset twist';
+
+    const bip39Node = `bip39:${mnemonic}` as const;
+
+    // ethereum coin type
+    const node = new BIP44Node({
+      depth: 2,
+      derivationPath: [bip39Node, `bip32:44'`, `bip32:60'`],
+    });
+
+    expect(node.key).toHaveLength(88);
+    expect(node.depth).toStrictEqual(2);
+    expect(node.toJSON()).toStrictEqual({
+      depth: 2,
+      key: expect.any(String),
+    });
+    console.log(node.toJSON());
+
+    const ethereumAddressDeriver = getBIP44AddressKeyDeriver(node as any, {
+      account: 0,
+      change: 0,
+    });
+    console.log('Deriver path:', ethereumAddressDeriver.path);
+
+    const account0Key = ethereumAddressDeriver(0);
+    console.log(account0Key);
+    expect(
+      privateKeyToEthAddress(base64StringToBuffer(account0Key)).toString('hex'),
+    ).toStrictEqual('5df603999c3d5ca2ab828339a9883585b1bce11b');
+
+    expect(() => {
+      node.derive([`bip32:60'`, `bip32:0'`, `bip32:0`, `bip32:0`]);
+    }).toThrow(
+      `Invalid HD tree path depth: The depth must be a positive integer N such that 0 <= N <= 5. Received: "6"`,
+    );
+
+    // const childNode = node.derive([`bip32:44'`])
+    // expect(childNode.key.length).toStrictEqual(88);
+    // expect(childNode.depth).toStrictEqual(1);
+  });
+
+  // https://github.com/brave/eth-hd-keyring/blob/482acf341f01a8d1e924d55bfdbd309444a78e46/test/index.js#L10-L12
+  it('eth-hd-keyring', () => {
+    const sampleMnemonic =
+      'finish oppose decorate face calm tragic certain desk hour urge dinosaur mango';
+    const firstAcct = '1c96099350f13d558464ec79b9be4445aa0ef579';
+    const secondAcct = '1b00aed43a693f3a957f9feb5cc08afa031e37a0';
+
+    const newBip39 = `bip39:${sampleMnemonic}` as const;
+
+    // ethereum coin typ
+    const node = new BIP44Node({
+      depth: 2,
+      derivationPath: [newBip39, `bip32:44'`, `bip32:60'`],
+    });
+
+    expect(node.key).toHaveLength(88);
+    expect(node.depth).toStrictEqual(2);
+    expect(node.toJSON()).toStrictEqual({
+      depth: 2,
+      key: expect.any(String),
+    });
+    console.log(node.toJSON());
+
+    const ethereumAddressDeriver = getBIP44AddressKeyDeriver(node as any, {
+      account: 0,
+      change: 0,
+    });
+    console.log('Deriver path:', ethereumAddressDeriver.path);
+
+    const account0Key = ethereumAddressDeriver(0);
+    const account1Key = ethereumAddressDeriver(1);
+    console.log(account0Key);
+    expect(
+      privateKeyToEthAddress(base64StringToBuffer(account0Key)).toString('hex'),
+    ).toStrictEqual(firstAcct);
+
+    expect(
+      privateKeyToEthAddress(base64StringToBuffer(account1Key)).toString('hex'),
+    ).toStrictEqual(secondAcct);
+
+    expect(() => {
+      node.derive([`bip32:60'`, `bip32:0'`, `bip32:0`, `bip32:0`]);
+    }).toThrow(
+      `Invalid HD tree path depth: The depth must be a positive integer N such that 0 <= N <= 5. Received: "6"`,
+    );
+
+    // const childNode = node.derive([`bip32:44'`])
+    // expect(childNode.key.length).toStrictEqual(88);
+    // expect(childNode.depth).toStrictEqual(1);
+  });
+
+  // https://github.com/ethereumjs/ethereumjs-wallet/blob/master/test/hdkey.spec.ts
+  it('ethereumjs-wallet', () => {
+    const fixtureseed = Buffer.from(
+      '747f302d9c916698912d5f70be53a6cf53bc495803a5523d3a7c3afa2afba94ec3803f838b3e1929ab5481f9da35441372283690fdcf27372c38f40ba134fe03',
+      'hex',
+    );
+    const seedKey = crypto
+      .createHmac('sha512', Buffer.from('Bitcoin seed', 'utf8'))
+      .update(fixtureseed)
+      .digest();
+
+    const fixturehd = hdkey.fromMasterSeed(fixtureseed);
+    const childfixturehd = fixturehd.derivePath("m/44'/0'/0/1");
+    const fixtureKey = childfixturehd.getWallet().getPrivateKey();
+
+    // ethereum coin typ
+    const _node = new BIP44Node({
+      depth: 0,
+      key: seedKey,
+    });
+
+    // const node = _node.derive([`bip32:44'`, `bip32:60'`])
+    const node = _node.derive([`bip32:44'`, `bip32:0'`, `bip32:0`, `bip32:1`]);
+
+    expect(node.key).toHaveLength(88);
+    expect(node.depth).toStrictEqual(4);
+    expect(node.toJSON()).toStrictEqual({
+      depth: 4,
+      key: expect.any(String),
+    });
+    console.log(node.toJSON());
+
+    const account0Key = node.key;
+
+    // const ethereumAddressDeriver = getBIP44AddressKeyDeriver(node as any, {
+    //   account: 0,
+    //   change: 0,
+    // })
+    // console.log('Deriver path:', ethereumAddressDeriver.path)
+
+    // const account0Key = ethereumAddressDeriver(0)
+    console.log(account0Key);
+    // expect(account0Key).toStrictEqual(fixtureKey)
+    expect(
+      privateKeyToEthAddress(base64StringToBuffer(account0Key)).toString('hex'),
+    ).toStrictEqual(childfixturehd.getWallet().getAddressString().slice(2));
+
+    expect(node.keyAsBuffer.slice(0, 32).toString('base64')).toStrictEqual(
+      fixtureKey.toString('base64'),
+    );
+    // console.log(fixtureKey)
+    // console.log(node.keyAsBuffer.slice(32))
+
+    // expect(() => {
+    //   node.derive([`bip32:60'`, `bip32:0'`, `bip32:0`, `bip32:0`])
+    // }).toThrow(`Invalid HD tree path depth: The depth must be a positive integer N such that 0 <= N <= 5. Received: "6"`)
+
+    // const childNode = node.derive([`bip32:44'`])
+    // expect(childNode.key.length).toStrictEqual(88);
+    // expect(childNode.depth).toStrictEqual(1);
+  });
+});

--- a/src/BIP44Node.ts
+++ b/src/BIP44Node.ts
@@ -47,7 +47,7 @@ export type BIP44NodeInterface = JsonBIP44Node & {
   toJSON(): JsonBIP44Node;
 };
 
-interface HDPathOptions {
+interface BIP44NodeOptions {
   readonly depth: BIP44Depth;
   readonly key?: Buffer | string;
   readonly derivationPath?: HDPathTuple;
@@ -84,7 +84,7 @@ export class BIP44Node implements BIP44NodeInterface {
    * @param options.key -
    * @param options.derivationPath -
    */
-  constructor({ depth, key, derivationPath }: HDPathOptions) {
+  constructor({ depth, key, derivationPath }: BIP44NodeOptions) {
     const [bufferKey, stringKey] = BIP44Node._parseKey(key);
 
     if (derivationPath) {

--- a/src/BIP44Node.ts
+++ b/src/BIP44Node.ts
@@ -26,7 +26,7 @@ export interface JsonBIP44Node {
    *
    * A BIP-44 path is of the form:
    *
-   * `m / purpose' / coin_type' / account' / change / address_index`
+   * `m / 44' / coin_type' / account' / change / address_index`
    *
    * With the following depths:
    *
@@ -91,7 +91,7 @@ export class BIP44Node implements BIP44NodeInterface {
    *
    * Recall that a BIP-44 HD tree path consists of the following nodes:
    *
-   * `m / purpose' / coin_type' / account' / change / address_index`
+   * `m / 44' / coin_type' / account' / change / address_index`
    *
    * With the following depths:
    *
@@ -197,7 +197,7 @@ export class BIP44Node implements BIP44NodeInterface {
    *
    * Recall that a BIP-44 HD tree path consists of the following nodes:
    *
-   * `m / purpose' / coin_type' / account' / change / address_index`
+   * `m / 44' / coin_type' / account' / change / address_index`
    *
    * With the following depths:
    *

--- a/src/BIP44Node.ts
+++ b/src/BIP44Node.ts
@@ -8,7 +8,7 @@ import {
   HDPathTuple,
   BIP_39_PATH_REGEX,
   BIP_32_PATH_REGEX,
-  BIP44PurposeNode,
+  BIP44PurposeNodeToken,
 } from './constants';
 import {
   bufferToBase64String,
@@ -313,9 +313,9 @@ function validateBIP44DerivationPath(
         break;
 
       case 1:
-        if (nodeToken !== BIP44PurposeNode) {
+        if (nodeToken !== BIP44PurposeNodeToken) {
           throw new Error(
-            `Invalid derivation path: The "purpose" node node (depth 1) must be the string "${BIP44PurposeNode}".`,
+            `Invalid derivation path: The "purpose" node node (depth 1) must be the string "${BIP44PurposeNodeToken}".`,
           );
         }
         break;

--- a/src/HDTreeNode.ts
+++ b/src/HDTreeNode.ts
@@ -10,129 +10,120 @@ import {
   bufferToBase64String,
   base64StringToBuffer,
   hexStringToBuffer,
-  isValidHexStringEntropy,
-  isValidBase64StringEntropy,
-  isValidBufferEntropy,
+  isValidHexStringKey,
+  isValidBase64StringKey,
+  isValidBufferKey,
 } from './utils';
 
+export interface JsonHDTreeNode {
+  readonly depth: HDTreeDepth;
+  readonly key: string;
+}
+
+export type HDTreeNodeInterface = JsonHDTreeNode & {
+  toJSON(): JsonHDTreeNode;
+};
+
 interface HDPathOptions {
-  depth: HDTreeDepth;
-  entropy?: Buffer | string;
-  derivationPath?: HDPathTuple;
+  readonly depth: HDTreeDepth;
+  readonly key?: Buffer | string;
+  readonly derivationPath?: HDPathTuple;
 }
 
 /**
  * - If the depth is 0:
- *   - If there is a path, it must be a single BIP39 segment
+ *   - If there is a path, it must be a single BIP39 node
  * - If the depth is >0:
- *    - If there is a path, the first segment must be a BIP32 segment
+ *    - If there is a path, the first segment must be a BIP32 node
  *
- * - If there is no entropy, there must be a path, and the first segment
- *   must be a BIP39 segment.
+ * - If there is no key, there must be a path, and the first node
+ *   must be a BIP39 node.
  */
 
 /**
  * TODO
  */
-export class HDTreeNode {
+export class HDTreeNode implements HDTreeNodeInterface {
   /**
    * The depth of the HD tree node.
    */
   public readonly depth: HDTreeDepth;
 
   /**
-   * The entropy of the HD tree node, as a Base64 string. Cryptographically, the
+   * The key of the HD tree node, as a Base64 string. Cryptographically, the
    * node itself.
    */
-  public readonly entropy: string;
+  public readonly key: string;
+
+  /**
+   * The key of the HD tree node, as a Node.js Buffer.
+   */
+  public get keyAsBuffer(): Buffer {
+    return base64StringToBuffer(this.key);
+  }
 
   /**
    * @param options - Options bag.
    * @param options.depth -
-   * @param options.entropy -
+   * @param options.key -
    * @param options.derivationPath -
    */
-  constructor({ depth, entropy, derivationPath }: HDPathOptions) {
-    const [bufferEntropy, stringEntropy] = HDTreeNode._parseEntropy(entropy);
+  constructor({ depth, key, derivationPath }: HDPathOptions) {
+    const [bufferKey, stringKey] = HDTreeNode._parseKey(key);
 
     if (derivationPath) {
-      this.entropy = deriveStringKeyFromPath(
-        derivationPath,
-        bufferEntropy,
-        depth,
-      );
+      this.key = deriveStringKeyFromPath(derivationPath, bufferKey, depth);
 
-      HDTreeNode._validateHDTreeDepth(depth, derivationPath.length);
+      validateHDTreeDepth(depth, derivationPath.length);
     } else {
-      if (!stringEntropy) {
+      if (!stringKey) {
         throw new Error(
-          'Invalid parameters: Must specify entropy if no derivation path is specified.',
+          'Invalid parameters: Must specify key if no derivation path is specified.',
         );
       }
-      this.entropy = stringEntropy;
-      HDTreeNode._validateHDTreeDepth(depth, null);
+      this.key = stringKey;
+      validateHDTreeDepth(depth, null);
     }
     this.depth = depth;
 
     Object.freeze(this);
   }
 
-  private static _parseEntropy(entropy: unknown) {
-    if (entropy === undefined || entropy === null) {
+  private static _parseKey(key: unknown) {
+    if (key === undefined || key === null) {
       return [undefined, undefined];
     }
 
-    let bufferEntropy: Buffer;
-    let stringEntropy: string;
-    if (typeof entropy === 'string') {
-      if (isValidHexStringEntropy(entropy)) {
-        bufferEntropy = hexStringToBuffer(entropy);
-        stringEntropy = bufferToBase64String(bufferEntropy);
-      } else if (isValidBase64StringEntropy(entropy)) {
-        stringEntropy = entropy;
-        bufferEntropy = base64StringToBuffer(entropy);
+    let bufferKey: Buffer;
+    let stringKey: string;
+    if (typeof key === 'string') {
+      if (isValidHexStringKey(key)) {
+        bufferKey = hexStringToBuffer(key);
+        stringKey = bufferToBase64String(bufferKey);
+      } else if (isValidBase64StringKey(key)) {
+        stringKey = key;
+        bufferKey = base64StringToBuffer(key);
       } else {
         throw new Error(
-          'Invalid string entropy: Must be a 64-byte hexadecimal or base64 string.',
+          'Invalid string key: Must be a 64-byte hexadecimal or Base64 string.',
         );
       }
-    } else if (Buffer.isBuffer(entropy)) {
-      if (!isValidBufferEntropy(entropy)) {
+    } else if (Buffer.isBuffer(key)) {
+      if (!isValidBufferKey(key)) {
         throw new Error(
-          'Invalid buffer entropy: Must be a 64-byte, non-empty Buffer.',
+          'Invalid buffer key: Must be a 64-byte, non-empty Buffer.',
         );
       }
 
-      bufferEntropy = entropy;
-      stringEntropy = bufferToBase64String(entropy);
+      bufferKey = key;
+      stringKey = bufferToBase64String(key);
     } else {
       throw new Error(
-        `Invalid entropy: Must be a Buffer or string if specified. Received: "${typeof entropy}"`,
+        `Invalid key: Must be a Buffer or string if specified. Received: "${typeof key}"`,
       );
     }
 
-    return [bufferEntropy, stringEntropy] as const;
-  }
-
-  private static _validateHDTreeDepth(
-    depth: number,
-    derivationPathLength: number | null,
-  ) {
-    if (
-      !Number.isInteger(depth) ||
-      depth < MIN_HD_TREE_DEPTH ||
-      depth > MAX_HD_TREE_DEPTH
-    ) {
-      throw new Error(
-        `Invalid HD tree path depth: The depth must be a positive integer N such that 0 <= N <= 5. Received: "${depth}"`,
-      );
-    }
-
-    if (derivationPathLength !== null && depth !== derivationPathLength - 1) {
-      throw new Error(
-        `Invalid HD tree path depth: The specified depth does not correspond to the length of the provided HD path: "${derivationPathLength}"`,
-      );
-    }
+    return [bufferKey, stringKey] as const;
   }
 
   public derive(path: PartialHDPathTuple): HDTreeNode {
@@ -142,31 +133,56 @@ export class HDTreeNode {
       );
     }
 
-    if ((path as any).length === 0) {
-      throw new Error(
-        'Invalid HD derivation path: Deriving a path of length 0 is not defined.',
-      );
-    }
-
-    const newDepth = (this.depth + path.length) as HDTreeDepth;
-    HDTreeNode._validateHDTreeDepth(newDepth, null);
-
-    const newEntropy = deriveKeyFromPath(
-      path,
-      base64StringToBuffer(this.entropy),
-    );
-
-    const options = {
-      depth: newDepth,
-      entropy: newEntropy,
-    };
-    return new HDTreeNode(options);
+    return deriveChildNode(this.keyAsBuffer, this.depth, path);
   }
 
-  toJSON(): Pick<HDTreeNode, 'depth' | 'entropy'> {
+  toJSON(): JsonHDTreeNode {
     return {
       depth: this.depth,
-      entropy: this.entropy,
+      key: this.key,
     };
+  }
+}
+
+export function deriveChildNode(
+  parentKey: Buffer,
+  parentDepth: HDTreeDepth,
+  pathToChild: PartialHDPathTuple,
+) {
+  if ((pathToChild as any).length === 0) {
+    throw new Error(
+      'Invalid HD derivation path: Deriving a path of length 0 is not defined.',
+    );
+  }
+
+  const newDepth = (parentDepth + pathToChild.length) as HDTreeDepth;
+  validateHDTreeDepth(newDepth, null);
+
+  const childKey = deriveKeyFromPath(pathToChild, parentKey);
+
+  return new HDTreeNode({
+    depth: newDepth,
+    key: childKey,
+  });
+}
+
+function validateHDTreeDepth(
+  depth: number,
+  derivationPathLength: number | null,
+) {
+  if (
+    !Number.isInteger(depth) ||
+    depth < MIN_HD_TREE_DEPTH ||
+    depth > MAX_HD_TREE_DEPTH
+  ) {
+    throw new Error(
+      `Invalid HD tree path depth: The depth must be a positive integer N such that 0 <= N <= 5. Received: "${depth}"`,
+    );
+  }
+
+  if (derivationPathLength !== null && depth !== derivationPathLength - 1) {
+    throw new Error(
+      `Invalid HD tree path depth: The specified depth does not correspond to the length of the provided HD path: "${derivationPathLength}"`,
+    );
   }
 }

--- a/src/HDTreeNode.ts
+++ b/src/HDTreeNode.ts
@@ -1,0 +1,352 @@
+import { deriveKeyFromPath, deriveStringKeyFromPath } from './derivation';
+import {
+  BIP32Node,
+  HDPathTuple,
+  HDPathString,
+  PartialHDPathString,
+  PATH_SEPARATOR,
+  MIN_HD_TREE_DEPTH,
+  MAX_HD_TREE_DEPTH,
+  HDTreeDepth,
+  AnonymizedHDPathTuple,
+  ANONYMIZED_ROOT,
+  BIP_39,
+  UNKNOWN_NODE_TOKEN,
+  KEY_BUFFER_LENGTH,
+} from './constants';
+import {
+  bufferToHexString,
+  getHexBuffer,
+  isValidHexString,
+  stripHexPrefix,
+} from './utils';
+
+type AddedHDPathSegmentTuple = BIP32Node[];
+
+function segmentStringToTuple(segment: HDPathString): HDPathTuple {
+  return segment.split(PATH_SEPARATOR) as HDPathTuple;
+}
+
+function segmentTupleToString(
+  segment: HDPathTuple | AddedHDPathSegmentTuple,
+): HDPathString | PartialHDPathString {
+  return segment.join(PATH_SEPARATOR) as HDPathString | PartialHDPathString;
+}
+
+function validateHDTreeDepth(
+  depth: number,
+  derivationPathLength: number | null,
+) {
+  if (
+    !Number.isInteger(depth) ||
+    depth < MIN_HD_TREE_DEPTH ||
+    depth > MAX_HD_TREE_DEPTH
+  ) {
+    throw new Error(
+      `Invalid HD Tree Path depth: The depth must be a positive integer N such that 0 <= N <= 5. Received: "${depth}"`,
+    );
+  }
+
+  if (derivationPathLength !== null && depth !== derivationPathLength - 1) {
+    throw new Error(
+      `Invalid HD Tree Path depth: The specified depth does not correspond to the length of the provided HD path: "${derivationPathLength}"`,
+    );
+  }
+}
+
+interface HDPathOptions {
+  depth: HDTreeDepth;
+  entropy?: Buffer | string;
+  anonymizedPath?: AnonymizedHDPathTuple;
+  derivationPath?: HDPathTuple | HDPathString;
+}
+
+/**
+ * - If the depth is 0:
+ *   - If there is a path, it must be a single BIP39 segment
+ * - If the depth is >0:
+ *    - If there is a path, the first segment must be a BIP32 segment
+ *
+ * - If there is no entropy, there must be a path, and the first segment
+ *   must be a BIP39 segment.
+ */
+
+export class HDTreeNode {
+  /**
+   * The depth of the HD tree node.
+   */
+  public readonly depth: HDTreeDepth;
+
+  /**
+   * The entropy of the HD tree node. Cryptographically, the node itself.
+   */
+  public readonly entropy: string;
+
+  /**
+   * The path to the node, including the root and the node itself.
+   * The derivation schema of any node along the path may or may not be known.
+   */
+  public readonly path: AnonymizedHDPathTuple;
+
+  /**
+   * @param options - Options bag.
+   * @param options.depth -
+   * @param options.entropy -
+   * @param options.derivationPath -
+   */
+  constructor({
+    depth,
+    entropy,
+    derivationPath,
+    anonymizedPath,
+  }: HDPathOptions) {
+    HDTreeNode._validateConstructorParameters({
+      depth,
+      entropy,
+      derivationPath,
+      anonymizedPath,
+    });
+
+    let stringEntropy, bufferEntropy;
+    if (entropy) {
+      if (typeof entropy === 'string') {
+        stringEntropy = entropy;
+        bufferEntropy = getHexBuffer(entropy);
+      } else {
+        bufferEntropy = entropy;
+        stringEntropy = bufferToHexString(entropy);
+      }
+    }
+
+    if (derivationPath) {
+      const stringPath =
+        typeof derivationPath === 'string'
+          ? derivationPath
+          : segmentTupleToString(derivationPath);
+      this.entropy = deriveStringKeyFromPath(stringPath, bufferEntropy, depth);
+
+      validateHDTreeDepth(
+        depth,
+        typeof derivationPath === 'string'
+          ? segmentStringToTuple(derivationPath).length
+          : derivationPath.length,
+      );
+
+      this.path = HDTreeNode._getAnonymizedPath({
+        depth,
+        derivationPath,
+      });
+    } else {
+      if (!stringEntropy) {
+        throw new Error(
+          'Invalid parameters: Must specify entropy if no derivation path is specified.',
+        );
+      }
+      this.entropy = stringEntropy;
+      this.path = HDTreeNode._getAnonymizedPath({ depth, anonymizedPath });
+
+      validateHDTreeDepth(depth, null);
+    }
+    this.depth = depth;
+
+    Object.freeze(this);
+  }
+
+  private static _validateConstructorParameters({
+    depth,
+    entropy,
+    derivationPath,
+    anonymizedPath,
+  }: HDPathOptions) {
+    if (derivationPath && anonymizedPath) {
+      throw new Error(
+        'Invalid parameters: May not specify derivationPath and anonymizedPath',
+      );
+    }
+
+    if (derivationPath === '') {
+      throw new Error(
+        'Invalid derivation path: May not specify the empty string.',
+      );
+    }
+
+    if (anonymizedPath && anonymizedPath.length !== depth) {
+      throw new Error(
+        'Invalid anonymized path: The anonymized path length must match the specified depth.',
+      );
+    }
+
+    if (entropy) {
+      if (typeof entropy !== 'string' && !Buffer.isBuffer(entropy)) {
+        throw new Error(
+          `Invalid entropy: Must be a Buffer or string if specified. Received: "${typeof entropy}"`,
+        );
+      }
+
+      if (Buffer.isBuffer(entropy) && !isValidBufferEntropy(entropy)) {
+        throw new Error(
+          'Invalid buffer entropy: Must be a 64-byte, non-empty Buffer.',
+        );
+      }
+
+      if (typeof entropy === 'string' && !isValidStringEntropy(entropy)) {
+        throw new Error(
+          'Invalid string entropy: Must be a 64-character, nonzero hexadecimal string.',
+        );
+      }
+    }
+  }
+
+  public derive(path: AddedHDPathSegmentTuple): HDTreeNode {
+    if (this.depth === MAX_HD_TREE_DEPTH) {
+      throw new Error(
+        'Unable to derive: This HD Tree Path already ends with a leaf node.',
+      );
+    }
+
+    if (path.length === 0) {
+      throw new Error(
+        'Invalid HD derivation path: Deriving a path of length 0 is not defined.',
+      );
+    }
+
+    const newDepth = (this.depth + path.length) as HDTreeDepth;
+    validateHDTreeDepth(newDepth, null);
+
+    const newStringPath = segmentTupleToString(path);
+
+    const newEntropy = deriveKeyFromPath(
+      newStringPath,
+      getHexBuffer(this.entropy),
+    );
+
+    const options = {
+      depth: newDepth,
+      entropy: newEntropy,
+      // This performs some validation that we want.
+      anonymizedPath: HDTreeNode._getAnonymizedPath({
+        depth: newDepth,
+        anonymizedPath: [...this.path, ...path] as AnonymizedHDPathTuple,
+      }),
+    };
+    return new HDTreeNode(options);
+  }
+
+  private static _getAnonymizedPath({
+    depth,
+    derivationPath,
+    anonymizedPath,
+  }: Omit<HDPathOptions, 'entropy'>): AnonymizedHDPathTuple {
+    if (!derivationPath && !anonymizedPath) {
+      return getUnknownHDPathRepresentation(depth);
+    }
+
+    if (derivationPath && anonymizedPath) {
+      throw new Error('Invalid _getAnonymizedPath parameters.');
+    }
+
+    if (derivationPath) {
+      const _derivationPath =
+        typeof derivationPath === 'string'
+          ? segmentStringToTuple(derivationPath)
+          : derivationPath;
+      return anonymizeHDPath(_derivationPath);
+    }
+
+    if (anonymizedPath) {
+      if (anonymizedPath.length - 1 !== depth) {
+        throw new Error(
+          'Invalid anonymized path: path length does not match the specified depth.',
+        );
+      }
+      validateAnonymizedHDPath(anonymizedPath);
+      return anonymizedPath;
+    }
+    /** istanbul ignore next: unreachable */
+    throw new Error('Invalid _getAnonymizedPath parameters.');
+  }
+
+  serialize(): Pick<HDTreeNode, 'depth' | 'entropy' | 'path'> {
+    return {
+      depth: this.depth,
+      entropy: this.entropy,
+      path: this.path,
+    };
+  }
+}
+
+function anonymizeHDPath(
+  path: HDPathTuple | AnonymizedHDPathTuple,
+): AnonymizedHDPathTuple {
+  const [, ..._path] = path;
+  let anonymizedPath: string[];
+
+  if (path[0] === ANONYMIZED_ROOT) {
+    anonymizedPath = path;
+  } else {
+    anonymizedPath = [ANONYMIZED_ROOT];
+    _path.forEach((node) => {
+      anonymizedPath.push(node);
+    });
+  }
+
+  validateAnonymizedHDPath(anonymizedPath);
+  return anonymizedPath as AnonymizedHDPathTuple;
+}
+
+function validateAnonymizedHDPath(path: string[]) {
+  if (path.length > MAX_HD_TREE_DEPTH) {
+    throw new Error(
+      `Anonymized path is too long. The max is 5, found: "${path.length}"`,
+    );
+  }
+
+  path.forEach((node) => {
+    if (node.includes(BIP_39)) {
+      throw new Error('Intermediary HD Tree node potentially toxic.');
+    }
+  });
+}
+
+function getUnknownHDPathRepresentation(
+  depth: HDTreeDepth,
+): AnonymizedHDPathTuple {
+  const path = [];
+  for (let i = 0; i <= depth; i++) {
+    if (i === depth) {
+      path.unshift(ANONYMIZED_ROOT);
+    } else {
+      path.unshift(UNKNOWN_NODE_TOKEN);
+    }
+  }
+  return path as AnonymizedHDPathTuple;
+}
+
+function isValidBufferEntropy(buffer: Buffer): boolean {
+  if (buffer.length !== KEY_BUFFER_LENGTH) {
+    return false;
+  }
+
+  for (const byte of buffer) {
+    if (byte !== 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isValidStringEntropy(stringEntropy: string): boolean {
+  if (!isValidHexString(stringEntropy)) {
+    return false;
+  }
+
+  const stripped = stripHexPrefix(stringEntropy);
+  if (stripped.length !== KEY_BUFFER_LENGTH) {
+    return false;
+  }
+
+  if (/^0+$/iu.test(stripped)) {
+    return false;
+  }
+  return true;
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -36,6 +36,20 @@ export type BIP32Node = HardenedBIP32Node | UnhardenedBIP32Node;
 
 export const BIP44PurposeNode = `bip32:44'`;
 
+/**
+ * e.g.
+ * -  bip32:0
+ * -  bip32:0'
+ */
+export const BIP_32_PATH_REGEX = /^bip32:\d+'?$/u;
+
+/**
+ * bip39:<SPACE_DELMITED_SEED_PHRASE>
+ *
+ * The seed phrase must consist of 12 <= 24 words.
+ */
+export const BIP_39_PATH_REGEX = /^bip39:([a-z]+){1}( [a-z]+){11,23}$/u;
+
 type HDPathString0 = AnonymizedBIP39Node;
 type HDPathString1 = `${HDPathString0} / ${HardenedBIP32Node}`;
 type HDPathString2 = `${HDPathString1} / ${HardenedBIP32Node}`;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -54,50 +54,6 @@ export type PartialHDPathString =
   | PartialHDPathString4
   | PartialHDPathString5;
 
-export const ANONYMIZED_ROOT = 'm' as const;
-export const UNKNOWN_NODE_TOKEN = 'bip32:?' as const;
-
-export type AnonymizedRootNode = typeof ANONYMIZED_ROOT;
-export type UnknownHDNode = typeof UNKNOWN_NODE_TOKEN;
-export type AnonymizedIntermediaryNode = BIP32Node | UnknownHDNode;
-
-type AnonymizedHDPathTuple0 = [AnonymizedRootNode];
-type AnonymizedHDPathTuple1 = [AnonymizedRootNode, AnonymizedIntermediaryNode];
-type AnonymizedHDPathTuple2 = [
-  AnonymizedRootNode,
-  AnonymizedIntermediaryNode,
-  AnonymizedIntermediaryNode,
-];
-type AnonymizedHDPathTuple3 = [
-  AnonymizedRootNode,
-  AnonymizedIntermediaryNode,
-  AnonymizedIntermediaryNode,
-  AnonymizedIntermediaryNode,
-];
-type AnonymizedHDPathTuple4 = [
-  AnonymizedRootNode,
-  AnonymizedIntermediaryNode,
-  AnonymizedIntermediaryNode,
-  AnonymizedIntermediaryNode,
-  AnonymizedIntermediaryNode,
-];
-type AnonymizedHDPathTuple5 = [
-  AnonymizedRootNode,
-  AnonymizedIntermediaryNode,
-  AnonymizedIntermediaryNode,
-  AnonymizedIntermediaryNode,
-  AnonymizedIntermediaryNode,
-  AnonymizedIntermediaryNode,
-];
-
-export type AnonymizedHDPathTuple =
-  | AnonymizedHDPathTuple0
-  | AnonymizedHDPathTuple1
-  | AnonymizedHDPathTuple2
-  | AnonymizedHDPathTuple3
-  | AnonymizedHDPathTuple4
-  | AnonymizedHDPathTuple5;
-
 type HDPathTuple0 = [BIP39Node];
 type HDPathTuple1 = [BIP39Node, BIP32Node];
 type HDPathTuple2 = [BIP39Node, BIP32Node, BIP32Node];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,8 @@ export const BASE_64_KEY_LENGTH = 88 as const;
 export const BASE_64_ZERO =
   'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==' as const;
 
+export const HEXADECIMAL_KEY_LENGTH = 128 as const;
+
 // Source: https://stackoverflow.com/a/475217
 export const BASE_64_REGEX =
   /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$/u;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,7 @@
 export const KEY_BUFFER_LENGTH = 64 as const;
 
+export const BASE_64_ENTROPY_LENGTH = 88 as const;
+
 export const PATH_SEPARATOR = '/';
 
 export const BIP_39 = 'bip39';
@@ -13,7 +15,7 @@ export type HDTreeDepth = MinHDTreeDepth | 1 | 2 | 3 | 4 | MaxHDTreeDepth;
 
 export type SingleQuoteChar = `'`;
 
-export type BIP39Node = `bip39:${number}`;
+export type BIP39Node = `bip39:${string}`;
 export type BIP32Node = `bip32:${number}${SingleQuoteChar | ''}`;
 
 type HDPathString0 = BIP39Node;
@@ -54,14 +56,20 @@ export type PartialHDPathString =
   | PartialHDPathString4
   | PartialHDPathString5;
 
-type HDPathTuple0 = [BIP39Node];
-type HDPathTuple1 = [BIP39Node, BIP32Node];
-type HDPathTuple2 = [BIP39Node, BIP32Node, BIP32Node];
-type HDPathTuple3 = [BIP39Node, BIP32Node, BIP32Node, BIP32Node];
+type RootedHDPathTuple0 = [BIP39Node];
+type RootedHDPathTuple1 = [BIP39Node, BIP32Node];
+type RootedHDPathTuple2 = [BIP39Node, BIP32Node, BIP32Node];
+type RootedHDPathTuple3 = [BIP39Node, BIP32Node, BIP32Node, BIP32Node];
 
-type HDPathTuple4 = [BIP39Node, BIP32Node, BIP32Node, BIP32Node, BIP32Node];
+type RootedHDPathTuple4 = [
+  BIP39Node,
+  BIP32Node,
+  BIP32Node,
+  BIP32Node,
+  BIP32Node,
+];
 
-type HDPathTuple5 = [
+type RootedHDPathTuple5 = [
   BIP39Node,
   BIP32Node,
   BIP32Node,
@@ -70,10 +78,33 @@ type HDPathTuple5 = [
   BIP32Node,
 ];
 
-export type HDPathTuple =
-  | HDPathTuple0
-  | HDPathTuple1
-  | HDPathTuple2
-  | HDPathTuple3
-  | HDPathTuple4
-  | HDPathTuple5;
+export type RootedHDPathTuple =
+  | RootedHDPathTuple0
+  | RootedHDPathTuple1
+  | RootedHDPathTuple2
+  | RootedHDPathTuple3
+  | RootedHDPathTuple4
+  | RootedHDPathTuple5;
+
+type PartialHDPathTuple1 = [BIP32Node];
+type PartialHDPathTuple2 = [BIP32Node, BIP32Node];
+type PartialHDPathTuple3 = [BIP32Node, BIP32Node, BIP32Node];
+type PartialHDPathTuple4 = [BIP32Node, BIP32Node, BIP32Node, BIP32Node];
+type PartialHDPathTuple5 = [
+  BIP32Node,
+  BIP32Node,
+  BIP32Node,
+  BIP32Node,
+  BIP32Node,
+];
+
+export type PartialHDPathTuple =
+  | PartialHDPathTuple1
+  | PartialHDPathTuple2
+  | PartialHDPathTuple3
+  | PartialHDPathTuple4
+  | PartialHDPathTuple5;
+
+export type HDPathTuple = RootedHDPathTuple | PartialHDPathTuple;
+
+export type FullHDPathTuple = RootedHDPathTuple5;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-export const KEY_BUFFER_LENGTH = 64 as const;
+export const BUFFER_KEY_LENGTH = 64 as const;
 
 export const BASE_64_KEY_LENGTH = 88 as const;
 
@@ -116,6 +116,9 @@ export type PartialHDPathTuple =
   | PartialHDPathTuple10
   | PartialHDPathTuple11;
 
+/**
+ * Every ordered subset of a full HD path tuple.
+ */
 export type HDPathTuple = RootedHDPathTuple | PartialHDPathTuple;
 
 export type FullHDPathTuple = RootedHDPathTuple5;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -34,7 +34,7 @@ export type HardenedBIP32Node = `bip32:${number}'`;
 export type UnhardenedBIP32Node = `bip32:${number}`;
 export type BIP32Node = HardenedBIP32Node | UnhardenedBIP32Node;
 
-export const BIP44PurposeNode = `bip32:44'`;
+export const BIP44PurposeNodeToken = `bip32:44'`;
 
 /**
  * e.g.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,28 +9,26 @@ export const BASE_64_ZERO =
 export const BASE_64_REGEX =
   /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$/u;
 
-export const MIN_HD_TREE_DEPTH = 0 as const;
-export const MAX_HD_TREE_DEPTH = 5 as const;
+export const MIN_BIP_44_DEPTH = 0 as const;
+export const MAX_BIP_44_DEPTH = 5 as const;
 
-export type MinHDTreeDepth = typeof MIN_HD_TREE_DEPTH;
-export type MaxHDTreeDepth = typeof MAX_HD_TREE_DEPTH;
-export type HDTreeDepth = MinHDTreeDepth | 1 | 2 | 3 | 4 | MaxHDTreeDepth;
+export type MinBIP44Depth = typeof MIN_BIP_44_DEPTH;
+export type MaxBIP44Depth = typeof MAX_BIP_44_DEPTH;
+export type BIP44Depth = MinBIP44Depth | 1 | 2 | 3 | 4 | MaxBIP44Depth;
 
-type SingleQuote = `'`;
-
-// BIP-32 derivation path:
+// BIP-44 derivation path:
 // m / purpose' / coin_type' / account' / change / address_index
 //
 // Per BIP-43 / BIP-44, "purpose" should always be "44":
 // m / 44' / coin_type' / account' / change / address_index
 //
-// The Ethereum "coin_type" is "60". Here's an example Ethereum HD path for
-// "account 0":
+// The Ethereum "coin_type" is "60". Its "account" and "change" indices are
+// always "0". Here's an example Ethereum HD path for account "0":
 // m  / 44' / 60' / 0' / 0 / 0
 
 export type AnonymizedBIP39Node = 'm';
 export type BIP39Node = `bip39:${string}`;
-export type HardenedBIP32Node = `bip32:${number}${SingleQuote}`;
+export type HardenedBIP32Node = `bip32:${number}'`;
 export type UnhardenedBIP32Node = `bip32:${number}`;
 export type BIP32Node = HardenedBIP32Node | UnhardenedBIP32Node;
 
@@ -44,6 +42,7 @@ type HDPathString4 = `${HDPathString3} / ${UnhardenedBIP32Node}`;
 type HDPathString5 = `${HDPathString4} / ${UnhardenedBIP32Node}`;
 
 export type CoinTypeHDPathString = HDPathString2;
+export type ChangeHDPathString = HDPathString4;
 export type AddressHDPathString = HDPathString5;
 
 export type HDPathString =

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,123 @@
+export const KEY_BUFFER_LENGTH = 64 as const;
+
+export const PATH_SEPARATOR = '/';
+
+export const BIP_39 = 'bip39';
+
+export const MIN_HD_TREE_DEPTH = 0 as const;
+export const MAX_HD_TREE_DEPTH = 5 as const;
+
+export type MinHDTreeDepth = typeof MIN_HD_TREE_DEPTH;
+export type MaxHDTreeDepth = typeof MAX_HD_TREE_DEPTH;
+export type HDTreeDepth = MinHDTreeDepth | 1 | 2 | 3 | 4 | MaxHDTreeDepth;
+
+export type SingleQuoteChar = `'`;
+
+export type BIP39Node = `bip39:${number}`;
+export type BIP32Node = `bip32:${number}${SingleQuoteChar | ''}`;
+
+type HDPathString0 = BIP39Node;
+type HDPathString1 = `${BIP39Node}/${BIP32Node}`;
+type HDPathString2 = `${BIP39Node}/${BIP32Node}/${BIP32Node}`;
+
+type HDPathString3 = `${BIP39Node}/${BIP32Node}/${BIP32Node}/${BIP32Node}`;
+
+type HDPathString4 =
+  `${BIP39Node}/${BIP32Node}/${BIP32Node}/${BIP32Node}/${BIP32Node}`;
+
+type HDPathString5 =
+  `${BIP39Node}/${BIP32Node}/${BIP32Node}/${BIP32Node}/${BIP32Node}/${BIP32Node}`;
+
+export type HDPathString =
+  | HDPathString0
+  | HDPathString1
+  | HDPathString2
+  | HDPathString3
+  | HDPathString4
+  | HDPathString5;
+
+type PartialHDPathString1 = `${BIP32Node}`;
+type PartialHDPathString2 = `${BIP32Node}/${BIP32Node}`;
+
+type PartialHDPathString3 = `${BIP32Node}/${BIP32Node}/${BIP32Node}`;
+
+type PartialHDPathString4 =
+  `${BIP32Node}/${BIP32Node}/${BIP32Node}/${BIP32Node}`;
+
+type PartialHDPathString5 =
+  `${BIP32Node}/${BIP32Node}/${BIP32Node}/${BIP32Node}/${BIP32Node}`;
+
+export type PartialHDPathString =
+  | PartialHDPathString1
+  | PartialHDPathString2
+  | PartialHDPathString3
+  | PartialHDPathString4
+  | PartialHDPathString5;
+
+export const ANONYMIZED_ROOT = 'm' as const;
+export const UNKNOWN_NODE_TOKEN = 'bip32:?' as const;
+
+export type AnonymizedRootNode = typeof ANONYMIZED_ROOT;
+export type UnknownHDNode = typeof UNKNOWN_NODE_TOKEN;
+export type AnonymizedIntermediaryNode = BIP32Node | UnknownHDNode;
+
+type AnonymizedHDPathTuple0 = [AnonymizedRootNode];
+type AnonymizedHDPathTuple1 = [AnonymizedRootNode, AnonymizedIntermediaryNode];
+type AnonymizedHDPathTuple2 = [
+  AnonymizedRootNode,
+  AnonymizedIntermediaryNode,
+  AnonymizedIntermediaryNode,
+];
+type AnonymizedHDPathTuple3 = [
+  AnonymizedRootNode,
+  AnonymizedIntermediaryNode,
+  AnonymizedIntermediaryNode,
+  AnonymizedIntermediaryNode,
+];
+type AnonymizedHDPathTuple4 = [
+  AnonymizedRootNode,
+  AnonymizedIntermediaryNode,
+  AnonymizedIntermediaryNode,
+  AnonymizedIntermediaryNode,
+  AnonymizedIntermediaryNode,
+];
+type AnonymizedHDPathTuple5 = [
+  AnonymizedRootNode,
+  AnonymizedIntermediaryNode,
+  AnonymizedIntermediaryNode,
+  AnonymizedIntermediaryNode,
+  AnonymizedIntermediaryNode,
+  AnonymizedIntermediaryNode,
+];
+
+export type AnonymizedHDPathTuple =
+  | AnonymizedHDPathTuple0
+  | AnonymizedHDPathTuple1
+  | AnonymizedHDPathTuple2
+  | AnonymizedHDPathTuple3
+  | AnonymizedHDPathTuple4
+  | AnonymizedHDPathTuple5;
+
+type HDPathTuple0 = [BIP39Node];
+type HDPathTuple1 = [BIP39Node, BIP32Node];
+type HDPathTuple2 = [BIP39Node, BIP32Node, BIP32Node];
+type HDPathTuple3 = [BIP39Node, BIP32Node, BIP32Node, BIP32Node];
+
+type HDPathTuple4 = [BIP39Node, BIP32Node, BIP32Node, BIP32Node, BIP32Node];
+
+type HDPathTuple5 = [
+  BIP39Node,
+  BIP32Node,
+  BIP32Node,
+  BIP32Node,
+  BIP32Node,
+  BIP32Node,
+];
+
+export type HDPathTuple =
+  | HDPathTuple0
+  | HDPathTuple1
+  | HDPathTuple2
+  | HDPathTuple3
+  | HDPathTuple4
+  | HDPathTuple5;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,9 +2,12 @@ export const KEY_BUFFER_LENGTH = 64 as const;
 
 export const BASE_64_ENTROPY_LENGTH = 88 as const;
 
-export const PATH_SEPARATOR = '/';
+export const BASE_64_ZERO =
+  'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==' as const;
 
-export const BIP_39 = 'bip39';
+// Source: https://stackoverflow.com/a/475217
+export const BASE_64_REGEX =
+  /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$/u;
 
 export const MIN_HD_TREE_DEPTH = 0 as const;
 export const MAX_HD_TREE_DEPTH = 5 as const;
@@ -13,10 +16,10 @@ export type MinHDTreeDepth = typeof MIN_HD_TREE_DEPTH;
 export type MaxHDTreeDepth = typeof MAX_HD_TREE_DEPTH;
 export type HDTreeDepth = MinHDTreeDepth | 1 | 2 | 3 | 4 | MaxHDTreeDepth;
 
-export type SingleQuoteChar = `'`;
+type SingleQuote = `'`;
 
 export type BIP39Node = `bip39:${string}`;
-export type BIP32Node = `bip32:${number}${SingleQuoteChar | ''}`;
+export type BIP32Node = `bip32:${number}${SingleQuote | ''}`;
 
 type HDPathString0 = BIP39Node;
 type HDPathString1 = `${BIP39Node}/${BIP32Node}`;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 export const KEY_BUFFER_LENGTH = 64 as const;
 
-export const BASE_64_ENTROPY_LENGTH = 88 as const;
+export const BASE_64_KEY_LENGTH = 88 as const;
 
 export const BASE_64_ZERO =
   'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==' as const;
@@ -18,20 +18,33 @@ export type HDTreeDepth = MinHDTreeDepth | 1 | 2 | 3 | 4 | MaxHDTreeDepth;
 
 type SingleQuote = `'`;
 
+// BIP-32 derivation path:
+// m / purpose' / coin_type' / account' / change / address_index
+//
+// Per BIP-43 / BIP-44, "purpose" should always be "44":
+// m / 44' / coin_type' / account' / change / address_index
+//
+// The Ethereum "coin_type" is "60". Here's an example Ethereum HD path for
+// "account 0":
+// m  / 44' / 60' / 0' / 0 / 0
+
+export type AnonymizedBIP39Node = 'm';
 export type BIP39Node = `bip39:${string}`;
-export type BIP32Node = `bip32:${number}${SingleQuote | ''}`;
+export type HardenedBIP32Node = `bip32:${number}${SingleQuote}`;
+export type UnhardenedBIP32Node = `bip32:${number}`;
+export type BIP32Node = HardenedBIP32Node | UnhardenedBIP32Node;
 
-type HDPathString0 = BIP39Node;
-type HDPathString1 = `${BIP39Node}/${BIP32Node}`;
-type HDPathString2 = `${BIP39Node}/${BIP32Node}/${BIP32Node}`;
+export const BIP44PurposeNode = `bip32:44'`;
 
-type HDPathString3 = `${BIP39Node}/${BIP32Node}/${BIP32Node}/${BIP32Node}`;
+type HDPathString0 = AnonymizedBIP39Node;
+type HDPathString1 = `${HDPathString0} / ${HardenedBIP32Node}`;
+type HDPathString2 = `${HDPathString1} / ${HardenedBIP32Node}`;
+type HDPathString3 = `${HDPathString2} / ${HardenedBIP32Node}`;
+type HDPathString4 = `${HDPathString3} / ${UnhardenedBIP32Node}`;
+type HDPathString5 = `${HDPathString4} / ${UnhardenedBIP32Node}`;
 
-type HDPathString4 =
-  `${BIP39Node}/${BIP32Node}/${BIP32Node}/${BIP32Node}/${BIP32Node}`;
-
-type HDPathString5 =
-  `${BIP39Node}/${BIP32Node}/${BIP32Node}/${BIP32Node}/${BIP32Node}/${BIP32Node}`;
+export type CoinTypeHDPathString = HDPathString2;
+export type AddressHDPathString = HDPathString5;
 
 export type HDPathString =
   | HDPathString0
@@ -41,45 +54,12 @@ export type HDPathString =
   | HDPathString4
   | HDPathString5;
 
-type PartialHDPathString1 = `${BIP32Node}`;
-type PartialHDPathString2 = `${BIP32Node}/${BIP32Node}`;
-
-type PartialHDPathString3 = `${BIP32Node}/${BIP32Node}/${BIP32Node}`;
-
-type PartialHDPathString4 =
-  `${BIP32Node}/${BIP32Node}/${BIP32Node}/${BIP32Node}`;
-
-type PartialHDPathString5 =
-  `${BIP32Node}/${BIP32Node}/${BIP32Node}/${BIP32Node}/${BIP32Node}`;
-
-export type PartialHDPathString =
-  | PartialHDPathString1
-  | PartialHDPathString2
-  | PartialHDPathString3
-  | PartialHDPathString4
-  | PartialHDPathString5;
-
-type RootedHDPathTuple0 = [BIP39Node];
-type RootedHDPathTuple1 = [BIP39Node, BIP32Node];
-type RootedHDPathTuple2 = [BIP39Node, BIP32Node, BIP32Node];
-type RootedHDPathTuple3 = [BIP39Node, BIP32Node, BIP32Node, BIP32Node];
-
-type RootedHDPathTuple4 = [
-  BIP39Node,
-  BIP32Node,
-  BIP32Node,
-  BIP32Node,
-  BIP32Node,
-];
-
-type RootedHDPathTuple5 = [
-  BIP39Node,
-  BIP32Node,
-  BIP32Node,
-  BIP32Node,
-  BIP32Node,
-  BIP32Node,
-];
+type RootedHDPathTuple0 = readonly [BIP39Node];
+type RootedHDPathTuple1 = readonly [...RootedHDPathTuple0, HardenedBIP32Node];
+type RootedHDPathTuple2 = readonly [...RootedHDPathTuple1, HardenedBIP32Node];
+type RootedHDPathTuple3 = readonly [...RootedHDPathTuple2, HardenedBIP32Node];
+type RootedHDPathTuple4 = readonly [...RootedHDPathTuple3, UnhardenedBIP32Node];
+type RootedHDPathTuple5 = readonly [...RootedHDPathTuple4, UnhardenedBIP32Node];
 
 export type RootedHDPathTuple =
   | RootedHDPathTuple0
@@ -89,24 +69,51 @@ export type RootedHDPathTuple =
   | RootedHDPathTuple4
   | RootedHDPathTuple5;
 
-type PartialHDPathTuple1 = [BIP32Node];
-type PartialHDPathTuple2 = [BIP32Node, BIP32Node];
-type PartialHDPathTuple3 = [BIP32Node, BIP32Node, BIP32Node];
-type PartialHDPathTuple4 = [BIP32Node, BIP32Node, BIP32Node, BIP32Node];
-type PartialHDPathTuple5 = [
-  BIP32Node,
-  BIP32Node,
-  BIP32Node,
-  BIP32Node,
-  BIP32Node,
+type PartialHDPathTuple1 = readonly [HardenedBIP32Node];
+type PartialHDPathTuple2 = readonly [...PartialHDPathTuple1, HardenedBIP32Node];
+type PartialHDPathTuple3 = readonly [...PartialHDPathTuple2, HardenedBIP32Node];
+type PartialHDPathTuple4 = readonly [
+  ...PartialHDPathTuple3,
+  UnhardenedBIP32Node,
 ];
+type PartialHDPathTuple5 = readonly [
+  ...PartialHDPathTuple4,
+  UnhardenedBIP32Node,
+];
+type PartialHDPathTuple6 = readonly [UnhardenedBIP32Node];
+type PartialHDPathTuple7 = readonly [UnhardenedBIP32Node, UnhardenedBIP32Node];
+type PartialHDPathTuple8 = readonly [
+  HardenedBIP32Node,
+  UnhardenedBIP32Node,
+  UnhardenedBIP32Node,
+];
+type PartialHDPathTuple9 = readonly [HardenedBIP32Node, UnhardenedBIP32Node];
+type PartialHDPathTuple10 = readonly [
+  HardenedBIP32Node,
+  HardenedBIP32Node,
+  UnhardenedBIP32Node,
+];
+type PartialHDPathTuple11 = readonly [
+  HardenedBIP32Node,
+  HardenedBIP32Node,
+  UnhardenedBIP32Node,
+  UnhardenedBIP32Node,
+];
+
+export type CoinTypeToAddressTuple = PartialHDPathTuple8;
 
 export type PartialHDPathTuple =
   | PartialHDPathTuple1
   | PartialHDPathTuple2
   | PartialHDPathTuple3
   | PartialHDPathTuple4
-  | PartialHDPathTuple5;
+  | PartialHDPathTuple5
+  | PartialHDPathTuple6
+  | PartialHDPathTuple7
+  | PartialHDPathTuple8
+  | PartialHDPathTuple9
+  | PartialHDPathTuple10
+  | PartialHDPathTuple11;
 
 export type HDPathTuple = RootedHDPathTuple | PartialHDPathTuple;
 

--- a/src/derivation.test.ts
+++ b/src/derivation.test.ts
@@ -18,7 +18,9 @@ function bip32PathToMultipath(path: string[]): PartialHDPathTuple {
   if (pathParts[0].toLowerCase() === 'm') {
     pathParts = pathParts.slice(1);
   }
-  return pathParts.map((part) => `bip32:${part}`) as PartialHDPathTuple;
+  return pathParts.map(
+    (part) => `bip32:${part}`,
+  ) as unknown as PartialHDPathTuple;
 }
 
 const mnemonic =
@@ -131,19 +133,19 @@ describe('derivation', () => {
     expect(() => {
       deriveKeyFromPath([bip39Part], parentKey);
     }).toThrow(
-      /Invalid derivation parameters: May not specify parent entropy if the path segment starts with a BIP-39 node\./u,
+      /Invalid derivation parameters: May not specify parent key if the path segment starts with a BIP-39 node\./u,
     );
 
     // Multipaths that start with bip32 segment require parentKey
     expect(() => {
-      deriveKeyFromPath(['bip32:1']);
+      deriveKeyFromPath([`bip32:1'`]);
     }).toThrow(
-      /Invalid derivation parameters: Must specify parent entropy if the first node of the path segment is not a BIP-39 node\./u,
+      /Invalid derivation parameters: Must specify parent key if the first node of the path segment is not a BIP-39 node\./u,
     );
 
     // parentKey must be a buffer if specified
     expect(() => {
-      deriveKeyFromPath(['bip32:1'], parentKey.toString('base64') as any);
+      deriveKeyFromPath([`bip32:1'`], parentKey.toString('base64') as any);
     }).toThrow('Parent key must be a Buffer if specified.');
   });
 

--- a/src/derivation.test.ts
+++ b/src/derivation.test.ts
@@ -1,155 +1,150 @@
 import fixtures from '../test/fixtures';
-import { FullHDPathTuple, HDPathTuple, PartialHDPathTuple } from './constants';
+import { HDPathTuple } from './constants';
 import { deriveKeyFromPath } from './derivation';
 import { derivers } from './derivers';
+import { getUnhardenedBIP32Node } from './utils';
 
 const {
   bip32: { deriveChildKey: bip32Derive, privateKeyToEthAddress },
   bip39: { deriveChildKey: bip39Derive, bip39MnemonicToMultipath },
 } = derivers;
 
-/**
- * @param bip32Path
- */
-function bip32PathToMultipath(path: string[]): PartialHDPathTuple {
-  let pathParts = [...path];
-  // strip "m" noop
-  if (pathParts[0].toLowerCase() === 'm') {
-    pathParts = pathParts.slice(1);
-  }
-  return pathParts.map(
-    (part) => `bip32:${part}`,
-  ) as unknown as PartialHDPathTuple;
-}
-
 const { addresses: expectedAddresses, mnemonic } = fixtures.local;
-const defaultEthereumPath = ['m', `44'`, `60'`, `0'`, `0`];
+const ethereumBip32PathParts = [
+  `bip32:44'`,
+  `bip32:60'`,
+  `bip32:0'`,
+  `bip32:0`,
+] as const;
 
 describe('derivation', () => {
-  it('deriveKeyFromPath - full path', () => {
-    // generate keys
-    const keys = expectedAddresses.map((_, index) => {
-      const bip32Part = bip32PathToMultipath([
-        ...defaultEthereumPath,
-        String(index),
-      ]);
+  describe('deriveKeyFromPath', () => {
+    it('derives full BIP-44 paths', () => {
+      // generate keys
+      const keys = expectedAddresses.map((_, index) => {
+        const bip32Part = [
+          ...ethereumBip32PathParts,
+          getUnhardenedBIP32Node(index),
+        ] as const;
+        const bip39Part = bip39MnemonicToMultipath(mnemonic);
+        const multipath = [bip39Part, ...bip32Part] as HDPathTuple;
+        expect(multipath).toStrictEqual([
+          `bip39:${mnemonic}`,
+          `bip32:44'`,
+          `bip32:60'`,
+          `bip32:0'`,
+          `bip32:0`,
+          `bip32:${index}`,
+        ]);
+        return deriveKeyFromPath(multipath);
+      });
+
+      // validate addresses
+      keys.forEach((key, index) => {
+        const address = privateKeyToEthAddress(key);
+        expect(address.toString('hex')).toStrictEqual(expectedAddresses[index]);
+      });
+    });
+
+    it('derives the correct keys using a previously derived parent key', () => {
+      // generate parent key
       const bip39Part = bip39MnemonicToMultipath(mnemonic);
-      const multipath = [bip39Part, ...bip32Part] as HDPathTuple;
-      expect(multipath).toStrictEqual([
-        `bip39:${mnemonic}`,
-        `bip32:44'`,
-        `bip32:60'`,
-        `bip32:0'`,
-        `bip32:0`,
-        `bip32:${index}`,
-      ]);
-      return deriveKeyFromPath(multipath);
+      const multipath = [bip39Part, ...ethereumBip32PathParts] as HDPathTuple;
+      const parentKey = deriveKeyFromPath(multipath);
+      const keys = expectedAddresses.map((_, index) => {
+        return deriveKeyFromPath([`bip32:${index}`], parentKey);
+      });
+
+      // validate addresses
+      keys.forEach((key, index) => {
+        const address = privateKeyToEthAddress(key);
+        expect(address.toString('hex')).toStrictEqual(expectedAddresses[index]);
+      });
     });
 
-    // validate addresses
-    keys.forEach((key, index) => {
-      const address = privateKeyToEthAddress(key);
-      expect(address.toString('hex')).toStrictEqual(expectedAddresses[index]);
+    it('validates inputs', () => {
+      // generate parent key
+      const bip39Part = bip39MnemonicToMultipath(mnemonic);
+      const multipath = [bip39Part, ...ethereumBip32PathParts] as const;
+      const parentKey = deriveKeyFromPath(multipath);
+
+      // Malformed multipaths are disallowed
+      expect(() => {
+        const [, ...rest] = multipath;
+        deriveKeyFromPath([bip39Part.replace('bip39', 'foo') as any, ...rest]);
+      }).toThrow(/Invalid HD path segment: The path segment is malformed\./u);
+
+      expect(() => {
+        const [, bip32Part1, ...rest] = multipath;
+        deriveKeyFromPath([
+          bip39Part,
+          bip32Part1.replace('bip32', 'bar') as any,
+          ...rest,
+        ]);
+      }).toThrow(/Invalid HD path segment: The path segment is malformed\./u);
+
+      expect(() => {
+        const [, bip32Part1, ...rest] = multipath;
+        deriveKeyFromPath([
+          bip39Part,
+          bip32Part1.replace(`44'`, 'xyz') as any,
+          ...rest,
+        ]);
+      }).toThrow(/Invalid HD path segment: The path segment is malformed\./u);
+
+      expect(() => {
+        const [, bip32Part1, ...rest] = multipath;
+        deriveKeyFromPath([
+          bip39Part,
+          bip32Part1.replace(`'`, '"') as any,
+          ...rest,
+        ]);
+      }).toThrow(/Invalid HD path segment: The path segment is malformed\./u);
+
+      // bip39 seed phrase component must be completely lowercase
+      expect(() => {
+        deriveKeyFromPath([bip39Part.replace('r', 'R') as any]);
+      }).toThrow(/Invalid HD path segment: The path segment is malformed\./u);
+
+      // Multipaths that start with bip39 segment require _no_ parentKey
+      expect(() => {
+        deriveKeyFromPath([bip39Part], parentKey);
+      }).toThrow(
+        /Invalid derivation parameters: May not specify parent key if the path segment starts with a BIP-39 node\./u,
+      );
+
+      // Multipaths that start with bip32 segment require parentKey
+      expect(() => {
+        deriveKeyFromPath([`bip32:1'`]);
+      }).toThrow(
+        /Invalid derivation parameters: Must specify parent key if the first node of the path segment is not a BIP-39 node\./u,
+      );
+
+      // parentKey must be a buffer if specified
+      expect(() => {
+        deriveKeyFromPath([`bip32:1'`], parentKey.toString('base64') as any);
+      }).toThrow('Parent key must be a Buffer if specified.');
     });
   });
 
-  it('deriveKeyFromPath - parent key reuse', () => {
-    // generate parent key
-    const bip32Part = bip32PathToMultipath(defaultEthereumPath);
-    const bip39Part = bip39MnemonicToMultipath(mnemonic);
-    const multipath = [bip39Part, ...bip32Part] as HDPathTuple;
-    const parentKey = deriveKeyFromPath(multipath);
-    const keys = expectedAddresses.map((_, index) => {
-      return deriveKeyFromPath([`bip32:${index}`], parentKey);
-    });
+  describe('bip32Derive', () => {
+    it('derives the expected keys and addresses', () => {
+      // generate parent key
+      let parentKey: Buffer;
+      parentKey = bip39Derive(mnemonic);
+      parentKey = bip32Derive(`44'`, parentKey);
+      parentKey = bip32Derive(`60'`, parentKey);
+      parentKey = bip32Derive(`0'`, parentKey);
+      parentKey = bip32Derive(`0`, parentKey);
+      const keys = expectedAddresses.map((_, index) => {
+        return bip32Derive(`${index}`, parentKey);
+      });
 
-    // validate addresses
-    keys.forEach((key, index) => {
-      const address = privateKeyToEthAddress(key);
-      expect(address.toString('hex')).toStrictEqual(expectedAddresses[index]);
-    });
-  });
-
-  it('deriveKeyFromPath - input validation', () => {
-    // generate parent key
-    const bip32Part = bip32PathToMultipath(defaultEthereumPath);
-    const bip39Part = bip39MnemonicToMultipath(mnemonic);
-    const multipath = [bip39Part, ...bip32Part] as FullHDPathTuple;
-    const parentKey = deriveKeyFromPath(multipath);
-
-    // Malformed multipaths are disallowed
-    expect(() => {
-      const [, ...rest] = multipath;
-      deriveKeyFromPath([bip39Part.replace('bip39', 'foo') as any, ...rest]);
-    }).toThrow(/Invalid HD path segment: The path segment is malformed\./u);
-
-    expect(() => {
-      const [, bip32Part1, ...rest] = multipath;
-      deriveKeyFromPath([
-        bip39Part,
-        bip32Part1.replace('bip32', 'bar') as any,
-        ...rest,
-      ]);
-    }).toThrow(/Invalid HD path segment: The path segment is malformed\./u);
-
-    expect(() => {
-      const [, bip32Part1, ...rest] = multipath;
-      deriveKeyFromPath([
-        bip39Part,
-        bip32Part1.replace(`44'`, 'xyz') as any,
-        ...rest,
-      ]);
-    }).toThrow(/Invalid HD path segment: The path segment is malformed\./u);
-
-    expect(() => {
-      const [, bip32Part1, ...rest] = multipath;
-      deriveKeyFromPath([
-        bip39Part,
-        bip32Part1.replace(`'`, '"') as any,
-        ...rest,
-      ]);
-    }).toThrow(/Invalid HD path segment: The path segment is malformed\./u);
-
-    // bip39 seed phrase component must be completely lowercase
-    expect(() => {
-      deriveKeyFromPath([bip39Part.replace('r', 'R') as any]);
-    }).toThrow(/Invalid HD path segment: The path segment is malformed\./u);
-
-    // Multipaths that start with bip39 segment require _no_ parentKey
-    expect(() => {
-      deriveKeyFromPath([bip39Part], parentKey);
-    }).toThrow(
-      /Invalid derivation parameters: May not specify parent key if the path segment starts with a BIP-39 node\./u,
-    );
-
-    // Multipaths that start with bip32 segment require parentKey
-    expect(() => {
-      deriveKeyFromPath([`bip32:1'`]);
-    }).toThrow(
-      /Invalid derivation parameters: Must specify parent key if the first node of the path segment is not a BIP-39 node\./u,
-    );
-
-    // parentKey must be a buffer if specified
-    expect(() => {
-      deriveKeyFromPath([`bip32:1'`], parentKey.toString('base64') as any);
-    }).toThrow('Parent key must be a Buffer if specified.');
-  });
-
-  it('bip32Derive', () => {
-    // generate parent key
-    let parentKey: Buffer;
-    parentKey = bip39Derive(mnemonic);
-    parentKey = bip32Derive(`44'`, parentKey);
-    parentKey = bip32Derive(`60'`, parentKey);
-    parentKey = bip32Derive(`0'`, parentKey);
-    parentKey = bip32Derive(`0`, parentKey);
-    const keys = expectedAddresses.map((_, index) => {
-      return bip32Derive(`${index}`, parentKey);
-    });
-    // validate addresses
-    keys.forEach((key, index) => {
-      const address = privateKeyToEthAddress(key);
-      expect(address.toString('hex')).toStrictEqual(expectedAddresses[index]);
+      // validate addresses
+      keys.forEach((key, index) => {
+        const address = privateKeyToEthAddress(key);
+        expect(address.toString('hex')).toStrictEqual(expectedAddresses[index]);
+      });
     });
   });
 });

--- a/src/derivation.test.ts
+++ b/src/derivation.test.ts
@@ -1,14 +1,7 @@
+import fixtures from '../test/fixtures';
 import { FullHDPathTuple, HDPathTuple, PartialHDPathTuple } from './constants';
 import { deriveKeyFromPath } from './derivation';
 import { derivers } from './derivers';
-
-// TODO: Import for further derivation tests
-// import crypto from 'crypto';
-// import { hdkey } from 'ethereumjs-wallet';
-// import { BIP44Node } from './BIP44Node';
-// import { getBIP44AddressKeyDeriver } from './BIP44CoinTypeNode';
-// import { privateKeyToEthAddress } from './derivers/bip32';
-// import { base64StringToBuffer } from './utils';
 
 const {
   bip32: { deriveChildKey: bip32Derive, privateKeyToEthAddress },
@@ -31,21 +24,8 @@ function bip32PathToMultipath(path: string[]): PartialHDPathTuple {
   ) as unknown as PartialHDPathTuple;
 }
 
-const mnemonic =
-  'romance hurry grit huge rifle ordinary loud toss sound congress upset twist';
-
-const expectedAddresses = [
-  '5df603999c3d5ca2ab828339a9883585b1bce11b',
-  '441c07e32a609afd319ffbb66432b424058bcfe9',
-  '1f7c93dfe849c06dd610e77473bfaaef7f183c7c',
-  '9e28bae18e0e358b12796697c6546f77d4657527',
-  '6e7734c7f4fb973a3800b72fb1a6bf82d85d3d29',
-  'f87328a8ea5208946c60dbd9385d4c8533ad5dd8',
-  'bdc59c95b5afd6cb0318a24fd390f143fec85d51',
-  '05751e88f2d9f0fccffc8d9c5188adaa378d60e4',
-  'c4311bfd3fea0238a3f5ced088bd366b33f1e292',
-  '7b99c781cbfff075229314ccbdc7f6d9e8440ad9',
-];
+const { mnemonic } = fixtures.local;
+const expectedAddresses = fixtures.local.addresses;
 
 describe('derivation', () => {
   it('deriveKeyFromPath - full path', () => {

--- a/src/derivation.test.ts
+++ b/src/derivation.test.ts
@@ -2,6 +2,14 @@ import { FullHDPathTuple, HDPathTuple, PartialHDPathTuple } from './constants';
 import { deriveKeyFromPath } from './derivation';
 import { derivers } from './derivers';
 
+// TODO: Import for further derivation tests
+// import crypto from 'crypto';
+// import { hdkey } from 'ethereumjs-wallet';
+// import { BIP44Node } from './BIP44Node';
+// import { getBIP44AddressKeyDeriver } from './BIP44CoinTypeNode';
+// import { privateKeyToEthAddress } from './derivers/bip32';
+// import { base64StringToBuffer } from './utils';
+
 const {
   bip32: { deriveChildKey: bip32Derive, privateKeyToEthAddress },
   bip39: { deriveChildKey: bip39Derive, bip39MnemonicToMultipath },

--- a/src/derivation.test.ts
+++ b/src/derivation.test.ts
@@ -28,6 +28,7 @@ describe('derivation', () => {
         ] as const;
         const bip39Part = bip39MnemonicToMultipath(mnemonic);
         const multipath = [bip39Part, ...bip32Part] as HDPathTuple;
+
         expect(multipath).toStrictEqual([
           `bip39:${mnemonic}`,
           `bip32:44'`,
@@ -192,6 +193,24 @@ describe('derivation', () => {
       expect(() => bip32Derive(`44'`, Buffer.allocUnsafe(63).fill(1))).toThrow(
         'Invalid parent key: Must be 64 bytes long.',
       );
+    });
+  });
+
+  // The outputs of this function are tested in key derivation above
+  describe('privateKeyToEthAddress', () => {
+    it('throws for invalid inputs', () => {
+      [
+        Buffer.allocUnsafe(63).fill(1),
+        Buffer.alloc(64, 0),
+        'foo',
+        {},
+        null,
+        undefined,
+      ].forEach((invalidInput) => {
+        expect(() => privateKeyToEthAddress(invalidInput as any)).toThrow(
+          'Invalid key: The key must be a 64-byte, non-zero Buffer.',
+        );
+      });
     });
   });
 });

--- a/src/derivation.test.ts
+++ b/src/derivation.test.ts
@@ -1,5 +1,5 @@
 import { derivers } from './derivers';
-import { deriveKeyFromPath } from '.';
+import { deriveKeyFromPath } from './derivation';
 
 const {
   bip32: {

--- a/src/derivation.test.ts
+++ b/src/derivation.test.ts
@@ -8,8 +8,6 @@ const {
   bip39: { deriveChildKey: bip39Derive, bip39MnemonicToMultipath },
 } = derivers;
 
-const defaultEthereumPath = ['m', `44'`, `60'`, `0'`, `0`];
-
 /**
  * @param bip32Path
  */
@@ -24,8 +22,8 @@ function bip32PathToMultipath(path: string[]): PartialHDPathTuple {
   ) as unknown as PartialHDPathTuple;
 }
 
-const { mnemonic } = fixtures.local;
-const expectedAddresses = fixtures.local.addresses;
+const { addresses: expectedAddresses, mnemonic } = fixtures.local;
+const defaultEthereumPath = ['m', `44'`, `60'`, `0'`, `0`];
 
 describe('derivation', () => {
   it('deriveKeyFromPath - full path', () => {
@@ -140,9 +138,7 @@ describe('derivation', () => {
   it('bip32Derive', () => {
     // generate parent key
     let parentKey: Buffer;
-    parentKey = bip39Derive(
-      `romance hurry grit huge rifle ordinary loud toss sound congress upset twist`,
-    );
+    parentKey = bip39Derive(mnemonic);
     parentKey = bip32Derive(`44'`, parentKey);
     parentKey = bip32Derive(`60'`, parentKey);
     parentKey = bip32Derive(`0'`, parentKey);

--- a/src/derivation.test.ts
+++ b/src/derivation.test.ts
@@ -2,7 +2,7 @@ import fixtures from '../test/fixtures';
 import { HDPathTuple } from './constants';
 import { deriveKeyFromPath } from './derivation';
 import { derivers } from './derivers';
-import { getUnhardenedBIP32Node } from './utils';
+import { getUnhardenedBIP32NodeToken } from './utils';
 
 const {
   bip32: { deriveChildKey: bip32Derive, privateKeyToEthAddress },
@@ -24,7 +24,7 @@ describe('derivation', () => {
       const keys = expectedAddresses.map((_, index) => {
         const bip32Part = [
           ...ethereumBip32PathParts,
-          getUnhardenedBIP32Node(index),
+          getUnhardenedBIP32NodeToken(index),
         ] as const;
         const bip39Part = bip39MnemonicToMultipath(mnemonic);
         const multipath = [bip39Part, ...bip32Part] as HDPathTuple;

--- a/src/derivation.ts
+++ b/src/derivation.ts
@@ -3,6 +3,8 @@ import {
   BIP44Depth,
   MAX_BIP_44_DEPTH,
   MIN_BIP_44_DEPTH,
+  BIP_39_PATH_REGEX,
+  BIP_32_PATH_REGEX,
 } from './constants';
 import { derivers, Deriver } from './derivers';
 
@@ -71,20 +73,6 @@ export function deriveKeyFromPath(
 function hasDeriver(pathType: string): pathType is keyof typeof derivers {
   return pathType in derivers;
 }
-
-/**
- * e.g.
- * -  bip32:0
- * -  bip32:0'
- */
-const BIP_32_PATH_REGEX = /^bip32:\d+'?$/u;
-
-/**
- * bip39:<SPACE_DELMITED_SEED_PHRASE>
- *
- * The seed phrase must consist of 12 <= 24 words.
- */
-const BIP_39_PATH_REGEX = /^bip39:([a-z]+){1}( [a-z]+){11,23}$/u;
 
 /**
  * The path segment must be one of the following:

--- a/src/derivation.ts
+++ b/src/derivation.ts
@@ -115,7 +115,7 @@ const BIP_39_PATH_REGEX = /^bip39:([a-z]+){1}( [a-z]+){11,23}$/u;
  */
 export function validatePathSegment(
   pathSegment: HDPathTuple,
-  hasEntropy: boolean,
+  hasKey: boolean,
   depth?: HDTreeDepth,
 ) {
   if ((pathSegment as any).length === 0) {
@@ -149,15 +149,15 @@ export function validatePathSegment(
     );
   }
 
-  if (!hasEntropy && !startsWithBip39) {
+  if (!hasKey && !startsWithBip39) {
     throw new Error(
-      'Invalid derivation parameters: Must specify parent entropy if the first node of the path segment is not a BIP-39 node.',
+      'Invalid derivation parameters: Must specify parent key if the first node of the path segment is not a BIP-39 node.',
     );
   }
 
-  if (hasEntropy && startsWithBip39) {
+  if (hasKey && startsWithBip39) {
     throw new Error(
-      'Invalid derivation parameters: May not specify parent entropy if the path segment starts with a BIP-39 node.',
+      'Invalid derivation parameters: May not specify parent key if the path segment starts with a BIP-39 node.',
     );
   }
 }

--- a/src/derivation.ts
+++ b/src/derivation.ts
@@ -1,4 +1,3 @@
-import bip39 from 'bip39';
 import {
   HDPathTuple,
   BIP44Depth,
@@ -6,17 +5,6 @@ import {
   MIN_BIP_44_DEPTH,
 } from './constants';
 import { derivers, Deriver } from './derivers';
-import { bufferToBase64String } from './utils';
-
-/**
- * Converts the given BIP-39 mnemonic to a cryptographic seed.
- *
- * @param mnemonic - The BIP-39 mnemonic.
- * @returns The cryptographic seed corresponding to the given mnemonic.
- */
-export function mnemonicToSeed(mnemonic: string): Buffer {
-  return bip39.mnemonicToSeed(mnemonic);
-}
 
 /**
  * ethereum default seed path: "m/44'/60'/0'/0/{account_index}"
@@ -29,14 +17,6 @@ export function mnemonicToSeed(mnemonic: string): Buffer {
  * 0: { privateKey, chainCode } = parentKey.privateKey + sha512Hmac(parentKey.chainCode, [parentKey.publicKey, index])
  * 0: { privateKey, chainCode } = parentKey.privateKey + sha512Hmac(parentKey.chainCode, [parentKey.publicKey, index])
  */
-
-export function deriveStringKeyFromPath(
-  pathSegment: HDPathTuple,
-  parentKey?: Buffer,
-  depth?: BIP44Depth,
-): string {
-  return bufferToBase64String(deriveKeyFromPath(pathSegment, parentKey, depth));
-}
 
 /**
  * Takes a full or partial HD path string and returns the key corresponding to
@@ -72,6 +52,7 @@ export function deriveKeyFromPath(
   // derive through each part of path
   pathSegment.forEach((node) => {
     const [pathType, pathValue] = node.split(':');
+    /* istanbul ignore if: should be impossible */
     if (!hasDeriver(pathType)) {
       throw new Error(`Unknown derivation type: "${pathType}"`);
     }

--- a/src/derivation.ts
+++ b/src/derivation.ts
@@ -1,9 +1,9 @@
 import bip39 from 'bip39';
 import {
   HDPathTuple,
-  HDTreeDepth,
-  MAX_HD_TREE_DEPTH,
-  MIN_HD_TREE_DEPTH,
+  BIP44Depth,
+  MAX_BIP_44_DEPTH,
+  MIN_BIP_44_DEPTH,
 } from './constants';
 import { derivers, Deriver } from './derivers';
 import { bufferToBase64String } from './utils';
@@ -33,7 +33,7 @@ export function mnemonicToSeed(mnemonic: string): Buffer {
 export function deriveStringKeyFromPath(
   pathSegment: HDPathTuple,
   parentKey?: Buffer,
-  depth?: HDTreeDepth,
+  depth?: BIP44Depth,
 ): string {
   return bufferToBase64String(deriveKeyFromPath(pathSegment, parentKey, depth));
 }
@@ -60,7 +60,7 @@ export function deriveStringKeyFromPath(
 export function deriveKeyFromPath(
   pathSegment: HDPathTuple,
   parentKey?: Buffer,
-  depth?: HDTreeDepth,
+  depth?: BIP44Depth,
 ): Buffer {
   if (parentKey && !Buffer.isBuffer(parentKey)) {
     throw new Error('Parent key must be a Buffer if specified.');
@@ -116,13 +116,13 @@ const BIP_39_PATH_REGEX = /^bip39:([a-z]+){1}( [a-z]+){11,23}$/u;
 export function validatePathSegment(
   pathSegment: HDPathTuple,
   hasKey: boolean,
-  depth?: HDTreeDepth,
+  depth?: BIP44Depth,
 ) {
   if ((pathSegment as any).length === 0) {
     throw new Error(`Invalid HD path segment: The segment must not be empty.`);
   }
 
-  if (pathSegment.length - 1 > MAX_HD_TREE_DEPTH) {
+  if (pathSegment.length - 1 > MAX_BIP_44_DEPTH) {
     throw new Error(
       `Invalid HD path segment: The segment cannot exceed a 0-indexed depth of 5.`,
     );
@@ -141,11 +141,11 @@ export function validatePathSegment(
   });
 
   if (
-    depth === MIN_HD_TREE_DEPTH &&
+    depth === MIN_BIP_44_DEPTH &&
     (!startsWithBip39 || pathSegment.length !== 1)
   ) {
     throw new Error(
-      `Invalid HD path segment: The segment must consist of a single BIP-39 node for depths of ${MIN_HD_TREE_DEPTH}. Received: "${pathSegment}"`,
+      `Invalid HD path segment: The segment must consist of a single BIP-39 node for depths of ${MIN_BIP_44_DEPTH}. Received: "${pathSegment}"`,
     );
   }
 

--- a/src/derivers/bip32.ts
+++ b/src/derivers/bip32.ts
@@ -2,16 +2,29 @@ import crypto from 'crypto';
 import secp256k1 from 'secp256k1';
 import createKeccakHash from 'keccak';
 import { BUFFER_KEY_LENGTH } from '../constants';
+import { isValidBufferKey } from '../utils';
 
 const HARDENED_OFFSET = 0x80000000;
 
 type KeccakBits = '224' | '256' | '384' | '512';
 
 /**
- * @param keyBuffer
+ * Converts a BIP-32 private key to an Ethereum address.
+ *
+ * **WARNING:** Only validates that the key is non-zero and of the correct
+ * length. It is the consumer's responsibility to ensure that the specified
+ * key is a valid BIP-44 Ethereum `address_index` key.
+ *
+ * @param key - The `address_index` key buffer to convert to an Ethereum
+ * address.
+ * @returns The Ethereum address corresponding to the given key.
  */
-export function privateKeyToEthAddress(keyBuffer: Buffer) {
-  const privateKey = keyBuffer.slice(0, 32);
+export function privateKeyToEthAddress(key: Buffer) {
+  if (!Buffer.isBuffer(key) || !isValidBufferKey(key)) {
+    throw new Error('Invalid key: The key must be a 64-byte, non-zero Buffer.');
+  }
+
+  const privateKey = key.slice(0, 32);
   const publicKey = secp256k1.publicKeyCreate(privateKey, false).slice(1);
   return keccak(publicKey as Buffer).slice(-20);
 }

--- a/src/derivers/bip32.ts
+++ b/src/derivers/bip32.ts
@@ -30,11 +30,11 @@ export function privateKeyToEthAddress(key: Buffer) {
 }
 
 /**
- * @param a
- * @param bits
+ * @param data
+ * @param keccakBits
  */
-function keccak(a: string | Buffer, bits: KeccakBits = '256'): Buffer {
-  return createKeccakHash(`keccak${bits}`).update(a).digest();
+function keccak(data: string | Buffer, keccakBits: KeccakBits = '256'): Buffer {
+  return createKeccakHash(`keccak${keccakBits}`).update(data).digest();
 }
 
 /**
@@ -90,10 +90,10 @@ interface DeriveSecretExtensionArgs {
 
 // the bip32 secret extension is created from the parent private or public key and the child index
 /**
- * @param options0
- * @param options0.parentPrivateKey
- * @param options0.childIndex
- * @param options0.isHardened
+ * @param options
+ * @param options.parentPrivateKey
+ * @param options.childIndex
+ * @param options.isHardened
  */
 function deriveSecretExtension({
   parentPrivateKey,
@@ -123,10 +123,10 @@ interface GenerateKeyArgs {
 }
 
 /**
- * @param options0
- * @param options0.parentPrivateKey
- * @param options0.parentExtraEntropy
- * @param options0.secretExtension
+ * @param options
+ * @param options.parentPrivateKey
+ * @param options.parentExtraEntropy
+ * @param options.secretExtension
  */
 function generateKey({
   parentPrivateKey,

--- a/src/derivers/bip32.ts
+++ b/src/derivers/bip32.ts
@@ -29,19 +29,27 @@ function keccak(a: string | Buffer, bits: KeccakBits = '256'): Buffer {
  * @param parentKey
  */
 export function deriveChildKey(pathPart: string, parentKey: Buffer): Buffer {
-  const isHardened = pathPart.includes(`'`);
-  const indexPart = pathPart.split(`'`)[0];
-  const childIndex = parseInt(indexPart, 10);
-  if (childIndex >= HARDENED_OFFSET) {
-    throw new Error('Invalid index');
-  }
-
   if (!parentKey) {
-    throw new Error('Must provide parentKey');
+    throw new Error('Invalid parameters: Must specify a parent key.');
   }
 
   if (parentKey.length !== BUFFER_KEY_LENGTH) {
-    throw new Error('Parent key invalid length');
+    throw new Error('Invalid parent key: Must be 64 bytes long.');
+  }
+
+  const isHardened = pathPart.includes(`'`);
+  const indexPart = pathPart.split(`'`)[0];
+  const childIndex = parseInt(indexPart, 10);
+
+  if (
+    !/^\d+$/u.test(indexPart) ||
+    !Number.isInteger(childIndex) ||
+    childIndex < 0 ||
+    childIndex >= HARDENED_OFFSET
+  ) {
+    throw new Error(
+      `Invalid BIP-32 index: The index must be a non-negative decimal integer less than ${HARDENED_OFFSET}.`,
+    );
   }
 
   const parentPrivateKey = parentKey.slice(0, 32);

--- a/src/derivers/bip32.ts
+++ b/src/derivers/bip32.ts
@@ -1,7 +1,7 @@
 import crypto from 'crypto';
 import secp256k1 from 'secp256k1';
 import createKeccakHash from 'keccak';
-import { KEY_BUFFER_LENGTH } from '../constants';
+import { BUFFER_KEY_LENGTH } from '../constants';
 
 const HARDENED_OFFSET = 0x80000000;
 
@@ -40,7 +40,7 @@ export function deriveChildKey(pathPart: string, parentKey: Buffer): Buffer {
     throw new Error('Must provide parentKey');
   }
 
-  if (parentKey.length !== KEY_BUFFER_LENGTH) {
+  if (parentKey.length !== BUFFER_KEY_LENGTH) {
     throw new Error('Parent key invalid length');
   }
 

--- a/src/derivers/bip32.ts
+++ b/src/derivers/bip32.ts
@@ -25,19 +25,6 @@ function keccak(a: string | Buffer, bits: KeccakBits = '256'): Buffer {
 }
 
 /**
- * @param bip32Path
- */
-export function bip32PathToMultipath(bip32Path: string): string {
-  let pathParts = bip32Path.trim().split('/');
-  // strip "m" noop
-  if (pathParts[0].toLowerCase() === 'm') {
-    pathParts = pathParts.slice(1);
-  }
-  const multipath = pathParts.map((part) => `bip32:${part}`).join('/');
-  return multipath;
-}
-
-/**
  * @param pathPart
  * @param parentKey
  */

--- a/src/derivers/bip32.ts
+++ b/src/derivers/bip32.ts
@@ -1,9 +1,7 @@
-// node
 import crypto from 'crypto';
-import assert from 'assert';
-// npm
 import secp256k1 from 'secp256k1';
 import createKeccakHash from 'keccak';
+import { KEY_BUFFER_LENGTH } from '../constants';
 
 const HARDENED_OFFSET = 0x80000000;
 
@@ -23,9 +21,7 @@ export function privateKeyToEthAddress(keyBuffer: Buffer) {
  * @param bits
  */
 function keccak(a: string | Buffer, bits: KeccakBits = '256'): Buffer {
-  return createKeccakHash(`keccak${bits}` as any)
-    .update(a)
-    .digest();
+  return createKeccakHash(`keccak${bits}`).update(a).digest();
 }
 
 /**
@@ -49,9 +45,17 @@ export function deriveChildKey(pathPart: string, parentKey: Buffer): Buffer {
   const isHardened = pathPart.includes(`'`);
   const indexPart = pathPart.split(`'`)[0];
   const childIndex = parseInt(indexPart, 10);
-  assert(childIndex < HARDENED_OFFSET, 'Invalid index');
-  assert(Boolean(parentKey), 'Must provide parentKey');
-  assert(parentKey.length === 64, 'Parent key invalid length');
+  if (childIndex >= HARDENED_OFFSET) {
+    throw new Error('Invalid index');
+  }
+
+  if (!parentKey) {
+    throw new Error('Must provide parentKey');
+  }
+
+  if (parentKey.length !== KEY_BUFFER_LENGTH) {
+    throw new Error('Parent key invalid length');
+  }
 
   const parentPrivateKey = parentKey.slice(0, 32);
   const parentExtraEntropy = parentKey.slice(32);

--- a/src/derivers/bip39.ts
+++ b/src/derivers/bip39.ts
@@ -19,11 +19,13 @@ export function bip39MnemonicToMultipath(mnemonic: string): BIP39Node {
  * @param _parentKey
  */
 export function deriveChildKey(pathPart: string, _parentKey?: never): Buffer {
-  const mnemonic = pathPart;
-  const seedBuffer = bip39.mnemonicToSeed(mnemonic);
-  return createKeyFromSeed(seedBuffer);
+  return createBip39KeyFromSeed(bip39.mnemonicToSeed(pathPart));
 }
 
-export function createKeyFromSeed(seed: Buffer): Buffer {
+/**
+ * @param seed - The cryptographic seed bytes.
+ * @returns The bytes of the corresponding BIP-39 master key.
+ */
+export function createBip39KeyFromSeed(seed: Buffer): Buffer {
   return crypto.createHmac('sha512', ROOT_BASE_SECRET).update(seed).digest();
 }

--- a/src/derivers/bip39.ts
+++ b/src/derivers/bip39.ts
@@ -1,5 +1,6 @@
 import crypto from 'crypto';
 import bip39 from 'bip39';
+import { BIP39Node } from '../constants';
 
 // This magic constant is analogous to a salt, and is consistent across all
 // major BIP-32 implementations.
@@ -8,7 +9,7 @@ const ROOT_BASE_SECRET = Buffer.from('Bitcoin seed', 'utf8');
 /**
  * @param mnemonic
  */
-export function bip39MnemonicToMultipath(mnemonic: string): string {
+export function bip39MnemonicToMultipath(mnemonic: string): BIP39Node {
   return `bip39:${mnemonic.toLowerCase().trim()}`;
 }
 

--- a/src/derivers/bip39.ts
+++ b/src/derivers/bip39.ts
@@ -21,10 +21,9 @@ export function bip39MnemonicToMultipath(mnemonic: string): BIP39Node {
 export function deriveChildKey(pathPart: string, _parentKey?: never): Buffer {
   const mnemonic = pathPart;
   const seedBuffer = bip39.mnemonicToSeed(mnemonic);
-  const key = crypto
-    .createHmac('sha512', ROOT_BASE_SECRET)
-    .update(seedBuffer)
-    .digest();
+  return createKeyFromSeed(seedBuffer);
+}
 
-  return key;
+export function createKeyFromSeed(seed: Buffer): Buffer {
+  return crypto.createHmac('sha512', ROOT_BASE_SECRET).update(seed).digest();
 }

--- a/src/derivers/bip39.ts
+++ b/src/derivers/bip39.ts
@@ -21,10 +21,10 @@ export function bip39MnemonicToMultipath(mnemonic: string): BIP39Node {
 export function deriveChildKey(pathPart: string, _parentKey?: never): Buffer {
   const mnemonic = pathPart;
   const seedBuffer = bip39.mnemonicToSeed(mnemonic);
-  const entropy = crypto
+  const key = crypto
     .createHmac('sha512', ROOT_BASE_SECRET)
     .update(seedBuffer)
     .digest();
 
-  return entropy;
+  return key;
 }

--- a/src/derivers/bip39.ts
+++ b/src/derivers/bip39.ts
@@ -1,6 +1,8 @@
 import crypto from 'crypto';
 import bip39 from 'bip39';
 
+// This magic constant is analogous to a salt, and is consistent across all
+// major BIP-32 implementations.
 const ROOT_BASE_SECRET = Buffer.from('Bitcoin seed', 'utf8');
 
 /**

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,11 @@
+import * as mod from '.';
+
+// This is purely for coverage shenanigans
+describe('index', () => {
+  it('has expected exports', () => {
+    const { MAX_BIP_44_DEPTH, PackageBuffer } = mod;
+
+    expect(MAX_BIP_44_DEPTH).toStrictEqual(5);
+    expect(PackageBuffer).toStrictEqual(Buffer);
+  });
+});

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3,9 +3,10 @@ import * as mod from '.';
 // This is purely for coverage shenanigans
 describe('index', () => {
   it('has expected exports', () => {
-    const { MAX_BIP_44_DEPTH, PackageBuffer } = mod;
+    const { MAX_BIP_44_DEPTH, MIN_BIP_44_DEPTH, PackageBuffer } = mod;
 
     expect(MAX_BIP_44_DEPTH).toStrictEqual(5);
+    expect(MIN_BIP_44_DEPTH).toStrictEqual(0);
     expect(PackageBuffer).toStrictEqual(Buffer);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,17 @@ export { BIP44Node, BIP44NodeInterface, JsonBIP44Node } from './BIP44Node';
 export {
   BIP44CoinTypeNode,
   BIP44CoinTypeNodeInterface,
-  COIN_TYPE_DEPTH,
+  BIP_44_COIN_TYPE_DEPTH,
   CoinTypeHDPathTuple,
   deriveBIP44AddressKey,
   getBIP44AddressKeyDeriver,
   JsonBIP44CoinTypeNode,
 } from './BIP44CoinTypeNode';
+export {
+  MIN_BIP_44_DEPTH,
+  MAX_BIP_44_DEPTH,
+  BIP44Depth,
+  BIP44PurposeNode,
+  BIP32Node,
+  BIP39Node,
+} from './constants';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,10 @@
-export * from './BIP44Node';
+export { BIP44Node, BIP44NodeInterface, JsonBIP44Node } from './BIP44Node';
+export {
+  BIP44CoinTypeNode,
+  BIP44CoinTypeNodeInterface,
+  COIN_TYPE_DEPTH,
+  CoinTypeHDPathTuple,
+  deriveBIP44AddressKey,
+  getBIP44AddressKeyDeriver,
+  JsonBIP44CoinTypeNode,
+} from './BIP44CoinTypeNode';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export * from './HDTreeNode';
+export * from './BIP44Node';

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,3 +16,9 @@ export {
   BIP32Node,
   BIP39Node,
 } from './constants';
+
+/**
+ * The {@link Buffer} accessible to `@metamask/key-tree`, re-exported in case
+ * of module resolution issues.
+ */
+export const PackageBuffer = Buffer;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ export {
   MIN_BIP_44_DEPTH,
   MAX_BIP_44_DEPTH,
   BIP44Depth,
-  BIP44PurposeNode,
+  BIP44PurposeNodeToken,
   BIP32Node,
   BIP39Node,
 } from './constants';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export * from './derivation';
+export * from './HDTreeNode';

--- a/src/indext.test.ts
+++ b/src/indext.test.ts
@@ -1,8 +1,0 @@
-import * as mod from '.';
-
-// This is purely for coverage shenanigans
-describe('index', () => {
-  it('has expected exports', () => {
-    expect(mod.MAX_BIP_44_DEPTH).toStrictEqual(5);
-  });
-});

--- a/src/indext.test.ts
+++ b/src/indext.test.ts
@@ -1,0 +1,8 @@
+import * as mod from '.';
+
+// This is purely for coverage shenanigans
+describe('index', () => {
+  it('has expected exports', () => {
+    expect(mod.MAX_BIP_44_DEPTH).toStrictEqual(5);
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,6 +10,7 @@ import {
   CoinTypeToAddressTuple,
   HardenedBIP32Node,
   ChangeHDPathString,
+  HEXADECIMAL_KEY_LENGTH,
 } from './constants';
 
 export function getBIP44CoinTypePathString(
@@ -125,7 +126,7 @@ export function isValidHexStringKey(stringKey: string): boolean {
   }
 
   const stripped = stripHexPrefix(stringKey);
-  if (stripped.length !== KEY_BUFFER_LENGTH) {
+  if (stripped.length !== HEXADECIMAL_KEY_LENGTH) {
     return false;
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ import {
   BASE_64_KEY_LENGTH,
   BASE_64_REGEX,
   BASE_64_ZERO,
-  KEY_BUFFER_LENGTH,
+  BUFFER_KEY_LENGTH,
   BIP44PurposeNode,
   UnhardenedBIP32Node,
   CoinTypeHDPathString,
@@ -104,7 +104,7 @@ export function bufferToBase64String(input: Buffer) {
 }
 
 export function isValidBufferKey(buffer: Buffer): boolean {
-  if (buffer.length !== KEY_BUFFER_LENGTH) {
+  if (buffer.length !== BUFFER_KEY_LENGTH) {
     return false;
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@ import {
   BASE_64_REGEX,
   BASE_64_ZERO,
   BUFFER_KEY_LENGTH,
-  BIP44PurposeNode,
+  BIP44PurposeNodeToken,
   UnhardenedBIP32Node,
   CoinTypeHDPathString,
   CoinTypeToAddressTuple,
@@ -12,10 +12,21 @@ import {
   HEXADECIMAL_KEY_LENGTH,
 } from './constants';
 
+/**
+ * Gets a string representation of a BIP-44 path of depth 2, i.e.:
+ * `m / 44' / coin_type'`
+ *
+ * For display purposes only.
+ *
+ * @param coin_type - The `coin_type` index to create a path visualization for.
+ * @returns The visualization of the BIP-44 path for thte specified `coin_type`.
+ */
 export function getBIP44CoinTypePathString(
   coin_type: number,
 ): CoinTypeHDPathString {
-  return `m / ${BIP44PurposeNode} / ${getUnhardenedBIP32Node(coin_type)}'`;
+  return `m / ${BIP44PurposeNodeToken} / ${getUnhardenedBIP32NodeToken(
+    coin_type,
+  )}'`;
 }
 
 interface BIP44PathIndices {
@@ -30,70 +41,156 @@ export type CoinTypeToAddressIndices = Pick<
   'account' | 'change' | 'address_index'
 >;
 
+/**
+ * Gets a string representation of a BIP-44 path of depth 4, i.e.:
+ * `m / 44' / coin_type' / account' / change`
+ *
+ * For display purposes only.
+ *
+ * @param coinTypePath - The parent `coin_type` path.
+ * @param coin_type - The `change` index to create a path visualization for.
+ * @returns The visualization of the BIP-44 path for the specified `coin_type`
+ * and `change` indices.
+ */
 export function getBIP44ChangePathString(
   coinTypePath: CoinTypeHDPathString,
   indices: Omit<CoinTypeToAddressIndices, 'address_index'>,
 ): ChangeHDPathString {
-  return `${coinTypePath} / ${getHardenedBIP32Node(
+  return `${coinTypePath} / ${getHardenedBIP32NodeToken(
     indices.account || 0,
-  )} / ${getUnhardenedBIP32Node(indices.change || 0)}`;
+  )} / ${getUnhardenedBIP32NodeToken(indices.change || 0)}`;
 }
 
-export function getBIP44AddressPathTuple({
+/**
+ * Gets a BIP-44 path tuple of the form `account' / change / address_index`,
+ * which can be used to derive address keys together with a `coin_type` key.
+ *
+ * @param indices - The BIP-44 derivation index values.
+ * @param indices.account - The `account` index value.
+ * @param indices.change - The `change` index value.
+ * @param indices.address_index - The `address_index` index value.
+ * @returns The `account' / change / address_index` path corresponding to the
+ * specified indices.
+ */
+export function getBIP44CoinTypeToAddressPathTuple({
   account = 0,
   change = 0,
   address_index,
 }: CoinTypeToAddressIndices): CoinTypeToAddressTuple {
   return [
-    getHardenedBIP32Node(account),
-    getUnhardenedBIP32Node(change),
-    getUnhardenedBIP32Node(address_index),
+    getHardenedBIP32NodeToken(account),
+    getUnhardenedBIP32NodeToken(change),
+    getUnhardenedBIP32NodeToken(address_index),
   ] as const;
 }
 
-export function getHardenedBIP32Node(index: number): HardenedBIP32Node {
-  return `${getUnhardenedBIP32Node(index)}'`;
+/**
+ * A hardened BIP-32 node token, e.g. `bip32:0'`.
+ * Validates that the index is a non-negative integer number, and throws an
+ * error if validation fails.
+ *
+ * @param index - The index of the node.
+ * @returns The hardened BIP-32 node token.
+ */
+export function getHardenedBIP32NodeToken(index: number): HardenedBIP32Node {
+  validateBIP32Index(index);
+  return `${getUnhardenedBIP32NodeToken(index)}'`;
 }
 
-export function getUnhardenedBIP32Node(index: number): UnhardenedBIP32Node {
+/**
+ * An unhardened BIP-32 node token, e.g. `bip32:0`.
+ * Validates that the index is a non-negative integer number, and throws an
+ * error if validation fails.
+ *
+ * @param index - The index of the node.
+ * @returns The unhardened BIP-32 node token.
+ */
+export function getUnhardenedBIP32NodeToken(
+  index: number,
+): UnhardenedBIP32Node {
   validateBIP32Index(index);
   return `bip32:${index}`;
 }
 
+/**
+ * Validates that the index is a non-negative integer number. Throws an
+ * error if validation fails.
+ *
+ * @param addressIndex - The index to validate.
+ */
 export function validateBIP32Index(addressIndex: number) {
   if (!isValidBIP32Index(addressIndex)) {
     throw new Error(`Invalid BIP-32 index: Must be a non-negative integer.`);
   }
 }
 
+/**
+ * @param index - The BIP-32 index to test.
+ * @returns Whether the index is a non-negative integer number.
+ */
 export function isValidBIP32Index(index: number): boolean {
   return Number.isInteger(index) && index >= 0;
 }
 
+/**
+ * @param bip32Token - The token to test.
+ * @returns Whether the token is hardened, i.e. ends with `'`.
+ */
 export function isHardened(bip32Token: string): boolean {
   return bip32Token.endsWith(`'`);
 }
 
+/**
+ * @param hexString - The hexadecimal string to strip.
+ * @returns The hexadecimal string, without a `0x`-prefix, if any.
+ */
 export function stripHexPrefix(hexString: string): string {
   return hexString.replace(/^0x/iu, '');
 }
 
+/**
+ * Tests whether the specified string is a valid hexadecimal string. The string
+ * may or may not be `0x`-prefixed, and the test is case-insensitive.
+ *
+ * @param hexString - The string to test.
+ * @returns Whether the specified string is a valid hexadecimal string. The
+ * string may or may not be `0x`-prefixed.
+ */
 export function isValidHexString(hexString: string): boolean {
   return /^(?:0x)?[a-f0-9]+$/iu.test(hexString);
 }
 
-export function base64StringToBuffer(base64String: string) {
+/**
+ * @param base64String - The Base64 string to convert.
+ * @returns The {@link Buffer} corresponding to the Base64 string.
+ */
+export function base64StringToBuffer(base64String: string): Buffer {
   return Buffer.from(base64String, 'base64');
 }
 
-export function hexStringToBuffer(hexString: string) {
+/**
+ * @param hexString - The hexadecimal string to convert.
+ * @returns The {@link Buffer} corresponding to the hexadecimal string.
+ */
+export function hexStringToBuffer(hexString: string): Buffer {
   return Buffer.from(stripHexPrefix(hexString), 'hex');
 }
 
-export function bufferToBase64String(input: Buffer) {
+/**
+ * @param input - The {@link Buffer} to convert.
+ * @returns The buffer as a Base64 string.
+ */
+export function bufferToBase64String(input: Buffer): string {
   return input.toString('base64');
 }
 
+/**
+ * Tests whether the specified {@link Buffer} is a valid BIP-32 key.
+ * A valid buffer key is 64 bytes long and has at least one non-zero byte.
+ *
+ * @param buffer - The {@link Buffer} to test.
+ * @returns Whether the buffer represents a valid BIP-32 key.
+ */
 export function isValidBufferKey(buffer: Buffer): boolean {
   if (buffer.length !== BUFFER_KEY_LENGTH) {
     return false;
@@ -107,10 +204,22 @@ export function isValidBufferKey(buffer: Buffer): boolean {
   return false;
 }
 
+/**
+ * @param input - The string to test.
+ * @returns Whether the given string is a valid Base64 string.
+ */
 function isValidBase64String(input: string) {
   return BASE_64_REGEX.test(input);
 }
 
+/**
+ * Tests whether the specified hexadecimal string is a valid BIP-32 key.
+ * A valid hexadecimal string key is 128 characters long (excluding any `0x`
+ * prefix) and has at least one non-zero byte.
+ *
+ * @param stringKey - The hexadecimal string to test.
+ * @returns Whether the string represents a valid BIP-32 key.
+ */
 export function isValidHexStringKey(stringKey: string): boolean {
   if (!isValidHexString(stringKey)) {
     return false;
@@ -127,6 +236,14 @@ export function isValidHexStringKey(stringKey: string): boolean {
   return true;
 }
 
+/**
+ * Tests whether the specified Base64 string is a valid BIP-32 key.
+ * A valid Base64 string key is 88 characters long and has at least one non-zero
+ * byte.
+ *
+ * @param stringKey - The Base64 string to test.
+ * @returns Whether the string represents a valid BIP-32 key.
+ */
 export function isValidBase64StringKey(stringKey: string): boolean {
   if (!isValidBase64String(stringKey)) {
     return false;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,10 @@
+import {
+  BASE_64_ENTROPY_LENGTH,
+  BASE_64_REGEX,
+  BASE_64_ZERO,
+  KEY_BUFFER_LENGTH,
+} from './constants';
+
 export function stripHexPrefix(hexString: string): string {
   return hexString.replace(/^0x/iu, '');
 }
@@ -16,4 +23,52 @@ export function hexStringToBuffer(hexString: string) {
 
 export function bufferToBase64String(input: Buffer) {
   return input.toString('base64');
+}
+
+export function isValidBufferEntropy(buffer: Buffer): boolean {
+  if (buffer.length !== KEY_BUFFER_LENGTH) {
+    return false;
+  }
+
+  for (const byte of buffer) {
+    if (byte !== 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isValidBase64String(input: string) {
+  return BASE_64_REGEX.test(input);
+}
+
+export function isValidHexStringEntropy(stringEntropy: string): boolean {
+  if (!isValidHexString(stringEntropy)) {
+    return false;
+  }
+
+  const stripped = stripHexPrefix(stringEntropy);
+  if (stripped.length !== KEY_BUFFER_LENGTH) {
+    return false;
+  }
+
+  if (/^0+$/iu.test(stripped)) {
+    return false;
+  }
+  return true;
+}
+
+export function isValidBase64StringEntropy(stringEntropy: string): boolean {
+  if (!isValidBase64String(stringEntropy)) {
+    return false;
+  }
+
+  if (stringEntropy.length !== BASE_64_ENTROPY_LENGTH) {
+    return false;
+  }
+
+  if (stringEntropy === BASE_64_ZERO) {
+    return false;
+  }
+  return true;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,17 @@
+export function stripHexPrefix(hexString: string): string {
+  return hexString.replace(/^0x/iu, '');
+}
+
+export function isValidHexString(hexString: string): boolean {
+  return /^(?:0x)?[a-f0-9]+$/iu.test(hexString);
+}
+
+export function getHexBuffer(input: string | Buffer) {
+  return Buffer.isBuffer(input)
+    ? input
+    : Buffer.from(stripHexPrefix(input), 'hex');
+}
+
+export function bufferToHexString(input: Buffer) {
+  return input.toString('hex');
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,12 +6,14 @@ export function isValidHexString(hexString: string): boolean {
   return /^(?:0x)?[a-f0-9]+$/iu.test(hexString);
 }
 
-export function getHexBuffer(input: string | Buffer) {
-  return Buffer.isBuffer(input)
-    ? input
-    : Buffer.from(stripHexPrefix(input), 'hex');
+export function base64StringToBuffer(base64String: string) {
+  return Buffer.from(base64String, 'base64');
 }
 
-export function bufferToHexString(input: Buffer) {
-  return input.toString('hex');
+export function hexStringToBuffer(hexString: string) {
+  return Buffer.from(stripHexPrefix(hexString), 'hex');
+}
+
+export function bufferToBase64String(input: Buffer) {
+  return input.toString('base64');
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -57,7 +57,6 @@ export function getHardenedBIP32Node(index: number): HardenedBIP32Node {
 
 export function getUnhardenedBIP32Node(index: number): UnhardenedBIP32Node {
   validateBIP32Index(index);
-
   return `bip32:${index}`;
 }
 
@@ -69,6 +68,10 @@ export function validateBIP32Index(addressIndex: number) {
 
 export function isValidBIP32Index(index: number): boolean {
   return Number.isInteger(index) && index >= 0;
+}
+
+export function isHardened(bip32Token: string): boolean {
+  return bip32Token.endsWith(`'`);
 }
 
 export function stripHexPrefix(hexString: string): string {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,6 +9,7 @@ import {
   AddressHDPathString,
   CoinTypeToAddressTuple,
   HardenedBIP32Node,
+  ChangeHDPathString,
 } from './constants';
 
 export function getBIP44CoinTypePathString(
@@ -38,6 +39,15 @@ export function getBIP44AddressPathString(
   )} / ${getUnhardenedBIP32Node(
     indices.change || 0,
   )} / ${getUnhardenedBIP32Node(indices.address_index)}`;
+}
+
+export function getBIP44ChangePathString(
+  coinTypePath: CoinTypeHDPathString,
+  indices: Omit<CoinTypeToAddressIndices, 'address_index'>,
+): ChangeHDPathString {
+  return `${coinTypePath} / ${getHardenedBIP32Node(
+    indices.account || 0,
+  )} / ${getUnhardenedBIP32Node(indices.change || 0)}`;
 }
 
 export function getBIP44AddressPathTuple({

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,7 +6,6 @@ import {
   BIP44PurposeNode,
   UnhardenedBIP32Node,
   CoinTypeHDPathString,
-  AddressHDPathString,
   CoinTypeToAddressTuple,
   HardenedBIP32Node,
   ChangeHDPathString,
@@ -30,17 +29,6 @@ export type CoinTypeToAddressIndices = Pick<
   BIP44PathIndices,
   'account' | 'change' | 'address_index'
 >;
-
-export function getBIP44AddressPathString(
-  coinTypePath: CoinTypeHDPathString,
-  indices: CoinTypeToAddressIndices,
-): AddressHDPathString {
-  return `${coinTypePath} / ${getHardenedBIP32Node(
-    indices.account || 0,
-  )} / ${getUnhardenedBIP32Node(
-    indices.change || 0,
-  )} / ${getUnhardenedBIP32Node(indices.address_index)}`;
-}
 
 export function getBIP44ChangePathString(
   coinTypePath: CoinTypeHDPathString,

--- a/test/__snapshots__/reference-implementations.test.ts.snap
+++ b/test/__snapshots__/reference-implementations.test.ts.snap
@@ -20,34 +20,34 @@ Array [
 ]
 `;
 
-exports[`reference implementation tests ethereumjs-wallet BIP44Node derives the same keys as the reference implementation 1`] = `"ceb27994cefb8c0f6b2b95bac3b92513a8d37fd0"`;
+exports[`reference implementation tests ethereumjs-wallet BIP44Node derives the same keys as the reference implementation 1`] = `"c5ba325f997531b5f0f50868913f0ce2fc0386bd"`;
 
-exports[`reference implementation tests ethereumjs-wallet BIP44Node derives the same keys as the reference implementation 2`] = `"1666faf80940cb2314b64a692f6859477373196a"`;
+exports[`reference implementation tests ethereumjs-wallet BIP44Node derives the same keys as the reference implementation 2`] = `"326aa42f2b600f624d800e109b1e146906bc8175"`;
 
-exports[`reference implementation tests ethereumjs-wallet BIP44Node derives the same keys as the reference implementation 3`] = `"71d44202324a1d976ef32007b73b0521d38e8784"`;
+exports[`reference implementation tests ethereumjs-wallet BIP44Node derives the same keys as the reference implementation 3`] = `"6d0cc8671c91559d5f2d43de9c33eee0497db7cd"`;
 
-exports[`reference implementation tests ethereumjs-wallet BIP44Node derives the same keys as the reference implementation 4`] = `"b7a47b81b8ca04fefc1764fe2138b0ddbba2cf38"`;
+exports[`reference implementation tests ethereumjs-wallet BIP44Node derives the same keys as the reference implementation 4`] = `"7bf971adda7f4487ac8f3dbd7450463ff3624f94"`;
 
-exports[`reference implementation tests ethereumjs-wallet BIP44Node derives the same keys as the reference implementation 5`] = `"e5d8e52b3cd36929e7c2435ccb9bf4290baa438e"`;
+exports[`reference implementation tests ethereumjs-wallet BIP44Node derives the same keys as the reference implementation 5`] = `"564d7507d39a881d04bffc0120ebd331e7c41758"`;
 
-exports[`reference implementation tests ethereumjs-wallet BIP44Node derives the same keys as the reference implementation 6`] = `"caae5e7f467274cf6c83626d0a7b57836cb2376c"`;
+exports[`reference implementation tests ethereumjs-wallet BIP44Node derives the same keys as the reference implementation 6`] = `"7496ff062c1fe3e750dff9cbbe317558161ba6db"`;
 
-exports[`reference implementation tests ethereumjs-wallet BIP44Node derives the same keys as the reference implementation 7`] = `"f0beee9eb42a90c19dae37e11308e31ef2c90c80"`;
+exports[`reference implementation tests ethereumjs-wallet BIP44Node derives the same keys as the reference implementation 7`] = `"ddf1f1a72a668d5014ec57a24019291fd2a00197"`;
 
-exports[`reference implementation tests ethereumjs-wallet BIP44Node derives the same keys as the reference implementation 8`] = `"1f94dc3288f8139d6042732c8176c30bf0c87e19"`;
+exports[`reference implementation tests ethereumjs-wallet BIP44Node derives the same keys as the reference implementation 8`] = `"24dd12b9df5375f3b7fc5a539d4ac1bd2c16e9a0"`;
 
-exports[`reference implementation tests ethereumjs-wallet deriveKeyFromPath derives the same keys as the reference implementation 1`] = `"ceb27994cefb8c0f6b2b95bac3b92513a8d37fd0"`;
+exports[`reference implementation tests ethereumjs-wallet deriveKeyFromPath derives the same keys as the reference implementation 1`] = `"c5ba325f997531b5f0f50868913f0ce2fc0386bd"`;
 
-exports[`reference implementation tests ethereumjs-wallet deriveKeyFromPath derives the same keys as the reference implementation 2`] = `"1666faf80940cb2314b64a692f6859477373196a"`;
+exports[`reference implementation tests ethereumjs-wallet deriveKeyFromPath derives the same keys as the reference implementation 2`] = `"326aa42f2b600f624d800e109b1e146906bc8175"`;
 
-exports[`reference implementation tests ethereumjs-wallet deriveKeyFromPath derives the same keys as the reference implementation 3`] = `"71d44202324a1d976ef32007b73b0521d38e8784"`;
+exports[`reference implementation tests ethereumjs-wallet deriveKeyFromPath derives the same keys as the reference implementation 3`] = `"6d0cc8671c91559d5f2d43de9c33eee0497db7cd"`;
 
-exports[`reference implementation tests ethereumjs-wallet deriveKeyFromPath derives the same keys as the reference implementation 4`] = `"b7a47b81b8ca04fefc1764fe2138b0ddbba2cf38"`;
+exports[`reference implementation tests ethereumjs-wallet deriveKeyFromPath derives the same keys as the reference implementation 4`] = `"7bf971adda7f4487ac8f3dbd7450463ff3624f94"`;
 
-exports[`reference implementation tests ethereumjs-wallet deriveKeyFromPath derives the same keys as the reference implementation 5`] = `"e5d8e52b3cd36929e7c2435ccb9bf4290baa438e"`;
+exports[`reference implementation tests ethereumjs-wallet deriveKeyFromPath derives the same keys as the reference implementation 5`] = `"564d7507d39a881d04bffc0120ebd331e7c41758"`;
 
-exports[`reference implementation tests ethereumjs-wallet deriveKeyFromPath derives the same keys as the reference implementation 6`] = `"caae5e7f467274cf6c83626d0a7b57836cb2376c"`;
+exports[`reference implementation tests ethereumjs-wallet deriveKeyFromPath derives the same keys as the reference implementation 6`] = `"7496ff062c1fe3e750dff9cbbe317558161ba6db"`;
 
-exports[`reference implementation tests ethereumjs-wallet deriveKeyFromPath derives the same keys as the reference implementation 7`] = `"f0beee9eb42a90c19dae37e11308e31ef2c90c80"`;
+exports[`reference implementation tests ethereumjs-wallet deriveKeyFromPath derives the same keys as the reference implementation 7`] = `"ddf1f1a72a668d5014ec57a24019291fd2a00197"`;
 
-exports[`reference implementation tests ethereumjs-wallet deriveKeyFromPath derives the same keys as the reference implementation 8`] = `"1f94dc3288f8139d6042732c8176c30bf0c87e19"`;
+exports[`reference implementation tests ethereumjs-wallet deriveKeyFromPath derives the same keys as the reference implementation 8`] = `"24dd12b9df5375f3b7fc5a539d4ac1bd2c16e9a0"`;

--- a/test/__snapshots__/reference-implementations.test.ts.snap
+++ b/test/__snapshots__/reference-implementations.test.ts.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`reference implementation tests eth-hd-keyring BIP44Node derives the same keys as the reference implementation 1`] = `
+Array [
+  "1c96099350f13d558464ec79b9be4445aa0ef579",
+  "1b00aed43a693f3a957f9feb5cc08afa031e37a0",
+  "8c9ba4f86ae12250ee1c3676ee925c77426d0b68",
+  "ffe45dbc6c1bee8f211da2ec961f73b82e9ab42c",
+  "b8a13c465c9a0a46f262a1ad666a752923e65b8c",
+]
+`;
+
+exports[`reference implementation tests eth-hd-keyring deriveKeyFromPath derives the same keys as the reference implementation 1`] = `
+Array [
+  "1c96099350f13d558464ec79b9be4445aa0ef579",
+  "1b00aed43a693f3a957f9feb5cc08afa031e37a0",
+  "8c9ba4f86ae12250ee1c3676ee925c77426d0b68",
+  "ffe45dbc6c1bee8f211da2ec961f73b82e9ab42c",
+  "b8a13c465c9a0a46f262a1ad666a752923e65b8c",
+]
+`;
+
+exports[`reference implementation tests ethereumjs-wallet BIP44Node derives the same keys as the reference implementation 1`] = `"ceb27994cefb8c0f6b2b95bac3b92513a8d37fd0"`;
+
+exports[`reference implementation tests ethereumjs-wallet BIP44Node derives the same keys as the reference implementation 2`] = `"1666faf80940cb2314b64a692f6859477373196a"`;
+
+exports[`reference implementation tests ethereumjs-wallet BIP44Node derives the same keys as the reference implementation 3`] = `"71d44202324a1d976ef32007b73b0521d38e8784"`;
+
+exports[`reference implementation tests ethereumjs-wallet BIP44Node derives the same keys as the reference implementation 4`] = `"b7a47b81b8ca04fefc1764fe2138b0ddbba2cf38"`;
+
+exports[`reference implementation tests ethereumjs-wallet BIP44Node derives the same keys as the reference implementation 5`] = `"e5d8e52b3cd36929e7c2435ccb9bf4290baa438e"`;
+
+exports[`reference implementation tests ethereumjs-wallet BIP44Node derives the same keys as the reference implementation 6`] = `"caae5e7f467274cf6c83626d0a7b57836cb2376c"`;
+
+exports[`reference implementation tests ethereumjs-wallet deriveKeyFromPath derives the same keys as the reference implementation 1`] = `"ceb27994cefb8c0f6b2b95bac3b92513a8d37fd0"`;
+
+exports[`reference implementation tests ethereumjs-wallet deriveKeyFromPath derives the same keys as the reference implementation 2`] = `"1666faf80940cb2314b64a692f6859477373196a"`;
+
+exports[`reference implementation tests ethereumjs-wallet deriveKeyFromPath derives the same keys as the reference implementation 3`] = `"71d44202324a1d976ef32007b73b0521d38e8784"`;
+
+exports[`reference implementation tests ethereumjs-wallet deriveKeyFromPath derives the same keys as the reference implementation 4`] = `"b7a47b81b8ca04fefc1764fe2138b0ddbba2cf38"`;
+
+exports[`reference implementation tests ethereumjs-wallet deriveKeyFromPath derives the same keys as the reference implementation 5`] = `"e5d8e52b3cd36929e7c2435ccb9bf4290baa438e"`;
+
+exports[`reference implementation tests ethereumjs-wallet deriveKeyFromPath derives the same keys as the reference implementation 6`] = `"caae5e7f467274cf6c83626d0a7b57836cb2376c"`;

--- a/test/__snapshots__/reference-implementations.test.ts.snap
+++ b/test/__snapshots__/reference-implementations.test.ts.snap
@@ -32,6 +32,10 @@ exports[`reference implementation tests ethereumjs-wallet BIP44Node derives the 
 
 exports[`reference implementation tests ethereumjs-wallet BIP44Node derives the same keys as the reference implementation 6`] = `"caae5e7f467274cf6c83626d0a7b57836cb2376c"`;
 
+exports[`reference implementation tests ethereumjs-wallet BIP44Node derives the same keys as the reference implementation 7`] = `"f0beee9eb42a90c19dae37e11308e31ef2c90c80"`;
+
+exports[`reference implementation tests ethereumjs-wallet BIP44Node derives the same keys as the reference implementation 8`] = `"1f94dc3288f8139d6042732c8176c30bf0c87e19"`;
+
 exports[`reference implementation tests ethereumjs-wallet deriveKeyFromPath derives the same keys as the reference implementation 1`] = `"ceb27994cefb8c0f6b2b95bac3b92513a8d37fd0"`;
 
 exports[`reference implementation tests ethereumjs-wallet deriveKeyFromPath derives the same keys as the reference implementation 2`] = `"1666faf80940cb2314b64a692f6859477373196a"`;
@@ -43,3 +47,7 @@ exports[`reference implementation tests ethereumjs-wallet deriveKeyFromPath deri
 exports[`reference implementation tests ethereumjs-wallet deriveKeyFromPath derives the same keys as the reference implementation 5`] = `"e5d8e52b3cd36929e7c2435ccb9bf4290baa438e"`;
 
 exports[`reference implementation tests ethereumjs-wallet deriveKeyFromPath derives the same keys as the reference implementation 6`] = `"caae5e7f467274cf6c83626d0a7b57836cb2376c"`;
+
+exports[`reference implementation tests ethereumjs-wallet deriveKeyFromPath derives the same keys as the reference implementation 7`] = `"f0beee9eb42a90c19dae37e11308e31ef2c90c80"`;
+
+exports[`reference implementation tests ethereumjs-wallet deriveKeyFromPath derives the same keys as the reference implementation 8`] = `"1f94dc3288f8139d6042732c8176c30bf0c87e19"`;

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -10,10 +10,6 @@ export default {
       '9e28bae18e0e358b12796697c6546f77d4657527',
       '6e7734c7f4fb973a3800b72fb1a6bf82d85d3d29',
       'f87328a8ea5208946c60dbd9385d4c8533ad5dd8',
-      'bdc59c95b5afd6cb0318a24fd390f143fec85d51',
-      '05751e88f2d9f0fccffc8d9c5188adaa378d60e4',
-      'c4311bfd3fea0238a3f5ced088bd366b33f1e292',
-      '7b99c781cbfff075229314ccbdc7f6d9e8440ad9',
     ],
   },
 

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -18,19 +18,13 @@ export default {
   'eth-hd-keyring': {
     mnemonic:
       'finish oppose decorate face calm tragic certain desk hour urge dinosaur mango',
-    // "ethereumAddresses": [
-    //   '1c96099350f13d558464ec79b9be4445aa0ef579',
-    //   '1b00aed43a693f3a957f9feb5cc08afa031e37a0',
-    // ]
   },
 
   // https://github.com/ethereumjs/ethereumjs-wallet/blob/2bc21b408da3b002a95aa752b94fa039ffc64e0f/test/hdkey.spec.ts
   // The state of the default branch as of 2021-10-19
   'ethereumjs-wallet': {
-    seed: Buffer.from(
+    hexSeed:
       '747f302d9c916698912d5f70be53a6cf53bc495803a5523d3a7c3afa2afba94ec3803f838b3e1929ab5481f9da35441372283690fdcf27372c38f40ba134fe03',
-      'hex',
-    ),
     path: {
       ours: {
         tuple: [`bip32:44'`, `bip32:0'`, `bip32:0`, `bip32:1`],
@@ -40,4 +34,281 @@ export default {
     },
     sampleIndices: [0, 1, 5, 50, 500, 5000, 4_999_999, 5_000_000],
   },
+
+  // The BIP-32 specification test vectors.
+  // https://github.com/bitcoin/bips/blob/f9a81b7791142e31ae9ab2a4e8c796f90cfe9627/bip-0032.mediawiki#test-vectors
+  // The state of the default branch as of 2021-10-20
+  bip32: [
+    // ===Test vector 1===
+    {
+      hexSeed: '000102030405060708090a0b0c0d0e0f',
+      keys: [
+        {
+          path: {
+            ours: {
+              tuple: [],
+              string: '',
+            },
+            theirs: 'm',
+          },
+          extPubKey:
+            'xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8',
+          extPrivKey:
+            'xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi',
+        },
+        {
+          path: {
+            ours: {
+              tuple: ["bip32:0'"],
+              string: "bip32:0'",
+            },
+            theirs: "m/0'",
+          },
+          extPubKey:
+            'xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw',
+          extPrivKey:
+            'xprv9uHRZZhk6KAJC1avXpDAp4MDc3sQKNxDiPvvkX8Br5ngLNv1TxvUxt4cV1rGL5hj6KCesnDYUhd7oWgT11eZG7XnxHrnYeSvkzY7d2bhkJ7',
+        },
+        {
+          path: {
+            ours: {
+              tuple: ["bip32:0'", 'bip32:1'],
+              string: "bip32:0'/bip32:1",
+            },
+            theirs: "m/0'/1",
+          },
+          extPubKey:
+            'xpub6ASuArnXKPbfEwhqN6e3mwBcDTgzisQN1wXN9BJcM47sSikHjJf3UFHKkNAWbWMiGj7Wf5uMash7SyYq527Hqck2AxYysAA7xmALppuCkwQ',
+          extPrivKey:
+            'xprv9wTYmMFdV23N2TdNG573QoEsfRrWKQgWeibmLntzniatZvR9BmLnvSxqu53Kw1UmYPxLgboyZQaXwTCg8MSY3H2EU4pWcQDnRnrVA1xe8fs',
+        },
+        {
+          path: {
+            ours: {
+              tuple: ["bip32:0'", 'bip32:1', "bip32:2'"],
+              string: "bip32:0'/bip32:1/bip32:2'",
+            },
+            theirs: "m/0'/1/2'",
+          },
+          extPubKey:
+            'xpub6D4BDPcP2GT577Vvch3R8wDkScZWzQzMMUm3PWbmWvVJrZwQY4VUNgqFJPMM3No2dFDFGTsxxpG5uJh7n7epu4trkrX7x7DogT5Uv6fcLW5',
+          extPrivKey:
+            'xprv9z4pot5VBttmtdRTWfWQmoH1taj2axGVzFqSb8C9xaxKymcFzXBDptWmT7FwuEzG3ryjH4ktypQSAewRiNMjANTtpgP4mLTj34bhnZX7UiM',
+        },
+        {
+          path: {
+            ours: {
+              tuple: ["bip32:0'", 'bip32:1', "bip32:2'", 'bip32:2'],
+              string: "bip32:0'/bip32:1/bip32:2'/bip32:2",
+            },
+            theirs: "m/0'/1/2'/2",
+          },
+          extPubKey:
+            'xpub6FHa3pjLCk84BayeJxFW2SP4XRrFd1JYnxeLeU8EqN3vDfZmbqBqaGJAyiLjTAwm6ZLRQUMv1ZACTj37sR62cfN7fe5JnJ7dh8zL4fiyLHV',
+          extPrivKey:
+            'xprvA2JDeKCSNNZky6uBCviVfJSKyQ1mDYahRjijr5idH2WwLsEd4Hsb2Tyh8RfQMuPh7f7RtyzTtdrbdqqsunu5Mm3wDvUAKRHSC34sJ7in334',
+        },
+        {
+          path: {
+            ours: {
+              tuple: [
+                "bip32:0'",
+                'bip32:1',
+                "bip32:2'",
+                'bip32:2',
+                'bip32:1000000000',
+              ],
+              string: "bip32:0'/bip32:1/bip32:2'/bip32:2/bip32:1000000000",
+            },
+            theirs: "m/0'/1/2'/2/1000000000",
+          },
+          extPubKey:
+            'xpub6H1LXWLaKsWFhvm6RVpEL9P4KfRZSW7abD2ttkWP3SSQvnyA8FSVqNTEcYFgJS2UaFcxupHiYkro49S8yGasTvXEYBVPamhGW6cFJodrTHy',
+          extPrivKey:
+            'xprvA41z7zogVVwxVSgdKUHDy1SKmdb533PjDz7J6N6mV6uS3ze1ai8FHa8kmHScGpWmj4WggLyQjgPie1rFSruoUihUZREPSL39UNdE3BBDu76',
+        },
+      ],
+    },
+
+    // ===Test vector 2===
+    {
+      hexSeed:
+        'fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542',
+      keys: [
+        {
+          path: {
+            ours: {
+              tuple: [],
+              string: '',
+            },
+            theirs: 'm',
+          },
+          extPubKey:
+            'xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB',
+          extPrivKey:
+            'xprv9s21ZrQH143K31xYSDQpPDxsXRTUcvj2iNHm5NUtrGiGG5e2DtALGdso3pGz6ssrdK4PFmM8NSpSBHNqPqm55Qn3LqFtT2emdEXVYsCzC2U',
+        },
+        {
+          path: {
+            ours: {
+              tuple: ['bip32:0'],
+              string: 'bip32:0',
+            },
+            theirs: 'm/0',
+          },
+          extPubKey:
+            'xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH',
+          extPrivKey:
+            'xprv9vHkqa6EV4sPZHYqZznhT2NPtPCjKuDKGY38FBWLvgaDx45zo9WQRUT3dKYnjwih2yJD9mkrocEZXo1ex8G81dwSM1fwqWpWkeS3v86pgKt',
+        },
+        {
+          path: {
+            ours: {
+              tuple: ['bip32:0', "bip32:2147483647'"],
+              string: "bip32:0/bip32:2147483647'",
+            },
+            theirs: "m/0/2147483647'",
+          },
+          extPubKey:
+            'xpub6ASAVgeehLbnwdqV6UKMHVzgqAG8Gr6riv3Fxxpj8ksbH9ebxaEyBLZ85ySDhKiLDBrQSARLq1uNRts8RuJiHjaDMBU4Zn9h8LZNnBC5y4a',
+          extPrivKey:
+            'xprv9wSp6B7kry3Vj9m1zSnLvN3xH8RdsPP1Mh7fAaR7aRLcQMKTR2vidYEeEg2mUCTAwCd6vnxVrcjfy2kRgVsFawNzmjuHc2YmYRmagcEPdU9',
+        },
+        {
+          path: {
+            ours: {
+              tuple: ['bip32:0', "bip32:2147483647'", 'bip32:1'],
+              string: "bip32:0/bip32:2147483647'/bip32:1",
+            },
+            theirs: "m/0/2147483647'/1",
+          },
+          extPubKey:
+            'xpub6DF8uhdarytz3FWdA8TvFSvvAh8dP3283MY7p2V4SeE2wyWmG5mg5EwVvmdMVCQcoNJxGoWaU9DCWh89LojfZ537wTfunKau47EL2dhHKon',
+          extPrivKey:
+            'xprv9zFnWC6h2cLgpmSA46vutJzBcfJ8yaJGg8cX1e5StJh45BBciYTRXSd25UEPVuesF9yog62tGAQtHjXajPPdbRCHuWS6T8XA2ECKADdw4Ef',
+        },
+        {
+          path: {
+            ours: {
+              tuple: [
+                'bip32:0',
+                "bip32:2147483647'",
+                'bip32:1',
+                "bip32:2147483646'",
+              ],
+              string: "bip32:0/bip32:2147483647'/bip32:1/bip32:2147483646'",
+            },
+            theirs: "m/0/2147483647'/1/2147483646'",
+          },
+          extPubKey:
+            'xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL',
+          extPrivKey:
+            'xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc',
+        },
+        {
+          path: {
+            ours: {
+              tuple: [
+                'bip32:0',
+                "bip32:2147483647'",
+                'bip32:1',
+                "bip32:2147483646'",
+                'bip32:2',
+              ],
+              string:
+                "bip32:0/bip32:2147483647'/bip32:1/bip32:2147483646'/bip32:2",
+            },
+            theirs: "m/0/2147483647'/1/2147483646'/2",
+          },
+          extPubKey:
+            'xpub6FnCn6nSzZAw5Tw7cgR9bi15UV96gLZhjDstkXXxvCLsUXBGXPdSnLFbdpq8p9HmGsApME5hQTZ3emM2rnY5agb9rXpVGyy3bdW6EEgAtqt',
+          extPrivKey:
+            'xprvA2nrNbFZABcdryreWet9Ea4LvTJcGsqrMzxHx98MMrotbir7yrKCEXw7nadnHM8Dq38EGfSh6dqA9QWTyefMLEcBYJUuekgW4BYPJcr9E7j',
+        },
+      ],
+    },
+
+    // ===Test vector 3===
+    // These vectors test for the retention of leading zeros. For more information, see: https://github.com/bitpay/bitcore-lib/issues/47 and https://github.com/iancoleman/bip39/issues/58
+    {
+      hexSeed:
+        '4b381541583be4423346c643850da4b320e46a87ae3d2a4e6da11eba819cd4acba45d239319ac14f863b8d5ab5a0d0c64d2e8a1e7d1457df2e5a3c51c73235be',
+      keys: [
+        {
+          path: {
+            ours: {
+              tuple: [],
+              string: '',
+            },
+            theirs: 'm',
+          },
+          extPubKey:
+            'xpub661MyMwAqRbcEZVB4dScxMAdx6d4nFc9nvyvH3v4gJL378CSRZiYmhRoP7mBy6gSPSCYk6SzXPTf3ND1cZAceL7SfJ1Z3GC8vBgp2epUt13',
+          extPrivKey:
+            'xprv9s21ZrQH143K25QhxbucbDDuQ4naNntJRi4KUfWT7xo4EKsHt2QJDu7KXp1A3u7Bi1j8ph3EGsZ9Xvz9dGuVrtHHs7pXeTzjuxBrCmmhgC6',
+        },
+        {
+          path: {
+            ours: {
+              tuple: ["bip32:0'"],
+              string: "bip32:0'",
+            },
+            theirs: "m/0'",
+          },
+          extPubKey:
+            'xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y',
+          extPrivKey:
+            'xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L',
+        },
+      ],
+    },
+
+    // ===Test vector 4===
+    // These vectors test for the retention of leading zeros. For more information, see: https://github.com/btcsuite/btcutil/issues/172 btcsuite/btcutil#172
+    {
+      hexSeed:
+        '3ddd5602285899a946114506157c7997e5444528f3003f6134712147db19b678',
+      keys: [
+        {
+          path: {
+            ours: {
+              tuple: [],
+              string: '',
+            },
+            theirs: 'm',
+          },
+          extPubKey:
+            'xpub661MyMwAqRbcGczjuMoRm6dXaLDEhW1u34gKenbeYqAix21mdUKJyuyu5F1rzYGVxyL6tmgBUAEPrEz92mBXjByMRiJdba9wpnN37RLLAXa',
+          extPrivKey:
+            'xprv9s21ZrQH143K48vGoLGRPxgo2JNkJ3J3fqkirQC2zVdk5Dgd5w14S7fRDyHH4dWNHUgkvsvNDCkvAwcSHNAQwhwgNMgZhLtQC63zxwhQmRv',
+        },
+        {
+          path: {
+            ours: {
+              tuple: ["bip32:0'"],
+              string: "bip32:0'",
+            },
+            theirs: "m/0'",
+          },
+          extPubKey:
+            'xpub69AUMk3qDBi3uW1sXgjCmVjJ2G6WQoYSnNHyzkmdCHEhSZ4tBok37xfFEqHd2AddP56Tqp4o56AePAgCjYdvpW2PU2jbUPFKsav5ut6Ch1m',
+          extPrivKey:
+            'xprv9vB7xEWwNp9kh1wQRfCCQMnZUEG21LpbR9NPCNN1dwhiZkjjeGRnaALmPXCX7SgjFTiCTT6bXes17boXtjq3xLpcDjzEuGLQBM5ohqkao9G',
+        },
+        {
+          path: {
+            ours: {
+              tuple: ["bip32:0'", "bip32:1'"],
+              string: "bip32:0'/bip32:1'",
+            },
+            theirs: "m/0'/1'",
+          },
+          extPubKey:
+            'xpub6BJA1jSqiukeaesWfxe6sNK9CCGaujFFSJLomWHprUL9DePQ4JDkM5d88n49sMGJxrhpjazuXYWdMf17C9T5XnxkopaeS7jGk1GyyVziaMt',
+          extPrivKey:
+            'xprv9xJocDuwtYCMNAo3Zw76WENQeAS6WGXQ55RCy7tDJ8oALr4FWkuVoHJeHVAcAqiZLE7Je3vZJHxspZdFHfnBEjHqU5hG1Jaj32dVoS6XLT1',
+        },
+      ],
+    },
+  ],
 } as const;

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -35,7 +35,7 @@ export default {
       },
       theirs: "m/44'/0'/0'/1",
     },
-    sampleIndices: [0, 1, 5, 50, 500, 5000, 4_999_999, 5_000_000],
+    sampleAddressIndices: [0, 1, 5, 50, 500, 5000, 4_999_999, 5_000_000],
   },
 
   // The BIP-32 specification test vectors.

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1,0 +1,47 @@
+export default {
+  // Fixtures defined and used in this package
+  local: {
+    mnemonic:
+      'romance hurry grit huge rifle ordinary loud toss sound congress upset twist',
+    addresses: [
+      '5df603999c3d5ca2ab828339a9883585b1bce11b',
+      '441c07e32a609afd319ffbb66432b424058bcfe9',
+      '1f7c93dfe849c06dd610e77473bfaaef7f183c7c',
+      '9e28bae18e0e358b12796697c6546f77d4657527',
+      '6e7734c7f4fb973a3800b72fb1a6bf82d85d3d29',
+      'f87328a8ea5208946c60dbd9385d4c8533ad5dd8',
+      'bdc59c95b5afd6cb0318a24fd390f143fec85d51',
+      '05751e88f2d9f0fccffc8d9c5188adaa378d60e4',
+      'c4311bfd3fea0238a3f5ced088bd366b33f1e292',
+      '7b99c781cbfff075229314ccbdc7f6d9e8440ad9',
+    ],
+  },
+
+  // https://github.com/brave/eth-hd-keyring/blob/482acf341f01a8d1e924d55bfdbd309444a78e46/test/index.js#L10-L12
+  // The state of the default branch as of 2021-10-19
+  'eth-hd-keyring': {
+    mnemonic:
+      'finish oppose decorate face calm tragic certain desk hour urge dinosaur mango',
+    // "ethereumAddresses": [
+    //   '1c96099350f13d558464ec79b9be4445aa0ef579',
+    //   '1b00aed43a693f3a957f9feb5cc08afa031e37a0',
+    // ]
+  },
+
+  // https://github.com/ethereumjs/ethereumjs-wallet/blob/2bc21b408da3b002a95aa752b94fa039ffc64e0f/test/hdkey.spec.ts
+  // The state of the default branch as of 2021-10-19
+  'ethereumjs-wallet': {
+    seed: Buffer.from(
+      '747f302d9c916698912d5f70be53a6cf53bc495803a5523d3a7c3afa2afba94ec3803f838b3e1929ab5481f9da35441372283690fdcf27372c38f40ba134fe03',
+      'hex',
+    ),
+    path: {
+      ours: {
+        tuple: [`bip32:44'`, `bip32:0'`, `bip32:0`, `bip32:1`],
+        string: [`bip32:44'/bip32:0'/bip32:0/bip32:1`],
+      },
+      theirs: "m/44'/0'/0/1",
+    },
+    sampleIndices: [0, 1, 5, 50, 500, 5000],
+  },
+} as const;

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -25,12 +25,15 @@ export default {
   'ethereumjs-wallet': {
     hexSeed:
       '747f302d9c916698912d5f70be53a6cf53bc495803a5523d3a7c3afa2afba94ec3803f838b3e1929ab5481f9da35441372283690fdcf27372c38f40ba134fe03',
+    // The path used is modified from the ethereumjs-wallet original, which
+    // isn't BIP-44 compatible. Since we're testing against their
+    // implementation, not any reference values, this is fine.
     path: {
       ours: {
-        tuple: [`bip32:44'`, `bip32:0'`, `bip32:0`, `bip32:1`],
-        string: [`bip32:44'/bip32:0'/bip32:0/bip32:1`],
+        tuple: [`bip32:44'`, `bip32:0'`, `bip32:0'`, `bip32:1`],
+        string: [`bip32:44'/bip32:0'/bip32:0'/bip32:1`],
       },
-      theirs: "m/44'/0'/0/1",
+      theirs: "m/44'/0'/0'/1",
     },
     sampleIndices: [0, 1, 5, 50, 500, 5000, 4_999_999, 5_000_000],
   },

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -38,6 +38,6 @@ export default {
       },
       theirs: "m/44'/0'/0/1",
     },
-    sampleIndices: [0, 1, 5, 50, 500, 5000],
+    sampleIndices: [0, 1, 5, 50, 500, 5000, 4_999_999, 5_000_000],
   },
 } as const;

--- a/test/reference-implementations.test.ts
+++ b/test/reference-implementations.test.ts
@@ -207,41 +207,8 @@ describe('reference implementation tests', () => {
   describe('BIP-32 specification test vectors', () => {
     const vectors = fixtures.bip32;
 
-    describe('BIP44Node', () => {
-      it('derives the test vector keys', () => {
-        vectors.forEach((vector) => {
-          const seed = hexStringToBuffer(vector.hexSeed);
-          const seedKey = createBip39KeyFromSeed(seed);
-
-          vector.keys.forEach(
-            (keyObj: { path: any; extPrivKey: string; extPubKey: string }) => {
-              const { path, extPrivKey } = keyObj;
-              const parentNode = new BIP44Node({
-                depth: 0,
-                key: seedKey,
-              });
-
-              let targetNode: BIP44Node;
-              if (path.ours.string === '') {
-                targetNode = parentNode;
-              } else {
-                targetNode = parentNode.derive(path.ours.tuple);
-              }
-
-              const xprvHdKey = hdkey
-                .fromExtendedKey(extPrivKey)
-                .getWallet()
-                .getPrivateKey();
-
-              expect(
-                targetNode.keyBuffer.slice(0, 32).toString('base64'),
-              ).toStrictEqual(xprvHdKey.toString('base64'));
-            },
-          );
-        });
-      });
-    });
-
+    // We only test the BIP-32 vectors with deriveKeyFromPath, since not all
+    // paths are BIP-44 compatible.
     describe('deriveKeyFromPath', () => {
       it('derives the test vector keys', () => {
         vectors.forEach((vector) => {

--- a/test/reference-implementations.test.ts
+++ b/test/reference-implementations.test.ts
@@ -1,0 +1,121 @@
+import HdKeyring from 'eth-hd-keyring';
+import { hdkey } from 'ethereumjs-wallet';
+import { BIP44Node } from '../src/BIP44Node';
+import { BIP44PurposeNode } from '../src/constants';
+import { privateKeyToEthAddress } from '../src/derivers/bip32';
+import { createKeyFromSeed } from '../src/derivers/bip39';
+import { getBIP44AddressPathTuple, stripHexPrefix } from '../src/utils';
+import fixtures from './fixtures';
+
+describe('reference implementation tests', () => {
+  describe('local', () => {
+    describe('BIP44Node', () => {
+      const { addresses, mnemonic } = fixtures.local;
+
+      it('derives the expected keys', () => {
+        // Ethereum coin type node
+        const node = new BIP44Node({
+          derivationPath: [`bip39:${mnemonic}`, BIP44PurposeNode, `bip32:60'`],
+        });
+
+        addresses.forEach((expectedAddress, index) => {
+          const childNode = node.derive(
+            getBIP44AddressPathTuple({ address_index: index }),
+          );
+
+          expect(
+            privateKeyToEthAddress(childNode.keyBuffer).toString('hex'),
+          ).toStrictEqual(expectedAddress);
+        });
+      });
+    });
+
+    describe('deriveKeyFromPath', () => {
+      it.todo('derives the expected keys');
+    });
+  });
+
+  describe('eth-hd-keyring', () => {
+    describe('BIP44Node', () => {
+      const { mnemonic } = fixtures['eth-hd-keyring'];
+
+      it('derives the same keys as the reference implementation', async () => {
+        const bip39Node = `bip39:${mnemonic}` as const;
+
+        // Ethereum coin type node
+        const node = new BIP44Node({
+          derivationPath: [bip39Node, BIP44PurposeNode, `bip32:60'`],
+        });
+
+        const numberOfAccounts = 5;
+        const ourAccounts = [];
+        for (let i = 0; i < numberOfAccounts; i++) {
+          ourAccounts.push(
+            privateKeyToEthAddress(
+              node.derive(getBIP44AddressPathTuple({ address_index: i }))
+                .keyBuffer,
+            ).toString('hex'),
+          );
+        }
+
+        const hdKeyring = new HdKeyring({
+          mnemonic,
+          numberOfAccounts,
+        });
+
+        expect(await hdKeyring.getAccounts()).toStrictEqual(
+          ourAccounts.map((account) => `0x${account}`),
+        );
+      });
+    });
+
+    describe('deriveKeyFromPath', () => {
+      it.todo('derives the same keys as the reference implementation');
+    });
+  });
+
+  describe('ethereumjs-wallet', () => {
+    describe('BIP44Node', () => {
+      const { sampleIndices, seed, path } = fixtures['ethereumjs-wallet'];
+
+      it('derives the same keys as the reference implementation', () => {
+        const seedKey = createKeyFromSeed(seed);
+
+        const fixtureHd = hdkey.fromMasterSeed(seed);
+        const childFixtureHd = fixtureHd.derivePath(path.theirs);
+        const childFixtureHdKey = childFixtureHd.getWallet().getPrivateKey();
+
+        const node = new BIP44Node({
+          depth: 0,
+          key: seedKey,
+        }).derive(path.ours.tuple);
+
+        expect(node.keyBuffer.slice(0, 32).toString('base64')).toStrictEqual(
+          childFixtureHdKey.toString('base64'),
+        );
+
+        expect(
+          privateKeyToEthAddress(node.keyBuffer).toString('hex'),
+        ).toStrictEqual(
+          stripHexPrefix(childFixtureHd.getWallet().getAddressString()),
+        );
+
+        sampleIndices.forEach((index) => {
+          const ourAddress = privateKeyToEthAddress(
+            node.derive([`bip32:${index}`]).keyBuffer,
+          ).toString('hex');
+
+          const theirAddress = stripHexPrefix(
+            childFixtureHd.deriveChild(index).getWallet().getAddressString(),
+          );
+
+          expect(ourAddress).toStrictEqual(theirAddress);
+        });
+      });
+    });
+
+    describe('deriveKeyFromPath', () => {
+      it.todo('derives the same keys as the reference implementation');
+    });
+  });
+});

--- a/test/reference-implementations.test.ts
+++ b/test/reference-implementations.test.ts
@@ -1,12 +1,12 @@
 import HdKeyring from 'eth-hd-keyring';
 import { hdkey } from 'ethereumjs-wallet';
 import { BIP44Node } from '../src/BIP44Node';
-import { BIP44PurposeNode } from '../src/constants';
+import { BIP44PurposeNodeToken } from '../src/constants';
 import { deriveKeyFromPath } from '../src/derivation';
 import { privateKeyToEthAddress } from '../src/derivers/bip32';
 import { createBip39KeyFromSeed } from '../src/derivers/bip39';
 import {
-  getBIP44AddressPathTuple,
+  getBIP44CoinTypeToAddressPathTuple,
   hexStringToBuffer,
   stripHexPrefix,
 } from '../src/utils';
@@ -21,12 +21,16 @@ describe('reference implementation tests', () => {
       it('derives the expected keys', () => {
         // Ethereum coin type node
         const node = new BIP44Node({
-          derivationPath: [mnemonicBip39Node, BIP44PurposeNode, `bip32:60'`],
+          derivationPath: [
+            mnemonicBip39Node,
+            BIP44PurposeNodeToken,
+            `bip32:60'`,
+          ],
         });
 
         addresses.forEach((expectedAddress, index) => {
           const childNode = node.derive(
-            getBIP44AddressPathTuple({ address_index: index }),
+            getBIP44CoinTypeToAddressPathTuple({ address_index: index }),
           );
 
           expect(
@@ -41,13 +45,13 @@ describe('reference implementation tests', () => {
         // Ethereum coin type key
         const parentKey = deriveKeyFromPath([
           mnemonicBip39Node,
-          BIP44PurposeNode,
+          BIP44PurposeNodeToken,
           `bip32:60'`,
         ]);
 
         addresses.forEach((expectedAddress, index) => {
           const childKey = deriveKeyFromPath(
-            getBIP44AddressPathTuple({ address_index: index }),
+            getBIP44CoinTypeToAddressPathTuple({ address_index: index }),
             parentKey,
           );
 
@@ -67,7 +71,11 @@ describe('reference implementation tests', () => {
       it('derives the same keys as the reference implementation', async () => {
         // Ethereum coin type node
         const node = new BIP44Node({
-          derivationPath: [mnemonicBip39Node, BIP44PurposeNode, `bip32:60'`],
+          derivationPath: [
+            mnemonicBip39Node,
+            BIP44PurposeNodeToken,
+            `bip32:60'`,
+          ],
         });
 
         const numberOfAccounts = 5;
@@ -75,8 +83,9 @@ describe('reference implementation tests', () => {
         for (let i = 0; i < numberOfAccounts; i++) {
           ourAccounts.push(
             privateKeyToEthAddress(
-              node.derive(getBIP44AddressPathTuple({ address_index: i }))
-                .keyBuffer,
+              node.derive(
+                getBIP44CoinTypeToAddressPathTuple({ address_index: i }),
+              ).keyBuffer,
             ).toString('hex'),
           );
         }
@@ -98,7 +107,7 @@ describe('reference implementation tests', () => {
         // Ethereum coin type key
         const parentKey = deriveKeyFromPath([
           mnemonicBip39Node,
-          BIP44PurposeNode,
+          BIP44PurposeNodeToken,
           `bip32:60'`,
         ]);
 
@@ -108,7 +117,7 @@ describe('reference implementation tests', () => {
           ourAccounts.push(
             privateKeyToEthAddress(
               deriveKeyFromPath(
-                getBIP44AddressPathTuple({ address_index: i }),
+                getBIP44CoinTypeToAddressPathTuple({ address_index: i }),
                 parentKey,
               ),
             ).toString('hex'),
@@ -129,7 +138,8 @@ describe('reference implementation tests', () => {
   });
 
   describe('ethereumjs-wallet', () => {
-    const { sampleIndices, hexSeed, path } = fixtures['ethereumjs-wallet'];
+    const { sampleAddressIndices, hexSeed, path } =
+      fixtures['ethereumjs-wallet'];
     const seed = hexStringToBuffer(hexSeed);
 
     describe('BIP44Node', () => {
@@ -155,7 +165,7 @@ describe('reference implementation tests', () => {
           stripHexPrefix(childFixtureHd.getWallet().getAddressString()),
         );
 
-        sampleIndices.forEach((index) => {
+        sampleAddressIndices.forEach((index) => {
           const ourAddress = privateKeyToEthAddress(
             node.derive([`bip32:${index}`]).keyBuffer,
           ).toString('hex');
@@ -188,7 +198,7 @@ describe('reference implementation tests', () => {
           stripHexPrefix(childFixtureHd.getWallet().getAddressString()),
         );
 
-        sampleIndices.forEach((index) => {
+        sampleAddressIndices.forEach((index) => {
           const ourAddress = privateKeyToEthAddress(
             deriveKeyFromPath([`bip32:${index}`], parentKey),
           ).toString('hex');

--- a/test/types/eth-hd-keyring/index.d.ts
+++ b/test/types/eth-hd-keyring/index.d.ts
@@ -1,0 +1,7 @@
+declare module 'eth-hd-keyring' {
+  export default class HdKeyring {
+    constructor(args: Record<string, unknown>);
+
+    getAccounts(): Promise<string[]>;
+  }
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "typeRoots": ["./node_modules/@types", "./test/types"]
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -665,6 +665,13 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/bn.js@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-5.1.0.tgz#32c5d271503a12653c62cf4d2b45e6eab8cebc68"
+  integrity sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/glob@^7.1.1":
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.4.tgz#ea59e21d2ee5c517914cb4bc8e4153b99e566672"
@@ -734,12 +741,19 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.6.4.tgz#a145cc0bb14ef9c4777361b7bbafa5cf8e3acb5a"
   integrity sha512-Wk7nG1JSaMfMpoMJDKUsWYugliB2Vy55pdjLpmLixeyMi7HizW2I/9QoxsPCkXl3dO+ZOVqPumKaDUv5zJu2uQ==
 
+"@types/pbkdf2@^3.0.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@types/pbkdf2/-/pbkdf2-3.1.0.tgz#039a0e9b67da0cdc4ee5dab865caa6b267bb66b1"
+  integrity sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/prettier@^2.1.5":
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.1.tgz#e1303048d5389563e130f5bdd89d37a99acb75eb"
   integrity sha512-Fo79ojj3vdEZOHg3wR9ksAMRz4P3S5fDB5e/YWZiFnyFQI1WY2Vftu9XoXVVtJfxB7Bpce/QTqWSSntkz2Znrw==
 
-"@types/secp256k1@^4.0.3":
+"@types/secp256k1@^4.0.1", "@types/secp256k1@^4.0.3":
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/@types/secp256k1/-/secp256k1-4.0.3.tgz#1b8e55d8e00f08ee7220b4d59a6abe89c37a901c"
   integrity sha512-Da66lEIFeIz9ltsdMZcpQvmrmmoqrfju8pm1BH8WbYjZSwUgCwXLb9C+9XYogwBITnbsSaMdVPb2ekf7TV+03w==
@@ -921,6 +935,11 @@ acorn@^8.2.4:
   version "8.5.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.5.0.tgz#4512ccb99b3698c752591e9bb4472e38ad43cee2"
   integrity sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==
+
+aes-js@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-3.1.2.tgz#db9aabde85d5caabbfc0d4f2a4446960f627146a"
+  integrity sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==
 
 agent-base@6:
   version "6.0.2"
@@ -1151,6 +1170,13 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+base-x@^3.0.2:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.8.tgz#1e1106c2537f0162e8b52474a557ebb09000018d"
+  integrity sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==
+  dependencies:
+    safe-buffer "^5.0.1"
+
 bcrypt-pbkdf@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
@@ -1183,10 +1209,20 @@ bip66@^1.1.5:
   dependencies:
     safe-buffer "^5.0.1"
 
+blakejs@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.1.1.tgz#bf313053978b2cd4c444a48795710be05c785702"
+  integrity sha512-bLG6PHOCZJKNshTjGRBvET0vTciwQE6zFKOKKXPDJfwFBd4Ac0yBfPZqcGvGJap50l7ktvlpFqc2jGVaUgbJgg==
+
 bn.js@^4.11.8, bn.js@^4.11.9:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
   integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
+
+bn.js@^5.1.2, bn.js@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
+  integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -1213,7 +1249,7 @@ browser-process-hrtime@^1.0.0:
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
   integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
 
-browserify-aes@^1.0.6:
+browserify-aes@^1.0.6, browserify-aes@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.2.0.tgz#326734642f403dabc3003209853bb70ad428ef48"
   integrity sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==
@@ -1242,6 +1278,22 @@ bs-logger@0.x:
   integrity sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==
   dependencies:
     fast-json-stable-stringify "2.x"
+
+bs58@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/bs58/-/bs58-4.0.1.tgz#be161e76c354f6f788ae4071f63f34e8c4f0a42a"
+  integrity sha1-vhYedsNU9veIrkBx9j806MTwpCo=
+  dependencies:
+    base-x "^3.0.2"
+
+bs58check@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/bs58check/-/bs58check-2.1.2.tgz#53b018291228d82a5aa08e7d796fdafda54aebfc"
+  integrity sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==
+  dependencies:
+    bs58 "^4.0.0"
+    create-hash "^1.1.0"
+    safe-buffer "^5.1.2"
 
 bser@2.1.1:
   version "2.1.1"
@@ -1441,7 +1493,7 @@ create-hash@^1.1.0, create-hash@^1.1.2, create-hash@^1.2.0:
     ripemd160 "^2.0.1"
     sha.js "^2.4.0"
 
-create-hmac@^1.1.4:
+create-hmac@^1.1.4, create-hmac@^1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/create-hmac/-/create-hmac-1.1.7.tgz#69170c78b3ab957147b2b8b04572e47ead2243ff"
   integrity sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==
@@ -1942,6 +1994,52 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+ethereum-cryptography@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz#8d6143cfc3d74bf79bbd8edecdf29e4ae20dd191"
+  integrity sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==
+  dependencies:
+    "@types/pbkdf2" "^3.0.0"
+    "@types/secp256k1" "^4.0.1"
+    blakejs "^1.1.0"
+    browserify-aes "^1.2.0"
+    bs58check "^2.1.2"
+    create-hash "^1.2.0"
+    create-hmac "^1.1.7"
+    hash.js "^1.1.7"
+    keccak "^3.0.0"
+    pbkdf2 "^3.0.17"
+    randombytes "^2.1.0"
+    safe-buffer "^5.1.2"
+    scrypt-js "^3.0.0"
+    secp256k1 "^4.0.1"
+    setimmediate "^1.0.5"
+
+ethereumjs-util@^7.1.2:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.1.3.tgz#b55d7b64dde3e3e45749e4c41288238edec32d23"
+  integrity sha512-y+82tEbyASO0K0X1/SRhbJJoAlfcvq8JbrG4a5cjrOks7HS/36efU/0j2flxCPOUM++HFahk33kr/ZxyC4vNuw==
+  dependencies:
+    "@types/bn.js" "^5.1.0"
+    bn.js "^5.1.2"
+    create-hash "^1.1.2"
+    ethereum-cryptography "^0.1.3"
+    rlp "^2.2.4"
+
+ethereumjs-wallet@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/ethereumjs-wallet/-/ethereumjs-wallet-1.0.2.tgz#2c000504b4c71e8f3782dabe1113d192522e99b6"
+  integrity sha512-CCWV4RESJgRdHIvFciVQFnCHfqyhXWchTPlkfp28Qc53ufs+doi5I/cV2+xeK9+qEo25XCWfP9MiL+WEPAZfdA==
+  dependencies:
+    aes-js "^3.1.2"
+    bs58check "^2.1.2"
+    ethereum-cryptography "^0.1.3"
+    ethereumjs-util "^7.1.2"
+    randombytes "^2.1.0"
+    scrypt-js "^3.0.1"
+    utf8 "^3.0.0"
+    uuid "^8.3.2"
+
 evp_bytestokey@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz#7fcbdb198dc71959432efe13842684e0525acb02"
@@ -2334,7 +2432,7 @@ hash-base@^3.0.0:
     readable-stream "^3.6.0"
     safe-buffer "^5.2.0"
 
-hash.js@^1.0.0, hash.js@^1.0.3:
+hash.js@^1.0.0, hash.js@^1.0.3, hash.js@^1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
   integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
@@ -3170,6 +3268,15 @@ keccak@^1.4.0:
     nan "^2.2.1"
     safe-buffer "^5.1.0"
 
+keccak@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/keccak/-/keccak-3.0.2.tgz#4c2c6e8c54e04f2670ee49fa734eb9da152206e0"
+  integrity sha512-PyKKjkH53wDMLGrvmRGSNWgmSxZOUqbnXwKL9tmgbFYA1iAYqW21kfR7mZXV0MlESiefxQQE9X9fTa3X+2MPDQ==
+  dependencies:
+    node-addon-api "^2.0.0"
+    node-gyp-build "^4.2.0"
+    readable-stream "^3.6.0"
+
 kleur@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
@@ -3385,6 +3492,16 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+
+node-addon-api@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
+  integrity sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==
+
+node-gyp-build@^4.2.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.3.0.tgz#9f256b03e5826150be39c764bf51e993946d71a3"
+  integrity sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==
 
 node-gyp@^7.1.0:
   version "7.1.2"
@@ -3648,6 +3765,17 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+pbkdf2@^3.0.17:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.1.2.tgz#dd822aa0887580e52f1a039dc3eda108efae3075"
+  integrity sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==
+  dependencies:
+    create-hash "^1.1.2"
+    create-hmac "^1.1.4"
+    ripemd160 "^2.0.1"
+    safe-buffer "^5.0.1"
+    sha.js "^2.4.8"
+
 pbkdf2@^3.0.9:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.1.1.tgz#cb8724b0fada984596856d1a6ebafd3584654b94"
@@ -3782,7 +3910,7 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.2.tgz#abf64491e6ecf0f38a6502403d4cda04f372dfd3"
   integrity sha512-dB15eXv3p2jDlbOiNLyMabYg1/sXvppd8DP2J3EOCQ0AkuSXCW2tP7mnVouVLJKgUMY6yP0kcQDVpLCN13h4Xg==
 
-randombytes@^2.0.1:
+randombytes@^2.0.1, randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
   integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
@@ -3937,6 +4065,13 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
+rlp@^2.2.4:
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/rlp/-/rlp-2.2.7.tgz#33f31c4afac81124ac4b283e2bd4d9720b30beaf"
+  integrity sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==
+  dependencies:
+    bn.js "^5.2.0"
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
@@ -3966,6 +4101,11 @@ saxes@^5.0.1:
   dependencies:
     xmlchars "^2.2.0"
 
+scrypt-js@^3.0.0, scrypt-js@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-3.0.1.tgz#d314a57c2aef69d1ad98a138a21fe9eafa9ee312"
+  integrity sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==
+
 secp256k1@^3.5.0:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-3.8.0.tgz#28f59f4b01dbee9575f56a47034b7d2e3b3b352d"
@@ -3979,6 +4119,15 @@ secp256k1@^3.5.0:
     elliptic "^6.5.2"
     nan "^2.14.0"
     safe-buffer "^5.1.2"
+
+secp256k1@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-4.0.2.tgz#15dd57d0f0b9fdb54ac1fa1694f40e5e9a54f4a1"
+  integrity sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==
+  dependencies:
+    elliptic "^6.5.2"
+    node-addon-api "^2.0.0"
+    node-gyp-build "^4.2.0"
 
 "semver@2 || 3 || 4 || 5":
   version "5.7.1"
@@ -4008,6 +4157,11 @@ set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
+
+setimmediate@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+  integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
 
 sha.js@^2.4.0, sha.js@^2.4.8:
   version "2.4.11"
@@ -4490,6 +4644,11 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+utf8@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/utf8/-/utf8-3.0.0.tgz#f052eed1364d696e769ef058b183df88c87f69d1"
+  integrity sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==
+
 util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
@@ -4499,6 +4658,11 @@ uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache@^2.0.3:
   version "2.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -665,6 +665,13 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/bn.js@^4.11.3":
+  version "4.11.6"
+  resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-4.11.6.tgz#c306c70d9358aaea33cd4eda092a742b9505967c"
+  integrity sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/bn.js@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-5.1.0.tgz#32c5d271503a12653c62cf4d2b45e6eab8cebc68"
@@ -1191,7 +1198,7 @@ bindings@^1.2.1, bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
-bip39@^2.5.0:
+bip39@^2.2.0, bip39@^2.5.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/bip39/-/bip39-2.6.0.tgz#9e3a720b42ec8b3fbe4038f1e445317b6a99321c"
   integrity sha512-RrnQRG2EgEoqO24ea+Q/fftuPUZLmrEM3qNhhGsA3PbaXaCW791LTzPuVyx/VprXQcTbPJ3K3UeTna8ZnVl2sg==
@@ -1214,7 +1221,7 @@ blakejs@^1.1.0:
   resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.1.1.tgz#bf313053978b2cd4c444a48795710be05c785702"
   integrity sha512-bLG6PHOCZJKNshTjGRBvET0vTciwQE6zFKOKKXPDJfwFBd4Ac0yBfPZqcGvGJap50l7ktvlpFqc2jGVaUgbJgg==
 
-bn.js@^4.11.8, bn.js@^4.11.9:
+bn.js@^4.11.0, bn.js@^4.11.8, bn.js@^4.11.9:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
   integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
@@ -1994,6 +2001,37 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+eth-hd-keyring@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/eth-hd-keyring/-/eth-hd-keyring-3.6.0.tgz#6835d30aa411b8d3ef098e82f6427b5325082abb"
+  integrity sha512-n2CwE9VNXsxLrXQa6suv0Umt4NT6+HtoahKgWx3YviXx4rQFwVT5nDwZfjhwrT31ESuoXYNIeJgz5hKLD96QeQ==
+  dependencies:
+    bip39 "^2.2.0"
+    eth-sig-util "^3.0.1"
+    eth-simple-keyring "^4.2.0"
+    ethereumjs-util "^7.0.9"
+    ethereumjs-wallet "^1.0.1"
+
+eth-sig-util@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/eth-sig-util/-/eth-sig-util-3.0.1.tgz#8753297c83a3f58346bd13547b59c4b2cd110c96"
+  integrity sha512-0Us50HiGGvZgjtWTyAI/+qTzYPMLy5Q451D0Xy68bxq1QMWdoOddDwGvsqcFT27uohKgalM9z/yxplyt+mY2iQ==
+  dependencies:
+    ethereumjs-abi "^0.6.8"
+    ethereumjs-util "^5.1.1"
+    tweetnacl "^1.0.3"
+    tweetnacl-util "^0.15.0"
+
+eth-simple-keyring@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/eth-simple-keyring/-/eth-simple-keyring-4.2.0.tgz#c197a4bd4cce7d701b5f3607d0b843112ddb17e3"
+  integrity sha512-lBxFObXJTBjktDkQszXrqoB317wghEUYATQ3W19vLAjaznrmbdy1lccPhXIRMT9bHIUgNKOJQkLohNZiT9tO8Q==
+  dependencies:
+    eth-sig-util "^3.0.1"
+    ethereumjs-util "^7.0.9"
+    ethereumjs-wallet "^1.0.1"
+    events "^1.1.1"
+
 ethereum-cryptography@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz#8d6143cfc3d74bf79bbd8edecdf29e4ae20dd191"
@@ -2015,7 +2053,41 @@ ethereum-cryptography@^0.1.3:
     secp256k1 "^4.0.1"
     setimmediate "^1.0.5"
 
-ethereumjs-util@^7.1.2:
+ethereumjs-abi@^0.6.8:
+  version "0.6.8"
+  resolved "https://registry.yarnpkg.com/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz#71bc152db099f70e62f108b7cdfca1b362c6fcae"
+  integrity sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==
+  dependencies:
+    bn.js "^4.11.8"
+    ethereumjs-util "^6.0.0"
+
+ethereumjs-util@^5.1.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz#a833f0e5fca7e5b361384dc76301a721f537bf65"
+  integrity sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==
+  dependencies:
+    bn.js "^4.11.0"
+    create-hash "^1.1.2"
+    elliptic "^6.5.2"
+    ethereum-cryptography "^0.1.3"
+    ethjs-util "^0.1.3"
+    rlp "^2.0.0"
+    safe-buffer "^5.1.1"
+
+ethereumjs-util@^6.0.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz#fcb4e4dd5ceacb9d2305426ab1a5cd93e3163b69"
+  integrity sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==
+  dependencies:
+    "@types/bn.js" "^4.11.3"
+    bn.js "^4.11.0"
+    create-hash "^1.1.2"
+    elliptic "^6.5.2"
+    ethereum-cryptography "^0.1.3"
+    ethjs-util "0.1.6"
+    rlp "^2.2.3"
+
+ethereumjs-util@^7.0.9, ethereumjs-util@^7.1.2:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.1.3.tgz#b55d7b64dde3e3e45749e4c41288238edec32d23"
   integrity sha512-y+82tEbyASO0K0X1/SRhbJJoAlfcvq8JbrG4a5cjrOks7HS/36efU/0j2flxCPOUM++HFahk33kr/ZxyC4vNuw==
@@ -2026,7 +2098,7 @@ ethereumjs-util@^7.1.2:
     ethereum-cryptography "^0.1.3"
     rlp "^2.2.4"
 
-ethereumjs-wallet@^1.0.2:
+ethereumjs-wallet@^1.0.1, ethereumjs-wallet@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ethereumjs-wallet/-/ethereumjs-wallet-1.0.2.tgz#2c000504b4c71e8f3782dabe1113d192522e99b6"
   integrity sha512-CCWV4RESJgRdHIvFciVQFnCHfqyhXWchTPlkfp28Qc53ufs+doi5I/cV2+xeK9+qEo25XCWfP9MiL+WEPAZfdA==
@@ -2039,6 +2111,19 @@ ethereumjs-wallet@^1.0.2:
     scrypt-js "^3.0.1"
     utf8 "^3.0.0"
     uuid "^8.3.2"
+
+ethjs-util@0.1.6, ethjs-util@^0.1.3:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/ethjs-util/-/ethjs-util-0.1.6.tgz#f308b62f185f9fe6237132fb2a9818866a5cd536"
+  integrity sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==
+  dependencies:
+    is-hex-prefixed "1.0.0"
+    strip-hex-prefix "1.0.0"
+
+events@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+  integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
 
 evp_bytestokey@^1.0.3:
   version "1.0.3"
@@ -2620,6 +2705,11 @@ is-glob@^4.0.0, is-glob@^4.0.1:
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-hex-prefixed@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz#7d8d37e6ad77e5d127148913c573e082d777f554"
+  integrity sha1-fY035q135dEnFIkTxXPggtd39VQ=
 
 is-negative-zero@^2.0.1:
   version "2.0.1"
@@ -4065,7 +4155,7 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rlp@^2.2.4:
+rlp@^2.0.0, rlp@^2.2.3, rlp@^2.2.4:
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/rlp/-/rlp-2.2.7.tgz#33f31c4afac81124ac4b283e2bd4d9720b30beaf"
   integrity sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==
@@ -4407,6 +4497,13 @@ strip-final-newline@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
+strip-hex-prefix@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz#0c5f155fef1151373377de9dbb588da05500e36f"
+  integrity sha1-DF8VX+8RUTczd96du1iNoFUA428=
+  dependencies:
+    is-hex-prefixed "1.0.0"
+
 strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
@@ -4581,10 +4678,20 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
+tweetnacl-util@^0.15.0:
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz#b80fcdb5c97bcc508be18c44a4be50f022eea00b"
+  integrity sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==
+
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
+
+tweetnacl@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.3.tgz#ac0af71680458d8a6378d0d0d050ab1407d35596"
+  integrity sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"


### PR DESCRIPTION
This PR attempts to refashion this package from an experimental key derivation module into something that we and our users can trust in production. This is accomplished by (1) adding numerous reference implementation tests (see `test/reference-implementations.test.ts`) and (2) adding new abstractions over our low-level key derivation functions. 

(2) is accomplished by the addition of two new classes, `BIP44Node` and `BIP44CoinTypeNode`, and associated utility functions. The API isn't perfect, but it's extremely easy to use on the address key derivation end, i.e. by our users. See the updated README and unit tests for details. Unit test coverage is at 100%.

This PR will be followed up by an ESLint update to add JSDoc linting, as well as release automation actions and completing repository standardization.

Closes #8
Closes #23