### PR TITLE
Add convenience methods for public keys and addresses

### DIFF
--- a/src/BIP44CoinTypeNode.test.ts
+++ b/src/BIP44CoinTypeNode.test.ts
@@ -1,6 +1,4 @@
 import fixtures from '../test/fixtures';
-import { createBip39KeyFromSeed } from './derivers/bip39';
-import { hexStringToBuffer } from './utils';
 import {
   BIP_44_COIN_TYPE_DEPTH,
   BIP44Node,

--- a/src/BIP44CoinTypeNode.test.ts
+++ b/src/BIP44CoinTypeNode.test.ts
@@ -1,4 +1,6 @@
 import fixtures from '../test/fixtures';
+import { createBip39KeyFromSeed } from './derivers/bip39';
+import { hexStringToBuffer } from './utils';
 import {
   BIP_44_COIN_TYPE_DEPTH,
   BIP44Node,
@@ -295,6 +297,42 @@ describe('BIP44CoinTypeNode', () => {
           })
         ).toString('base64'),
       ).toStrictEqual(expectedKey);
+    });
+  });
+
+  describe('getPublicKey', () => {
+    it('returns the public key for a node', async () => {
+      const coinType = 60;
+      const node = await BIP44Node.create({
+        derivationPath: [
+          defaultBip39NodeToken,
+          BIP44PurposeNodeToken,
+          `bip32:${coinType}'`,
+        ],
+      });
+
+      const parentNode = await BIP44CoinTypeNode.create(node, coinType);
+      const expectedKey = await node.getPublicKey();
+
+      expect(await parentNode.getPublicKey()).toBe(expectedKey);
+    });
+  });
+
+  describe('getAddress', () => {
+    it('returns an Ethereum address for a node', async () => {
+      const coinType = 60;
+      const node = await BIP44Node.create({
+        derivationPath: [
+          defaultBip39NodeToken,
+          BIP44PurposeNodeToken,
+          `bip32:${coinType}'`,
+        ],
+      });
+
+      const parentNode = await BIP44CoinTypeNode.create(node, coinType);
+      const expectedKey = await node.getAddress();
+
+      expect(await parentNode.getAddress()).toBe(expectedKey);
     });
   });
 

--- a/src/BIP44CoinTypeNode.ts
+++ b/src/BIP44CoinTypeNode.ts
@@ -141,6 +141,14 @@ export class BIP44CoinTypeNode implements BIP44CoinTypeNodeInterface {
     return this.#node.keyBuffer;
   }
 
+  public getPublicKey(compressed?: boolean) {
+    return this.#node.getPublicKey(compressed);
+  }
+
+  public getAddress() {
+    return this.#node.getAddress();
+  }
+
   public readonly path: CoinTypeHDPathString;
 
   public readonly coin_type: number;

--- a/src/BIP44Node.test.ts
+++ b/src/BIP44Node.test.ts
@@ -1,4 +1,6 @@
 import fixtures from '../test/fixtures';
+import { createBip39KeyFromSeed } from './derivers/bip39';
+import { hexStringToBuffer } from './utils';
 import { BIP44Node, BIP44PurposeNodeToken } from '.';
 
 const defaultBip39NodeToken = `bip39:${fixtures.local.mnemonic}` as const;
@@ -397,6 +399,54 @@ describe('BIP44Node', () => {
         'Invalid derivation path: The "address_index" node (depth 5) must be a BIP-32 node.',
       );
     });
