### PR TITLE
Extract build-only TypeScript configuration

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,11 +12,6 @@ module.exports = {
       statements: 100,
     },
   },
-  globals: {
-    'ts-jest': {
-      tsconfig: 'tsconfig.test.json',
-    },
-  },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],
   preset: 'ts-jest',
   // "resetMocks" resets all mocks, including mocked modules, to jest.fn(),

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dist/"
   ],
   "scripts": {
-    "build": "tsc --project .",
+    "build": "tsc --project tsconfig.build.json",
     "build:clean": "rimraf dist && yarn build",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:eslint": "eslint . --cache --ext js,ts",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "exclude": ["**/*.test.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,13 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "esModuleInterop": true,
     "inlineSources": true,
     "lib": ["ES2020"],
     "module": "CommonJS",
     "moduleResolution": "Node",
-    "outDir": "dist",
-    "rootDir": "src",
     "sourceMap": true,
     "strict": true,
     "target": "ES2017"
   },
-  "exclude": ["./src/**/*.test.ts"],
-  "include": ["./src/**/*.ts"]
+  "include": ["src"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "typeRoots": ["./node_modules/@types", "./test/types"]
-  }
-}


### PR DESCRIPTION
Based on MetaMask/controllers#732. Closes #47.

I also removed `tsconfig.test.json` since it doesn't seem to make any difference for running tests.