### PR TITLE
Allow deriving hardened `change` and `address_index`

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ const addressKey0 = addressKeyDeriver(0);
 // m / 44' / 60' / 0' / 0 / 1
 const addressKey1 = addressKeyDeriver(1);
 
+// m / 44' / 60' / 0' / 0 / 2'
+const addressKey2 = addressKeyDeriver(2, true);
+
 // Now, the extended private keys can be used to derive the corresponding public
 // keys and protocol addresses.
 ```

--- a/src/BIP44CoinTypeNode.test.ts
+++ b/src/BIP44CoinTypeNode.test.ts
@@ -578,6 +578,8 @@ describe('deriveBIP44AddressKey', () => {
     [
       {},
       { change: {} },
+      { change: null },
+      { change: undefined },
       { address_index: {} },
       { address_index: 'foo' },
       { address_index: { index: 1 } },

--- a/src/BIP44CoinTypeNode.test.ts
+++ b/src/BIP44CoinTypeNode.test.ts
@@ -651,6 +651,33 @@ describe('getBIP44AddressKeyDeriver', () => {
     expect(deriver(0, true).toString('base64')).toStrictEqual(expectedKey);
   });
 
+  it('returns the expected BIP-44 address key deriver function and derives a hardened index (default inputs, different address_index)', () => {
+    const coinType = 60;
+    const parentNode = new BIP44CoinTypeNode([
+      defaultBip39NodeToken,
+      BIP44PurposeNodeToken,
+      `bip32:${coinType}'`,
+    ]);
+    const expectedPath = `m / bip32:44' / bip32:${coinType}' / bip32:0' / bip32:0`;
+
+    const deriver = getBIP44AddressKeyDeriver(parentNode);
+    expect(deriver.coin_type).toStrictEqual(coinType);
+    expect(deriver.path).toStrictEqual(expectedPath);
+
+    const expectedKey = new BIP44Node({
+      derivationPath: [
+        defaultBip39NodeToken,
+        BIP44PurposeNodeToken,
+        `bip32:${coinType}'`,
+        `bip32:0'`,
+        `bip32:0`,
+        `bip32:9873'`,
+      ],
+    }).key;
+
+    expect(deriver(9873, true).toString('base64')).toStrictEqual(expectedKey);
+  });
+
   it('returns the expected BIP-44 address key deriver function (different coin_type)', () => {
     const coinType = 8129837;
     const parentNode = new BIP44CoinTypeNode([

--- a/src/BIP44CoinTypeNode.test.ts
+++ b/src/BIP44CoinTypeNode.test.ts
@@ -1,4 +1,5 @@
 import fixtures from '../test/fixtures';
+import { BIP_32_HARDENED_OFFSET } from './constants';
 import {
   BIP_44_COIN_TYPE_DEPTH,
   BIP44Node,
@@ -356,6 +357,32 @@ describe('deriveBIP44AddressKey', () => {
     ).toStrictEqual(expectedKey);
   });
 
+  it('derives an address_index key (default inputs, hardened address_index)', () => {
+    const coinType = 60;
+    const parentNode = new BIP44CoinTypeNode([
+      defaultBip39NodeToken,
+      BIP44PurposeNodeToken,
+      `bip32:${coinType}'`,
+    ]);
+
+    const expectedKey = new BIP44Node({
+      derivationPath: [
+        defaultBip39NodeToken,
+        BIP44PurposeNodeToken,
+        `bip32:${coinType}'`,
+        `bip32:0'`,
+        `bip32:0`,
+        `bip32:3333'`,
+      ],
+    }).key;
+
+    expect(
+      deriveBIP44AddressKey(parentNode, {
+        address_index: BIP_32_HARDENED_OFFSET + 3333,
+      }).toString('base64'),
+    ).toStrictEqual(expectedKey);
+  });
+
   it('derives a BIP-44 address key (non-default account value)', () => {
     const coinType = 60;
     const parentNode = new BIP44CoinTypeNode([
@@ -540,6 +567,33 @@ describe('getBIP44AddressKeyDeriver', () => {
     expect(deriver(0).toString('base64')).toStrictEqual(expectedKey);
   });
 
+  it('returns the expected BIP-44 address key deriver function and derives a hardened index (default inputs)', () => {
+    const coinType = 60;
+    const parentNode = new BIP44CoinTypeNode([
+      defaultBip39NodeToken,
+      BIP44PurposeNodeToken,
+      `bip32:${coinType}'`,
+    ]);
+    const expectedPath = `m / bip32:44' / bip32:${coinType}' / bip32:0' / bip32:0`;
+
+    const deriver = getBIP44AddressKeyDeriver(parentNode);
+    expect(deriver.coin_type).toStrictEqual(coinType);
+    expect(deriver.path).toStrictEqual(expectedPath);
+
+    const expectedKey = new BIP44Node({
+      derivationPath: [
+        defaultBip39NodeToken,
+        BIP44PurposeNodeToken,
+        `bip32:${coinType}'`,
+        `bip32:0'`,
+        `bip32:0`,
+        `bip32:0'`,
+      ],
+    }).key;
+
+    expect(deriver(0, true).toString('base64')).toStrictEqual(expectedKey);
+  });
+
   it('returns the expected BIP-44 address key deriver function (different coin_type)', () => {
     const coinType = 8129837;
     const parentNode = new BIP44CoinTypeNode([
@@ -641,6 +695,35 @@ describe('getBIP44AddressKeyDeriver', () => {
         `bip32:${coinType}'`,
         `bip32:0'`,
         `bip32:2`,
+        `bip32:0`,
+      ],
+    }).key;
+
+    expect(deriver(0).toString('base64')).toStrictEqual(expectedKey);
+  });
+
+  it('returns the expected BIP-44 address key deriver function (hardened change value)', () => {
+    const coinType = 60;
+    const parentNode = new BIP44CoinTypeNode([
+      defaultBip39NodeToken,
+      BIP44PurposeNodeToken,
+      `bip32:${coinType}'`,
+    ]);
+    const expectedPath = `m / bip32:44' / bip32:${coinType}' / bip32:0' / bip32:2'`;
+
+    const deriver = getBIP44AddressKeyDeriver(parentNode, {
+      change: BIP_32_HARDENED_OFFSET + 2,
+    });
+    expect(deriver.coin_type).toStrictEqual(coinType);
+    expect(deriver.path).toStrictEqual(expectedPath);
+
+    const expectedKey = new BIP44Node({
+      derivationPath: [
+        defaultBip39NodeToken,
+        BIP44PurposeNodeToken,
+        `bip32:${coinType}'`,
+        `bip32:0'`,
+        `bip32:2'`,
         `bip32:0`,
       ],
     }).key;

--- a/src/BIP44CoinTypeNode.ts
+++ b/src/BIP44CoinTypeNode.ts
@@ -20,6 +20,7 @@ import {
   getHardenedBIP32NodeToken,
   getUnhardenedBIP32NodeToken,
   getBIP44ChangePathString,
+  getBIP32NodeToken,
 } from './utils';
 
 export type CoinTypeHDPathTuple = [
@@ -266,10 +267,11 @@ export function deriveBIP44AddressKey(
 type BIP44AddressKeyDeriver = {
   /**
    * @param address_index - The `address_index` value.
+   * @param isHardened - Whether the derived index is hardened.
    * @returns The key corresponding to the path of this deriver and the
    * specified `address_index` value.
    */
-  (address_index: number): Buffer;
+  (address_index: number, isHardened?: boolean): Buffer;
 
   /**
    * A human-readable representation of the derivation path of this deriver
@@ -326,13 +328,18 @@ export function getBIP44AddressKeyDeriver(
       : base64StringToBuffer(key);
 
   const accountNode = getHardenedBIP32NodeToken(account);
-  const changeNode = getUnhardenedBIP32NodeToken(change);
+  const changeNode = getBIP32NodeToken(change);
 
-  const bip44AddressKeyDeriver = (address_index: number): Buffer => {
+  const bip44AddressKeyDeriver = (
+    address_index: number,
+    isHardened = false,
+  ): Buffer => {
     return deriveChildNode(parentKeyBuffer, BIP_44_COIN_TYPE_DEPTH, [
       accountNode,
       changeNode,
-      getUnhardenedBIP32NodeToken(address_index),
+      isHardened
+        ? getHardenedBIP32NodeToken(address_index)
+        : getUnhardenedBIP32NodeToken(address_index),
     ]).keyBuffer;
   };
 

--- a/src/BIP44Node.test.ts
+++ b/src/BIP44Node.test.ts
@@ -222,7 +222,7 @@ describe('BIP44Node', () => {
       );
     });
 
-    it('throws if the depth 4 node of the derivation path is not an unhardened BIP-32 node', () => {
+    it('throws if the depth 4 node of the derivation path is not a BIP-32 node', () => {
       expect(
         () =>
           new BIP44Node({
@@ -231,15 +231,15 @@ describe('BIP44Node', () => {
               BIP44PurposeNodeToken,
               `bip32:60'`,
               `bip32:0'`,
-              `bip32:0'`,
-            ] as any,
+              `bip32:-1`,
+            ],
           }),
       ).toThrow(
-        'Invalid derivation path: The "change" node (depth 4) must be an unhardened BIP-32 node.',
+        'Invalid derivation path: The "change" node (depth 4) must be a BIP-32 node.',
       );
     });
 
-    it('throws if the depth 5 node of the derivation path is not an unhardened BIP-32 node', () => {
+    it('throws if the depth 5 node of the derivation path is not a BIP-32 node', () => {
       expect(
         () =>
           new BIP44Node({
@@ -249,11 +249,11 @@ describe('BIP44Node', () => {
               `bip32:60'`,
               `bip32:0'`,
               `bip32:0`,
-              `bip32:0'`,
-            ] as any,
+              `bip32:-1`,
+            ],
           }),
       ).toThrow(
-        'Invalid derivation path: The "address_index" node (depth 5) must be an unhardened BIP-32 node.',
+        'Invalid derivation path: The "address_index" node (depth 5) must be a BIP-32 node.',
       );
     });
 
@@ -381,7 +381,7 @@ describe('BIP44Node', () => {
       );
     });
 
-    it('throws if the depth 4 node of the derivation path is not an unhardened BIP-32 node', () => {
+    it('throws if the depth 4 node of the derivation path is not a BIP-32 node', () => {
       expect(() =>
         new BIP44Node({
           derivationPath: [
@@ -390,13 +390,13 @@ describe('BIP44Node', () => {
             `bip32:60'`,
             `bip32:0'`,
           ],
-        }).derive([`bip32:0'`]),
+        }).derive([`bip32:-1'`]),
       ).toThrow(
-        'Invalid derivation path: The "change" node (depth 4) must be an unhardened BIP-32 node.',
+        'Invalid derivation path: The "change" node (depth 4) must be a BIP-32 node.',
       );
     });
 
-    it('throws if the depth 5 node of the derivation path is not an unhardened BIP-32 node', () => {
+    it('throws if the depth 5 node of the derivation path is not a BIP-32 node', () => {
       expect(() =>
         new BIP44Node({
           derivationPath: [
@@ -406,9 +406,9 @@ describe('BIP44Node', () => {
             `bip32:0'`,
             `bip32:0`,
           ],
-        }).derive([`bip32:0'`]),
+        }).derive([`bip32:-1`]),
       ).toThrow(
-        'Invalid derivation path: The "address_index" node (depth 5) must be an unhardened BIP-32 node.',
+        'Invalid derivation path: The "address_index" node (depth 5) must be a BIP-32 node.',
       );
     });
   });

--- a/src/BIP44Node.ts
+++ b/src/BIP44Node.ts
@@ -337,17 +337,17 @@ function validateBIP44DerivationPath(
         break;
 
       case 4:
-        if (!BIP_32_PATH_REGEX.test(nodeToken) || isHardened(nodeToken)) {
+        if (!BIP_32_PATH_REGEX.test(nodeToken)) {
           throw new Error(
-            'Invalid derivation path: The "change" node (depth 4) must be an unhardened BIP-32 node.',
+            'Invalid derivation path: The "change" node (depth 4) must be a BIP-32 node.',
           );
         }
         break;
 
       case MAX_BIP_44_DEPTH: // 5
-        if (!BIP_32_PATH_REGEX.test(nodeToken) || isHardened(nodeToken)) {
+        if (!BIP_32_PATH_REGEX.test(nodeToken)) {
           throw new Error(
-            'Invalid derivation path: The "address_index" node (depth 5) must be an unhardened BIP-32 node.',
+            'Invalid derivation path: The "address_index" node (depth 5) must be a BIP-32 node.',
           );
         }
         break;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,8 +11,8 @@ export const HEXADECIMAL_KEY_LENGTH = 128 as const;
 export const BASE_64_REGEX =
   /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$/u;
 
-export const MIN_BIP_44_DEPTH = 0 as const;
-export const MAX_BIP_44_DEPTH = 5 as const;
+export const MIN_BIP_44_DEPTH = 0;
+export const MAX_BIP_44_DEPTH = 5;
 
 export type MinBIP44Depth = typeof MIN_BIP_44_DEPTH;
 export type MaxBIP44Depth = typeof MAX_BIP_44_DEPTH;
@@ -50,12 +50,14 @@ export const BIP_32_PATH_REGEX = /^bip32:\d+'?$/u;
  */
 export const BIP_39_PATH_REGEX = /^bip39:([a-z]+){1}( [a-z]+){11,23}$/u;
 
+export const BIP_32_HARDENED_OFFSET = 0x80000000;
+
 type HDPathString0 = AnonymizedBIP39Node;
 type HDPathString1 = `${HDPathString0} / ${HardenedBIP32Node}`;
 type HDPathString2 = `${HDPathString1} / ${HardenedBIP32Node}`;
 type HDPathString3 = `${HDPathString2} / ${HardenedBIP32Node}`;
-type HDPathString4 = `${HDPathString3} / ${UnhardenedBIP32Node}`;
-type HDPathString5 = `${HDPathString4} / ${UnhardenedBIP32Node}`;
+type HDPathString4 = `${HDPathString3} / ${BIP32Node}`;
+type HDPathString5 = `${HDPathString4} / ${BIP32Node}`;
 
 export type CoinTypeHDPathString = HDPathString2;
 export type ChangeHDPathString = HDPathString4;
@@ -73,8 +75,8 @@ type RootedHDPathTuple0 = readonly [BIP39Node];
 type RootedHDPathTuple1 = readonly [...RootedHDPathTuple0, HardenedBIP32Node];
 type RootedHDPathTuple2 = readonly [...RootedHDPathTuple1, HardenedBIP32Node];
 type RootedHDPathTuple3 = readonly [...RootedHDPathTuple2, HardenedBIP32Node];
-type RootedHDPathTuple4 = readonly [...RootedHDPathTuple3, UnhardenedBIP32Node];
-type RootedHDPathTuple5 = readonly [...RootedHDPathTuple4, UnhardenedBIP32Node];
+type RootedHDPathTuple4 = readonly [...RootedHDPathTuple3, BIP32Node];
+type RootedHDPathTuple5 = readonly [...RootedHDPathTuple4, BIP32Node];
 
 export type RootedHDPathTuple =
   | RootedHDPathTuple0
@@ -87,32 +89,22 @@ export type RootedHDPathTuple =
 type PartialHDPathTuple1 = readonly [HardenedBIP32Node];
 type PartialHDPathTuple2 = readonly [...PartialHDPathTuple1, HardenedBIP32Node];
 type PartialHDPathTuple3 = readonly [...PartialHDPathTuple2, HardenedBIP32Node];
-type PartialHDPathTuple4 = readonly [
-  ...PartialHDPathTuple3,
-  UnhardenedBIP32Node,
-];
-type PartialHDPathTuple5 = readonly [
-  ...PartialHDPathTuple4,
-  UnhardenedBIP32Node,
-];
-type PartialHDPathTuple6 = readonly [UnhardenedBIP32Node];
-type PartialHDPathTuple7 = readonly [UnhardenedBIP32Node, UnhardenedBIP32Node];
-type PartialHDPathTuple8 = readonly [
-  HardenedBIP32Node,
-  UnhardenedBIP32Node,
-  UnhardenedBIP32Node,
-];
-type PartialHDPathTuple9 = readonly [HardenedBIP32Node, UnhardenedBIP32Node];
+type PartialHDPathTuple4 = readonly [...PartialHDPathTuple3, BIP32Node];
+type PartialHDPathTuple5 = readonly [...PartialHDPathTuple4, BIP32Node];
+type PartialHDPathTuple6 = readonly [BIP32Node];
+type PartialHDPathTuple7 = readonly [BIP32Node, BIP32Node];
+type PartialHDPathTuple8 = readonly [HardenedBIP32Node, BIP32Node, BIP32Node];
+type PartialHDPathTuple9 = readonly [HardenedBIP32Node, BIP32Node];
 type PartialHDPathTuple10 = readonly [
   HardenedBIP32Node,
   HardenedBIP32Node,
-  UnhardenedBIP32Node,
+  BIP32Node,
 ];
 type PartialHDPathTuple11 = readonly [
   HardenedBIP32Node,
   HardenedBIP32Node,
-  UnhardenedBIP32Node,
-  UnhardenedBIP32Node,
+  BIP32Node,
+  BIP32Node,
 ];
 
 export type CoinTypeToAddressTuple = PartialHDPathTuple8;

--- a/src/derivers/bip32.ts
+++ b/src/derivers/bip32.ts
@@ -2,10 +2,8 @@ import { CURVE, getPublicKey, utils as secp256k1Utils } from '@noble/secp256k1';
 import { keccak_256 as keccak256 } from '@noble/hashes/sha3';
 import { hmac } from '@noble/hashes/hmac';
 import { sha512 } from '@noble/hashes/sha512';
-import { BUFFER_KEY_LENGTH } from '../constants';
+import { BUFFER_KEY_LENGTH, BIP_32_HARDENED_OFFSET } from '../constants';
 import { bytesToNumber, hexStringToBuffer, isValidBufferKey } from '../utils';
-
-const HARDENED_OFFSET = 0x80000000;
 
 /**
  * Converts a BIP-32 private key to an Ethereum address.
@@ -49,10 +47,10 @@ export function deriveChildKey(pathPart: string, parentKey: Buffer): Buffer {
     !/^\d+$/u.test(indexPart) ||
     !Number.isInteger(childIndex) ||
     childIndex < 0 ||
-    childIndex >= HARDENED_OFFSET
+    childIndex >= BIP_32_HARDENED_OFFSET
   ) {
     throw new Error(
-      `Invalid BIP-32 index: The index must be a non-negative decimal integer less than ${HARDENED_OFFSET}.`,
+      `Invalid BIP-32 index: The index must be a non-negative decimal integer less than ${BIP_32_HARDENED_OFFSET}.`,
     );
   }
 
@@ -94,7 +92,7 @@ function deriveSecretExtension({
   if (isHardened) {
     // Hardened child
     const indexBuffer = Buffer.allocUnsafe(4);
-    indexBuffer.writeUInt32BE(childIndex + HARDENED_OFFSET, 0);
+    indexBuffer.writeUInt32BE(childIndex + BIP_32_HARDENED_OFFSET, 0);
     const pk = parentPrivateKey;
     const zb = Buffer.alloc(1, 0);
     return Buffer.concat([zb, pk, indexBuffer]);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -117,7 +117,7 @@ export function getUnhardenedBIP32NodeToken(
 }
 
 /**
- * An hardened or unhardened BIP-32 node token, e.g. `bip32:0` or `bip32:0'`.
+ * A hardened or unhardened BIP-32 node token, e.g. `bip32:0` or `bip32:0'`.
  * Validates that the index is a non-negative integer number, and throws an
  * error if validation fails.
  *

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,14 +3,16 @@ import {
   BASE_64_KEY_LENGTH,
   BASE_64_REGEX,
   BASE_64_ZERO,
-  BUFFER_KEY_LENGTH,
+  BIP32Node,
   BIP44PurposeNodeToken,
-  UnhardenedBIP32Node,
+  BIP_32_HARDENED_OFFSET,
+  BUFFER_KEY_LENGTH,
+  ChangeHDPathString,
   CoinTypeHDPathString,
   CoinTypeToAddressTuple,
   HardenedBIP32Node,
-  ChangeHDPathString,
   HEXADECIMAL_KEY_LENGTH,
+  UnhardenedBIP32Node,
 } from './constants';
 
 /**
@@ -59,7 +61,7 @@ export function getBIP44ChangePathString(
 ): ChangeHDPathString {
   return `${coinTypePath} / ${getHardenedBIP32NodeToken(
     indices.account || 0,
-  )} / ${getUnhardenedBIP32NodeToken(indices.change || 0)}`;
+  )} / ${getBIP32NodeToken(indices.change || 0)}`;
 }
 
 /**
@@ -80,8 +82,8 @@ export function getBIP44CoinTypeToAddressPathTuple({
 }: CoinTypeToAddressIndices): CoinTypeToAddressTuple {
   return [
     getHardenedBIP32NodeToken(account),
-    getUnhardenedBIP32NodeToken(change),
-    getUnhardenedBIP32NodeToken(address_index),
+    getBIP32NodeToken(change),
+    getBIP32NodeToken(address_index),
   ] as const;
 }
 
@@ -111,6 +113,22 @@ export function getUnhardenedBIP32NodeToken(
 ): UnhardenedBIP32Node {
   validateBIP32Index(index);
   return `bip32:${index}`;
+}
+
+/**
+ * An hardened or unhardened BIP-32 node token, e.g. `bip32:0` or `bip32:0'`.
+ * Validates that the index is a non-negative integer number, and throws an
+ * error if validation fails.
+ *
+ * @param index - The index of the node.
+ * @returns The hardened or unhardened BIP-32 node token.
+ */
+export function getBIP32NodeToken(index: number): BIP32Node {
+  if (isHardenedIndex(index)) {
+    return getHardenedBIP32NodeToken(index - BIP_32_HARDENED_OFFSET);
+  }
+
+  return getUnhardenedBIP32NodeToken(index);
 }
 
 /**
@@ -268,4 +286,14 @@ export function isValidBase64StringKey(stringKey: string): boolean {
  */
 export function bytesToNumber(bytes: Uint8Array): bigint {
   return BigInt(`0x${bytesToHex(bytes)}`);
+}
+
+/**
+ * Tests whether a BIP-32 index is a hardened index.
+ *
+ * @param index - The BIP-32 index to test.
+ * @returns Whether the index is a hardened index.
+ */
+export function isHardenedIndex(index: number): boolean {
+  return index >= BIP_32_HARDENED_OFFSET;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -130,7 +130,7 @@ export function getBIP32NodeToken(index: BIP44PathIndex): BIP32Node {
   }
 
   if (
-    typeof index !== 'object' ||
+    !index ||
     !Number.isInteger(index.index) ||
     typeof index.hardened !== 'boolean'
   ) {


### PR DESCRIPTION
This makes it possible to use a hardened `change` and `address_index`.

- Changed types to allow both hardened and unhardened indices for these paths.
- Changed some validation functions to allow both hardened and unhardened indices for these paths.
- Added an option `isHardened` to the deriver function, to derive a hardened `address_index`.

Closes #34.