+  });
+
+  describe('getPublicKey', () => {
+    const { hexSeed, path, sampleAddressIndices } =
+      fixtures['ethereumjs-wallet'];
+
+    it.each(sampleAddressIndices)(
+      'returns the public key for an secp256k1 node',
+      async ({ index, publicKey }) => {
+        const seedKey = createBip39KeyFromSeed(hexStringToBuffer(hexSeed));
+
+        const node = await BIP44Node.create({
+          key: seedKey,
+          depth: 0,
+        });
+
+        const childNode = await node.derive([
+          ...path.ours.tuple,
+          `bip32:${index}`,
+        ]);
+
+        expect(await childNode.getPublicKey()).toBe(publicKey);
+      },
+    );
+  });
+
+  describe('getAddress', () => {
+    const { hexSeed, path, sampleAddressIndices } =
+      fixtures['ethereumjs-wallet'];
+
+    it.each(sampleAddressIndices)(
+      'returns the address for an secp256k1 node',
+      async ({ index, address }) => {
+        const seedKey = createBip39KeyFromSeed(hexStringToBuffer(hexSeed));
+
+        const node = await BIP44Node.create({
+          key: seedKey,
+          depth: 0,
+        });
+
+        const childNode = await node.derive([
+          ...path.ours.tuple,
+          `bip32:${index}`,
+        ]);
+
+        expect(await childNode.getAddress()).toBe(address);
+      },
+    );
   });
 
   describe('toJSON', () => {

--- a/src/BIP44Node.ts
+++ b/src/BIP44Node.ts
@@ -196,8 +196,16 @@ export class BIP44Node implements BIP44NodeInterface {
     return new BIP44Node(node);
   }
 
+  public getPublicKey(compressed?: boolean) {
+    return this.#node.getPublicKey(compressed);
+  }
+
+  public getAddress() {
+    return this.#node.getAddress();
+  }
+
   // This is documented in the interface of this class.
-  toJSON(): JsonBIP44Node {
+  public toJSON(): JsonBIP44Node {
     return {
       depth: this.depth,
       key: this.key,

--- a/src/SLIP10Node.ts
+++ b/src/SLIP10Node.ts
@@ -154,6 +154,8 @@ export class SLIP10Node implements SLIP10NodeInterface {
   }
 
   get #privateKeyBuffer(): Buffer {
+    // `keyBuffer` consists of both the private key (first 32 bytes) and chain code
+    // (last 32 bytes), so we slice off the chain code here.
     return this.keyBuffer.slice(0, 32);
   }
 

--- a/src/SLIP10Node.ts
+++ b/src/SLIP10Node.ts
@@ -9,6 +9,7 @@ import {
   isValidHexStringKey,
 } from './utils';
 import { deriveKeyFromPath } from './derivation';
+import { privateKeyToEthAddress } from './derivers/bip32';
 
 /**
  * A wrapper for SLIP-10 Hierarchical Deterministic (HD) tree nodes, i.e.
@@ -152,6 +153,10 @@ export class SLIP10Node implements SLIP10NodeInterface {
     return bufferToBase64String(this.keyBuffer);
   }
 
+  get #privateKeyBuffer(): Buffer {
+    return this.keyBuffer.slice(0, 32);
+  }
+
   constructor({ depth, key, curve }: SLIP10NodeConstructorOptions) {
     this.depth = depth;
     this.keyBuffer = key;
@@ -185,8 +190,27 @@ export class SLIP10Node implements SLIP10NodeInterface {
     });
   }
 
+  public async getPublicKey(compressed = false): Promise<string> {
+    const publicKey = await this.curve.getPublicKey(
+      this.#privateKeyBuffer,
+      compressed,
+    );
+
+    return publicKey.toString('hex');
+  }
+
+  public async getAddress(): Promise<string> {
+    if (this.curve.name !== 'secp256k1') {
+      throw new Error(
+        'Unable to get address for this node: Only secp256k1 is supported.',
+      );
+    }
+
+    return privateKeyToEthAddress(this.keyBuffer).toString('hex');
+  }
+
   // This is documented in the interface of this class.
-  toJSON(): JsonSLIP10Node {
+  public toJSON(): JsonSLIP10Node {
     return {
       depth: this.depth,
       key: this.key,

--- a/src/derivers/bip32.ts
+++ b/src/derivers/bip32.ts
@@ -17,13 +17,13 @@ import { Curve, mod, secp256k1 } from '../curves';
  * @param curve - The curve to use.
  * @returns The Ethereum address corresponding to the given key.
  */
-export function privateKeyToEthAddress(key: Buffer, curve = secp256k1) {
+export function privateKeyToEthAddress(key: Buffer) {
   if (!Buffer.isBuffer(key) || !isValidBufferKey(key)) {
     throw new Error('Invalid key: The key must be a 64-byte, non-zero Buffer.');
   }
 
   const privateKey = key.slice(0, 32);
-  const publicKey = curve.getPublicKey(privateKey, false).slice(1);
+  const publicKey = secp256k1.getPublicKey(privateKey, false).slice(1);
   return Buffer.from(keccak256(Buffer.from(publicKey)).slice(-20));
 }
 

--- a/src/derivers/bip32.ts
+++ b/src/derivers/bip32.ts
@@ -14,7 +14,6 @@ import { Curve, mod, secp256k1 } from '../curves';
  *
  * @param key - The `address_index` key buffer to convert to an Ethereum
  * address.
- * @param curve - The curve to use.
  * @returns The Ethereum address corresponding to the given key.
  */
 export function privateKeyToEthAddress(key: Buffer) {

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -49,34 +49,50 @@ export default {
       {
         index: 0,
         address: 'c5ba325f997531b5f0f50868913f0ce2fc0386bd',
+        publicKey:
+          '0438e5105bf4d908b40743bd3fc0e8e4ac281872086bf3323dfb4459a8b147aaa74b2b6624479ce069d60ff41336ce7eb0613f66ee91ba72a7581144134d814624',
       },
       {
         index: 1,
         address: '326aa42f2b600f624d800e109b1e146906bc8175',
+        publicKey:
+          '04fcdae40d78db4aaa196c8f421f9d9243934f4abc69de95dd27522e275de7276b486b6219ad930775127a5645a226a716a52accc456cd93ea82f56ee98994cf6e',
       },
       {
         index: 5,
         address: '6d0cc8671c91559d5f2d43de9c33eee0497db7cd',
+        publicKey:
+          '04226d57014fd0e9eea04a6de8e2071b111b42a102e416f21529698acfec7b78a0ba774dd957dfb6c71f3c597b7cb3ee9c08eeb48f7bf34a8dc24319d743339346',
       },
       {
         index: 50,
         address: '7bf971adda7f4487ac8f3dbd7450463ff3624f94',
+        publicKey:
+          '04c7fa0b4154bcb1e2d854c035ba591c3b87ccfbf3fafd0ed30585a1f843e79efcea470920b3fba70524b8a9854ddcfa05192de7d54154e28a8156b5d83a3a7883',
       },
       {
         index: 500,
         address: '564d7507d39a881d04bffc0120ebd331e7c41758',
+        publicKey:
+          '0461091945ed21fa036f0e97b4135fc01fb936910989519ba9a8c1c0867f3b34fbe6941f8529d1771532d79fdb2060cecaa12f12323086aec6eeb2ba9a9d9af3e9',
       },
       {
         index: 5000,
         address: '7496ff062c1fe3e750dff9cbbe317558161ba6db',
+        publicKey:
+          '04cceed14fef73e6c61e648761df3489e6cd87dfbcfa20241fd001675654ecb3d8a0d3b50410a9444de6d38af04f28add1ae12280889b5816dfc66a597cea539ec',
       },
       {
         index: 4_999_999,
         address: 'ddf1f1a72a668d5014ec57a24019291fd2a00197',
+        publicKey:
+          '04b1eed5ab048a7de8939c1a9536d04076982454d7883ec665e4e7da4d457f99842df19468193267e93ec3e4faa5be9602072a6aad69de0f1687a5f1ea57a93a4c',
       },
       {
         index: 5_000_000,
         address: '24dd12b9df5375f3b7fc5a539d4ac1bd2c16e9a0',
+        publicKey:
+          '04e2ddbc99b6e0f8fc4e62242e375a49a8d856d6865607db474d444d4b729e28e3c80172acc9473b8ba6eaa7c893864589df35ca10d42ca9937cd6c77768871374',
       },
     ],
   },

--- a/test/reference-implementations.test.ts
+++ b/test/reference-implementations.test.ts
@@ -33,9 +33,7 @@ describe('reference implementation tests', () => {
             getBIP44CoinTypeToAddressPathTuple({ address_index: index }),
           );
 
-          expect(
-            privateKeyToEthAddress(childNode.keyBuffer).toString('hex'),
-          ).toStrictEqual(expectedAddress);
+          expect(await childNode.getAddress()).toStrictEqual(expectedAddress);
         }
       });
     });
@@ -83,13 +81,9 @@ describe('reference implementation tests', () => {
         const ourAccounts = [];
         for (let i = 0; i < numberOfAccounts; i++) {
           ourAccounts.push(
-            privateKeyToEthAddress(
-              (
-                await node.derive(
-                  getBIP44CoinTypeToAddressPathTuple({ address_index: i }),
-                )
-              ).keyBuffer,
-            ).toString('hex'),
+            await node
+              .derive(getBIP44CoinTypeToAddressPathTuple({ address_index: i }))
+              .then((childNode) => childNode.getAddress()),
           );
         }
 
@@ -147,9 +141,7 @@ describe('reference implementation tests', () => {
           privateKey,
         );
 
-        expect(
-          privateKeyToEthAddress(node.keyBuffer).toString('hex'),
-        ).toStrictEqual(address);
+        expect(await node.getAddress()).toStrictEqual(address);
 
         for (const { index, address: theirAddress } of sampleAddressIndices) {
           const ourAddress = privateKeyToEthAddress(
@@ -290,9 +282,9 @@ describe('reference implementation tests', () => {
               theirPrivateKey,
             );
 
-            expect(
-              (await ed25519.getPublicKey(ourPrivateKey)).toString('hex'),
-            ).toStrictEqual(theirPublicKey);
+            expect(await childNode.getPublicKey()).toStrictEqual(
+              theirPublicKey,
+            );
           }
         });
       });


### PR DESCRIPTION
~~Needs to be rebased after #43 is merged.~~ Done.

This PR adds convenience methods to get the (Ethereum) address and public key from an HD node.

**Why use a function instead of a getter?**
The method for deriving a public key from a private key can be async (in the case of `ed25519` for example), so it had to be an async function.

Closes #45.