### PR TITLE
Forbid TypeScript interfaces

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,9 @@ module.exports = {
     {
       files: ['*.ts'],
       extends: ['@metamask/eslint-config-typescript'],
+      rules: {
+        '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
+      },
     },
 
     {

--- a/src/BIP44CoinTypeNode.ts
+++ b/src/BIP44CoinTypeNode.ts
@@ -263,7 +263,7 @@ export function deriveBIP44AddressKey(
   ).keyBuffer;
 }
 
-interface BIP44AddressKeyDeriver {
+type BIP44AddressKeyDeriver = {
   /**
    * @param address_index - The `address_index` value.
    * @returns The key corresponding to the path of this deriver and the
@@ -289,7 +289,7 @@ interface BIP44AddressKeyDeriver {
    * The `coin_type` index of addresses derived by this deriver function.
    */
   coin_type: number;
-}
+};
 
 /**
  * Creates a function that derives BIP-44 address keys corresponding to the

--- a/src/BIP44Node.ts
+++ b/src/BIP44Node.ts
@@ -25,7 +25,7 @@ import {
  * cryptographic keys used to generate keypairs and addresses for cryptocurrency
  * protocols.
  */
-export interface JsonBIP44Node {
+export type JsonBIP44Node = {
   /**
    * The 0-indexed BIP-44 path depth of this node.
    *
@@ -43,7 +43,7 @@ export interface JsonBIP44Node {
    * The Base64 string representation of the key material for this node.
    */
   readonly key: string;
-}
+};
 
 export type BIP44NodeInterface = JsonBIP44Node & {
   /**
@@ -58,11 +58,11 @@ export type BIP44NodeInterface = JsonBIP44Node & {
   toJSON(): JsonBIP44Node;
 };
 
-interface BIP44NodeOptions {
+type BIP44NodeOptions = {
   readonly depth?: BIP44Depth;
   readonly key?: Buffer | string;
   readonly derivationPath?: RootedHDPathTuple;
-}
+};
 
 /**
  * A wrapper for BIP-44 Hierarchical Deterministic (HD) tree nodes, i.e.

--- a/src/derivers/bip32.ts
+++ b/src/derivers/bip32.ts
@@ -84,11 +84,11 @@ export function deriveChildKey(pathPart: string, parentKey: Buffer): Buffer {
   return Buffer.concat([privateKey, extraEntropy]);
 }
 
-interface DeriveSecretExtensionArgs {
+type DeriveSecretExtensionArgs = {
   parentPrivateKey: Buffer;
   childIndex: number;
   isHardened: boolean;
-}
+};
 
 // the bip32 secret extension is created from the parent private or public key and the child index
 /**
@@ -121,11 +121,11 @@ function deriveSecretExtension({
   return Buffer.concat([parentPublicKey, indexBuffer]);
 }
 
-interface GenerateKeyArgs {
+type GenerateKeyArgs = {
   parentPrivateKey: Buffer;
   parentExtraEntropy: string | Buffer;
   secretExtension: string | Buffer;
-}
+};
 
 /**
  * @param options

--- a/src/derivers/index.ts
+++ b/src/derivers/index.ts
@@ -1,9 +1,9 @@
 import * as bip32 from './bip32';
 import * as bip39 from './bip39';
 
-export interface Deriver {
+export type Deriver = {
   deriveChildKey: (pathPart: string, parentKey?: Buffer) => Buffer;
-}
+};
 
 export const derivers = {
   bip32,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,12 +29,12 @@ export function getBIP44CoinTypePathString(
   )}'`;
 }
 
-interface BIP44PathIndices {
+type BIP44PathIndices = {
   coin_type: number;
   account?: number;
   change?: number;
   address_index: number;
-}
+};
 
 export type CoinTypeToAddressIndices = Pick<
   BIP44PathIndices,


### PR DESCRIPTION
We hate interfaces, and they must be driven from this Earth in favor of object types.