### PR TITLE
Add support for public key derivation

### DIFF
--- a/src/BIP44CoinTypeNode.ts
+++ b/src/BIP44CoinTypeNode.ts
@@ -294,25 +294,31 @@ export async function deriveBIP44AddressKey(
 ): Promise<ChildNode> {
   validateCoinTypeNodeDepth(parentKeyOrNode.depth);
 
+  const options = {
+    depth: BIP_44_COIN_TYPE_DEPTH,
+    path: getBIP44CoinTypeToAddressPathTuple({
+      account,
+      change,
+      address_index,
+    }),
+    curve: secp256k1,
+  };
+
   if (parentKeyOrNode instanceof BIP44CoinTypeNode) {
-    return await deriveChildNode(
-      parentKeyOrNode.privateKeyBuffer,
-      parentKeyOrNode.publicKeyBuffer,
-      parentKeyOrNode.chainCodeBuffer,
-      BIP_44_COIN_TYPE_DEPTH,
-      getBIP44CoinTypeToAddressPathTuple({ account, change, address_index }),
-      secp256k1,
-    );
+    return await deriveChildNode({
+      privateKey: parentKeyOrNode.privateKeyBuffer,
+      publicKey: parentKeyOrNode.publicKeyBuffer,
+      chainCode: parentKeyOrNode.chainCodeBuffer,
+      ...options,
+    });
   }
 
-  return await deriveChildNode(
-    nullableHexStringToBuffer(parentKeyOrNode.privateKey),
-    hexStringToBuffer(parentKeyOrNode.publicKey),
-    hexStringToBuffer(parentKeyOrNode.chainCode),
-    BIP_44_COIN_TYPE_DEPTH,
-    getBIP44CoinTypeToAddressPathTuple({ account, change, address_index }),
-    secp256k1,
-  );
+  return await deriveChildNode({
+    privateKey: nullableHexStringToBuffer(parentKeyOrNode.privateKey),
+    publicKey: hexStringToBuffer(parentKeyOrNode.publicKey),
+    chainCode: hexStringToBuffer(parentKeyOrNode.chainCode),
+    ...options,
+  });
 }
 
 type BIP44AddressKeyDeriver = {
@@ -394,20 +400,20 @@ export function getBIP44AddressKeyDeriver(
     address_index: number,
     isHardened = false,
   ): Promise<ChildNode> => {
-    return await deriveChildNode(
-      parentKeyBuffer,
-      parentPublicKeyBuffer,
-      parentChainCodeBuffer,
-      BIP_44_COIN_TYPE_DEPTH,
-      [
+    return await deriveChildNode({
+      privateKey: parentKeyBuffer,
+      publicKey: parentPublicKeyBuffer,
+      chainCode: parentChainCodeBuffer,
+      depth: BIP_44_COIN_TYPE_DEPTH,
+      path: [
         accountNode,
         changeNode,
         isHardened
           ? getHardenedBIP32NodeToken(address_index)
           : getUnhardenedBIP32NodeToken(address_index),
       ],
-      secp256k1,
-    );
+      curve: secp256k1,
+    });
   };
 
   bip44AddressKeyDeriver.coin_type = node.coin_type;

--- a/src/BIP44Node.test.ts
+++ b/src/BIP44Node.test.ts
@@ -207,6 +207,36 @@ describe('BIP44Node', () => {
       });
     });
 
+    it('derives a public child node', async () => {
+      const coinTypeNode = `bip32:40'`;
+      const targetNode = await BIP44Node.fromDerivationPath({
+        derivationPath: [
+          defaultBip39NodeToken,
+          BIP44PurposeNodeToken,
+          coinTypeNode,
+          `bip32:0'`,
+          `bip32:0`,
+        ],
+      });
+
+      const node = await BIP44Node.fromDerivationPath({
+        derivationPath: [
+          defaultBip39NodeToken,
+          BIP44PurposeNodeToken,
+          coinTypeNode,
+          `bip32:0'`,
+        ],
+      });
+
+      const childNode = await node.neuter().derive([`bip32:0`]);
+
+      expect(childNode.privateKey).toBeUndefined();
+      expect(childNode).toMatchObject({
+        depth: targetNode.depth,
+        publicKey: targetNode.publicKey,
+      });
+    });
+
     it('throws if the parent node is already a leaf node', async () => {
       const node = await BIP44Node.fromDerivationPath({
         derivationPath: [

--- a/src/BIP44Node.test.ts
+++ b/src/BIP44Node.test.ts
@@ -1,7 +1,7 @@
 import fixtures from '../test/fixtures';
 import { createBip39KeyFromSeed, deriveChildKey } from './derivers/bip39';
 import { hexStringToBuffer } from './utils';
-import { BIP44Node, BIP44PurposeNodeToken, SLIP10Node } from '.';
+import { BIP44Node, BIP44PurposeNodeToken } from '.';
 
 const defaultBip39NodeToken = `bip39:${fixtures.local.mnemonic}` as const;
 

--- a/src/BIP44Node.ts
+++ b/src/BIP44Node.ts
@@ -193,6 +193,20 @@ export class BIP44Node implements BIP44NodeInterface {
   }
 
   /**
+   * Returns a neutered version of this node, i.e. a node without a private key.
+   */
+  public neuter(): BIP44Node {
+    const node = new SLIP10Node({
+      depth: this.depth,
+      chainCode: this.chainCodeBuffer,
+      publicKey: this.publicKeyBuffer,
+      curve: this.#node.curve,
+    });
+
+    return new BIP44Node(node);
+  }
+
+  /**
    * Derives a child of the key contains be this node and returns a new
    * {@link BIP44Node} containing the child key.
    *

--- a/src/BIP44Node.ts
+++ b/src/BIP44Node.ts
@@ -196,13 +196,7 @@ export class BIP44Node implements BIP44NodeInterface {
    * Returns a neutered version of this node, i.e. a node without a private key.
    */
   public neuter(): BIP44Node {
-    const node = new SLIP10Node({
-      depth: this.depth,
-      chainCode: this.chainCodeBuffer,
-      publicKey: this.publicKeyBuffer,
-      curve: this.#node.curve,
-    });
-
+    const node = this.#node.neuter();
     return new BIP44Node(node);
   }
 

--- a/src/SLIP10Node.test.ts
+++ b/src/SLIP10Node.test.ts
@@ -10,9 +10,9 @@ const defaultBip39NodeToken = `bip39:${fixtures.local.mnemonic}` as const;
 describe('SLIP10Node', () => {
   describe('fromExtendedKey', () => {
     it('initializes a new node from a private key', async () => {
-      const [privateKey, , chainCode] = await deriveChildKey(
-        fixtures.local.mnemonic,
-      );
+      const { privateKey, chainCode } = await deriveChildKey({
+        path: fixtures.local.mnemonic,
+      });
 
       const node = await SLIP10Node.fromExtendedKey({
         privateKey,
@@ -27,9 +27,9 @@ describe('SLIP10Node', () => {
     });
 
     it('initializes a new node from a hexadecimal private key and chain code', async () => {
-      const [privateKey, , chainCode] = await deriveChildKey(
-        fixtures.local.mnemonic,
-      );
+      const { privateKey, chainCode } = await deriveChildKey({
+        path: fixtures.local.mnemonic,
+      });
 
       const node = await SLIP10Node.fromExtendedKey({
         privateKey: privateKey.toString('hex'),
@@ -44,9 +44,9 @@ describe('SLIP10Node', () => {
     });
 
     it('initializes a new ed25519 node from a private key', async () => {
-      const [privateKey, , chainCode] = await deriveChildKey(
-        fixtures.local.mnemonic,
-      );
+      const { privateKey, chainCode } = await deriveChildKey({
+        path: fixtures.local.mnemonic,
+      });
 
       const node = await SLIP10Node.fromExtendedKey({
         privateKey,
@@ -61,9 +61,9 @@ describe('SLIP10Node', () => {
     });
 
     it('initializes a new node from a public key', async () => {
-      const [privateKey, , chainCode] = await deriveChildKey(
-        fixtures.local.mnemonic,
-      );
+      const { privateKey, chainCode } = await deriveChildKey({
+        path: fixtures.local.mnemonic,
+      });
 
       const privateNode = await SLIP10Node.fromExtendedKey({
         privateKey,
@@ -85,9 +85,9 @@ describe('SLIP10Node', () => {
     });
 
     it('initializes a new ed25519 node from a public key', async () => {
-      const [privateKey, , chainCode] = await deriveChildKey(
-        fixtures.local.mnemonic,
-      );
+      const { privateKey, chainCode } = await deriveChildKey({
+        path: fixtures.local.mnemonic,
+      });
 
       const privateNode = await SLIP10Node.fromExtendedKey({
         privateKey,
@@ -109,9 +109,9 @@ describe('SLIP10Node', () => {
     });
 
     it('initializes a new node from a hexadecimal public key and chain code', async () => {
-      const [privateKey, , chainCode] = await deriveChildKey(
-        fixtures.local.mnemonic,
-      );
+      const { privateKey, chainCode } = await deriveChildKey({
+        path: fixtures.local.mnemonic,
+      });
 
       const privateNode = await SLIP10Node.fromExtendedKey({
         privateKey,
@@ -133,9 +133,9 @@ describe('SLIP10Node', () => {
     });
 
     it('initializes a new node from JSON', async () => {
-      const [privateKey, , chainCode] = await deriveChildKey(
-        fixtures.local.mnemonic,
-      );
+      const { privateKey, chainCode } = await deriveChildKey({
+        path: fixtures.local.mnemonic,
+      });
 
       const node = await SLIP10Node.fromExtendedKey({
         privateKey,
@@ -148,9 +148,9 @@ describe('SLIP10Node', () => {
     });
 
     it('initializes a new node from JSON with a public key', async () => {
-      const [privateKey, , chainCode] = await deriveChildKey(
-        fixtures.local.mnemonic,
-      );
+      const { privateKey, chainCode } = await deriveChildKey({
+        path: fixtures.local.mnemonic,
+      });
 
       const node = await SLIP10Node.fromExtendedKey({
         privateKey,
@@ -363,15 +363,32 @@ describe('SLIP10Node', () => {
       });
     });
 
-    // TODO: Public key derivation
-    it('throws when trying to derive a node without a private key', async () => {
+    it('derives a public child node', async () => {
+      const targetNode = await SLIP10Node.fromDerivationPath({
+        derivationPath: [defaultBip39NodeToken, 'bip32:0'],
+        curve: 'secp256k1',
+      });
+
+      const node = await SLIP10Node.fromDerivationPath({
+        derivationPath: [defaultBip39NodeToken],
+        curve: 'secp256k1',
+      }).then((n) => n.neuter());
+
+      const childNode = await node.derive(['bip32:0']);
+
+      expect(childNode.publicKey).toBe(targetNode.publicKey);
+      expect(childNode.chainCode).toBe(targetNode.chainCode);
+      expect(childNode.privateKey).toBeUndefined();
+    });
+
+    it('throws when trying to derive a hardened node without a private key', async () => {
       const node = await SLIP10Node.fromDerivationPath({
         derivationPath: [defaultBip39NodeToken, BIP44PurposeNodeToken],
         curve: 'secp256k1',
       });
 
       await expect(node.neuter().derive([`bip32:0'`])).rejects.toThrow(
-        'Unable to derive child key: No private key.',
+        'Invalid path: Cannot derive hardened child keys without a private key.',
       );
     });
 
@@ -417,7 +434,7 @@ describe('SLIP10Node', () => {
     it.each(slip10)(
       'returns the public key for an ed25519 node',
       async ({ hexSeed, keys }) => {
-        const [privateKey, , chainCode] = await createBip39KeyFromSeed(
+        const { privateKey, chainCode } = await createBip39KeyFromSeed(
           hexStringToBuffer(hexSeed),
           ed25519,
         );
@@ -443,7 +460,7 @@ describe('SLIP10Node', () => {
     it.each(bip32)(
       'returns the public key for an secp256k1 node',
       async ({ hexSeed, keys }) => {
-        const [privateKey, , chainCode] = await createBip39KeyFromSeed(
+        const { privateKey, chainCode } = await createBip39KeyFromSeed(
           hexStringToBuffer(hexSeed),
           secp256k1,
         );
@@ -474,7 +491,7 @@ describe('SLIP10Node', () => {
     it.each(sampleAddressIndices)(
       'returns the address for an secp256k1 node',
       async ({ index, address }) => {
-        const [privateKey, , chainCode] = await createBip39KeyFromSeed(
+        const { privateKey, chainCode } = await createBip39KeyFromSeed(
           hexStringToBuffer(hexSeed),
           secp256k1,
         );
@@ -525,6 +542,7 @@ describe('SLIP10Node', () => {
 
       const neuterNode = node.neuter();
 
+      expect(neuterNode.publicKey).toBe(node.publicKey);
       expect(neuterNode.privateKey).toBeUndefined();
       expect(neuterNode.privateKeyBuffer).toBeUndefined();
     });

--- a/src/SLIP10Node.test.ts
+++ b/src/SLIP10Node.test.ts
@@ -376,9 +376,11 @@ describe('SLIP10Node', () => {
 
       const childNode = await node.derive(['bip32:0']);
 
-      expect(childNode.publicKey).toBe(targetNode.publicKey);
-      expect(childNode.chainCode).toBe(targetNode.chainCode);
       expect(childNode.privateKey).toBeUndefined();
+      expect(childNode).toMatchObject({
+        depth: targetNode.depth,
+        publicKey: targetNode.publicKey,
+      });
     });
 
     it('throws when trying to derive a hardened node without a private key', async () => {

--- a/src/SLIP10Node.test.ts
+++ b/src/SLIP10Node.test.ts
@@ -390,7 +390,7 @@ describe('SLIP10Node', () => {
       });
 
       await expect(node.neuter().derive([`bip32:0'`])).rejects.toThrow(
-        'Invalid path: Cannot derive hardened child keys without a private key.',
+        'Invalid parameters: Cannot derive hardened child keys without a private key.',
       );
     });
 

--- a/src/SLIP10Node.ts
+++ b/src/SLIP10Node.ts
@@ -245,7 +245,7 @@ export class SLIP10Node implements SLIP10NodeInterface {
       );
     }
 
-    return publicKeyToEthAddress(this.publicKeyBuffer).toString('hex');
+    return `0x${publicKeyToEthAddress(this.publicKeyBuffer).toString('hex')}`;
   }
 
   /**

--- a/src/curves/curve.ts
+++ b/src/curves/curve.ts
@@ -22,7 +22,7 @@ export type Curve = {
     compressed?: boolean,
   ) => Buffer | Promise<Buffer>;
   isValidPrivateKey: (privateKey: Uint8Array | string | bigint) => boolean;
-  publicAdd: (publicKey: Buffer, tweak: Buffer) => Uint8Array;
+  publicAdd: (publicKey: Buffer, tweak: Buffer) => Buffer;
   compressPublicKey: (publicKey: Buffer) => Buffer;
 };
 

--- a/src/curves/curve.ts
+++ b/src/curves/curve.ts
@@ -22,6 +22,8 @@ export type Curve = {
     compressed?: boolean,
   ) => Buffer | Promise<Buffer>;
   isValidPrivateKey: (privateKey: Uint8Array | string | bigint) => boolean;
+  publicAdd: (publicKey: Buffer, tweak: Buffer) => Uint8Array;
+  compressPublicKey: (publicKey: Buffer) => Buffer;
 };
 
 // As long as both parameters are specified, this function is the same for all curves.

--- a/src/curves/ed25519.test.ts
+++ b/src/curves/ed25519.test.ts
@@ -1,6 +1,13 @@
 import { bytesToHex } from '@noble/hashes/utils';
 import fixtures from '../../test/fixtures';
-import { curve, getPublicKey, isValidPrivateKey } from './ed25519';
+import { hexStringToBuffer } from '../utils';
+import {
+  compressPublicKey,
+  curve,
+  getPublicKey,
+  isValidPrivateKey,
+  publicAdd,
+} from './ed25519';
 
 describe('ed25519', () => {
   describe('curve', () => {
@@ -37,5 +44,26 @@ describe('ed25519', () => {
         }
       },
     );
+  });
+
+  describe('publicAdd', () => {
+    it('throws an error', () => {
+      expect(() => publicAdd(Buffer.alloc(1), Buffer.alloc(1))).toThrow(
+        'Ed25519 does not support public key derivation.',
+      );
+    });
+  });
+
+  describe('compressPublicKey', () => {
+    const { slip10 } = fixtures.ed25519;
+
+    it.each(slip10)('returns the same public key', async ({ keys }) => {
+      for (const { publicKey } of keys) {
+        const publicKeyBuffer = hexStringToBuffer(publicKey);
+        expect(compressPublicKey(publicKeyBuffer)).toStrictEqual(
+          publicKeyBuffer,
+        );
+      }
+    });
   });
 });

--- a/src/curves/ed25519.ts
+++ b/src/curves/ed25519.ts
@@ -1,4 +1,4 @@
-import { getPublicKey as getEd25519PublicKey, Point } from '@noble/ed25519';
+import { getPublicKey as getEd25519PublicKey } from '@noble/ed25519';
 
 export { CURVE as curve } from '@noble/ed25519';
 

--- a/src/curves/ed25519.ts
+++ b/src/curves/ed25519.ts
@@ -25,7 +25,7 @@ export const getPublicKey = async (
   return Buffer.concat([Buffer.alloc(1, 0), publicKey]);
 };
 
-export const publicAdd = (_publicKey: Buffer, _tweak: Buffer) => {
+export const publicAdd = (_publicKey: Buffer, _tweak: Buffer): Buffer => {
   throw new Error('Ed25519 does not support public key derivation.');
 };
 

--- a/src/curves/ed25519.ts
+++ b/src/curves/ed25519.ts
@@ -1,4 +1,4 @@
-import { getPublicKey as getEd25519PublicKey } from '@noble/ed25519';
+import { getPublicKey as getEd25519PublicKey, Point } from '@noble/ed25519';
 
 export { CURVE as curve } from '@noble/ed25519';
 
@@ -23,4 +23,13 @@ export const getPublicKey = async (
 ): Promise<Buffer> => {
   const publicKey = await getEd25519PublicKey(privateKey);
   return Buffer.concat([Buffer.alloc(1, 0), publicKey]);
+};
+
+export const publicAdd = (_publicKey: Buffer, _tweak: Buffer) => {
+  throw new Error('Ed25519 does not support public key derivation.');
+};
+
+export const compressPublicKey = (publicKey: Buffer): Buffer => {
+  // Ed25519 public keys don't have a compressed form.
+  return publicKey;
 };

--- a/src/curves/secp256k1.ts
+++ b/src/curves/secp256k1.ts
@@ -25,6 +25,10 @@ export const getPublicKey = (
 
 export const publicAdd = (publicKey: Buffer, tweak: Buffer): Buffer => {
   const point = Point.fromHex(publicKey);
+
+  // The returned child key Ki is point(parse256(IL)) + Kpar.
+  // This multiplies the tweak with the base point of the curve (Gx, Gy).
+  // https://github.com/bitcoin/bips/blob/274fa400d630ba757bec0c03b35ebe2345197108/bip-0032.mediawiki#public-parent-key--public-child-key
   const newPoint = point.add(Point.fromPrivateKey(tweak));
 
   newPoint.assertValidity();

--- a/src/curves/secp256k1.ts
+++ b/src/curves/secp256k1.ts
@@ -3,7 +3,6 @@ import {
   getPublicKey as getSecp256k1PublicKey,
   Point,
 } from '@noble/secp256k1';
-import { bytesToNumber } from '../utils';
 
 export { CURVE as curve } from '@noble/secp256k1';
 export const { isValidPrivateKey } = utils;
@@ -24,16 +23,13 @@ export const getPublicKey = (
   compressed?: boolean,
 ): Buffer => Buffer.from(getSecp256k1PublicKey(privateKey, compressed));
 
-export const publicAdd = (publicKey: Buffer, tweak: Buffer): Uint8Array => {
+export const publicAdd = (publicKey: Buffer, tweak: Buffer): Buffer => {
   const point = Point.fromHex(publicKey);
-  const newPoint = point.add(
-    // Multiplies `Point(Gx, Gy)` with the tweak
-    Point.BASE.multiply(bytesToNumber(tweak)),
-  );
+  const newPoint = point.add(Point.fromPrivateKey(tweak));
 
   newPoint.assertValidity();
 
-  return newPoint.toRawBytes(false);
+  return Buffer.from(newPoint.toRawBytes(false));
 };
 
 export const compressPublicKey = (publicKey: Uint8Array): Buffer => {

--- a/src/curves/secp256k1.ts
+++ b/src/curves/secp256k1.ts
@@ -1,4 +1,9 @@
-import { utils, getPublicKey as getSecp256k1PublicKey } from '@noble/secp256k1';
+import {
+  utils,
+  getPublicKey as getSecp256k1PublicKey,
+  Point,
+} from '@noble/secp256k1';
+import { bytesToNumber } from '../utils';
 
 export { CURVE as curve } from '@noble/secp256k1';
 export const { isValidPrivateKey } = utils;
@@ -18,3 +23,20 @@ export const getPublicKey = (
   privateKey: Uint8Array | string | bigint,
   compressed?: boolean,
 ): Buffer => Buffer.from(getSecp256k1PublicKey(privateKey, compressed));
+
+export const publicAdd = (publicKey: Buffer, tweak: Buffer): Uint8Array => {
+  const point = Point.fromHex(publicKey);
+  const newPoint = point.add(
+    // Multiplies `Point(Gx, Gy)` with the tweak
+    Point.BASE.multiply(bytesToNumber(tweak)),
+  );
+
+  newPoint.assertValidity();
+
+  return newPoint.toRawBytes(false);
+};
+
+export const compressPublicKey = (publicKey: Uint8Array): Buffer => {
+  const point = Point.fromHex(publicKey);
+  return Buffer.from(point.toRawBytes(true));
+};

--- a/src/derivation.test.ts
+++ b/src/derivation.test.ts
@@ -46,7 +46,9 @@ describe('derivation', () => {
       // validate addresses
       keys.forEach(({ privateKey }, index) => {
         const address = privateKeyToEthAddress(privateKey as Buffer);
-        expect(address.toString('hex')).toStrictEqual(expectedAddresses[index]);
+        expect(`0x${address.toString('hex')}`).toStrictEqual(
+          expectedAddresses[index],
+        );
       });
     });
 
@@ -70,7 +72,9 @@ describe('derivation', () => {
       // validate addresses
       keys.forEach(({ privateKey: childPrivateKey }, index) => {
         const address = privateKeyToEthAddress(childPrivateKey as Buffer);
-        expect(address.toString('hex')).toStrictEqual(expectedAddresses[index]);
+        expect(`0x${address.toString('hex')}`).toStrictEqual(
+          expectedAddresses[index],
+        );
       });
     });
 
@@ -210,7 +214,9 @@ describe('derivation', () => {
       // validate addresses
       keys.forEach(({ privateKey }, index) => {
         const address = privateKeyToEthAddress(privateKey as Buffer);
-        expect(address.toString('hex')).toStrictEqual(expectedAddresses[index]);
+        expect(`0x${address.toString('hex')}`).toStrictEqual(
+          expectedAddresses[index],
+        );
       });
     });
 

--- a/src/derivation.test.ts
+++ b/src/derivation.test.ts
@@ -173,7 +173,7 @@ describe('derivation', () => {
           path: [`bip32:1'`],
           privateKey: (privateKey as Buffer).toString('base64') as any,
         }),
-      ).rejects.toThrow('Parent key must be a Buffer if specified.');
+      ).rejects.toThrow('Private key must be a Buffer if specified.');
     });
   });
 

--- a/src/derivation.test.ts
+++ b/src/derivation.test.ts
@@ -1,7 +1,7 @@
 import fixtures from '../test/fixtures';
 import { HDPathTuple } from './constants';
 import { deriveKeyFromPath } from './derivation';
-import { derivers } from './derivers';
+import { DerivedKeys, derivers } from './derivers';
 import { getUnhardenedBIP32NodeToken } from './utils';
 import { privateKeyToEthAddress } from './derivers/bip32';
 
@@ -39,13 +39,13 @@ describe('derivation', () => {
             `bip32:0`,
             `bip32:${index}`,
           ]);
-          return deriveKeyFromPath(multipath);
+          return deriveKeyFromPath({ path: multipath });
         }),
       );
 
       // validate addresses
-      keys.forEach(([key], index) => {
-        const address = privateKeyToEthAddress(key);
+      keys.forEach(({ privateKey }, index) => {
+        const address = privateKeyToEthAddress(privateKey as Buffer);
         expect(address.toString('hex')).toStrictEqual(expectedAddresses[index]);
       });
     });
@@ -54,21 +54,22 @@ describe('derivation', () => {
       // generate parent key
       const bip39Part = bip39MnemonicToMultipath(mnemonic);
       const multipath = [bip39Part, ...ethereumBip32PathParts] as HDPathTuple;
-      const [parentKey, , chainCode] = await deriveKeyFromPath(multipath);
+      const { privateKey, chainCode } = await deriveKeyFromPath({
+        path: multipath,
+      });
       const keys = await Promise.all(
         expectedAddresses.map((_, index) => {
-          return deriveKeyFromPath(
-            [`bip32:${index}`],
-            parentKey,
-            undefined,
+          return deriveKeyFromPath({
+            path: [`bip32:${index}`],
+            privateKey,
             chainCode,
-          );
+          });
         }),
       );
 
       // validate addresses
-      keys.forEach(([key], index) => {
-        const address = privateKeyToEthAddress(key);
+      keys.forEach(({ privateKey: childPrivateKey }, index) => {
+        const address = privateKeyToEthAddress(childPrivateKey as Buffer);
         expect(address.toString('hex')).toStrictEqual(expectedAddresses[index]);
       });
     });
@@ -77,16 +78,20 @@ describe('derivation', () => {
       // generate parent key
       const bip39Part = bip39MnemonicToMultipath(mnemonic);
       const multipath = [bip39Part, ...ethereumBip32PathParts] as const;
-      const [parentKey] = await deriveKeyFromPath(multipath);
+      const { privateKey } = await deriveKeyFromPath({
+        path: multipath,
+      });
 
       // Empty segments are forbidden
-      await expect(() => deriveKeyFromPath([] as any)).rejects.toThrow(
+      await expect(() => deriveKeyFromPath({ path: [] })).rejects.toThrow(
         /Invalid HD path segment: The segment must not be empty\./u,
       );
 
       // Segments cannot exceed BIP-44 maximum depth
       await expect(() =>
-        deriveKeyFromPath([...multipath, multipath[4], multipath[4]] as any),
+        deriveKeyFromPath({
+          path: [...multipath, multipath[4], multipath[4]],
+        }),
       ).rejects.toThrow(
         /Invalid HD path segment: The segment cannot exceed a 0-indexed depth of 5\./u,
       );
@@ -94,79 +99,76 @@ describe('derivation', () => {
       // Malformed multipaths are disallowed
       await expect(() => {
         const [, ...rest] = multipath;
-        return deriveKeyFromPath([
-          bip39Part.replace('bip39', 'foo') as any,
-          ...rest,
-        ]);
+        return deriveKeyFromPath({
+          path: [bip39Part.replace('bip39', 'foo') as any, ...rest],
+        });
       }).rejects.toThrow(
         /Invalid HD path segment: The path segment is malformed\./u,
       );
 
       await expect(() => {
         const [, bip32Part1, ...rest] = multipath;
-        return deriveKeyFromPath([
-          bip39Part,
-          bip32Part1.replace('bip32', 'bar') as any,
-          ...rest,
-        ]);
+        return deriveKeyFromPath({
+          path: [bip39Part, bip32Part1.replace('bip32', 'bar') as any, ...rest],
+        });
       }).rejects.toThrow(
         /Invalid HD path segment: The path segment is malformed\./u,
       );
 
       await expect(() => {
         const [, bip32Part1, ...rest] = multipath;
-        return deriveKeyFromPath([
-          bip39Part,
-          bip32Part1.replace(`44'`, 'xyz') as any,
-          ...rest,
-        ]);
+        return deriveKeyFromPath({
+          path: [bip39Part, bip32Part1.replace(`44'`, 'xyz') as any, ...rest],
+        });
       }).rejects.toThrow(
         /Invalid HD path segment: The path segment is malformed\./u,
       );
 
       await expect(() => {
         const [, bip32Part1, ...rest] = multipath;
-        return deriveKeyFromPath([
-          bip39Part,
-          bip32Part1.replace(`'`, '"') as any,
-          ...rest,
-        ]);
+        return deriveKeyFromPath({
+          path: [bip39Part, bip32Part1.replace(`'`, '"') as any, ...rest],
+        });
       }).rejects.toThrow(
         /Invalid HD path segment: The path segment is malformed\./u,
       );
 
       await expect(
-        deriveKeyFromPath(
-          [bip39Part, ethereumBip32PathParts[0]],
-          Buffer.alloc(32).fill(1),
-          undefined,
-          Buffer.alloc(32).fill(1),
-          0,
-        ),
+        deriveKeyFromPath({
+          path: [bip39Part, ethereumBip32PathParts[0]],
+          depth: 0,
+        }),
       ).rejects.toThrow(
         /Invalid HD path segment: The segment must consist of a single BIP-39 node for depths of 0\. Received:/u,
       );
 
       // bip39 seed phrase component must be completely lowercase
       await expect(
-        deriveKeyFromPath([bip39Part.replace('r', 'R') as any]),
+        deriveKeyFromPath({
+          path: [bip39Part.replace('r', 'R') as any],
+        }),
       ).rejects.toThrow(
         /Invalid HD path segment: The path segment is malformed\./u,
       );
 
       // Multipaths that start with bip39 segment require _no_ parentKey
-      await expect(deriveKeyFromPath([bip39Part], parentKey)).rejects.toThrow(
+      await expect(
+        deriveKeyFromPath({ path: [bip39Part], privateKey }),
+      ).rejects.toThrow(
         /Invalid derivation parameters: May not specify parent key if the path segment starts with a BIP-39 node\./u,
       );
 
       // Multipaths that start with bip32 segment require parentKey
-      await expect(deriveKeyFromPath([`bip32:1'`])).rejects.toThrow(
+      await expect(deriveKeyFromPath({ path: [`bip32:1'`] })).rejects.toThrow(
         /Invalid derivation parameters: Must specify parent key if the first node of the path segment is not a BIP-39 node\./u,
       );
 
       // parentKey must be a buffer if specified
       await expect(
-        deriveKeyFromPath([`bip32:1'`], parentKey.toString('base64') as any),
+        deriveKeyFromPath({
+          path: [`bip32:1'`],
+          privateKey: (privateKey as Buffer).toString('base64') as any,
+        }),
       ).rejects.toThrow('Parent key must be a Buffer if specified.');
     });
   });
@@ -174,49 +176,40 @@ describe('derivation', () => {
   describe('bip32Derive', () => {
     it('derives the expected keys and addresses', async () => {
       // generate parent key
-      let privateKey: Buffer;
-      let chainCode: Buffer;
+      let derivedKeys: DerivedKeys;
 
       /* eslint-disable require-atomic-updates */
-      [privateKey, , chainCode] = await bip39Derive(mnemonic);
-      [privateKey, , chainCode] = await bip32Derive(
-        `44'`,
-        privateKey,
-        undefined,
-        chainCode,
-      );
+      derivedKeys = await bip39Derive({ path: mnemonic });
+      derivedKeys = await bip32Derive({
+        path: `44'`,
+        ...derivedKeys,
+      });
 
-      [privateKey, , chainCode] = await bip32Derive(
-        `60'`,
-        privateKey,
-        undefined,
-        chainCode,
-      );
+      derivedKeys = await bip32Derive({
+        path: `60'`,
+        ...derivedKeys,
+      });
 
-      [privateKey, , chainCode] = await bip32Derive(
-        `0'`,
-        privateKey,
-        undefined,
-        chainCode,
-      );
+      derivedKeys = await bip32Derive({
+        path: `0'`,
+        ...derivedKeys,
+      });
 
-      [privateKey, , chainCode] = await bip32Derive(
-        `0`,
-        privateKey,
-        undefined,
-        chainCode,
-      );
+      derivedKeys = await bip32Derive({
+        path: `0`,
+        ...derivedKeys,
+      });
       /* eslint-enable require-atomic-updates */
 
       const keys = await Promise.all(
         expectedAddresses.map((_, index) => {
-          return bip32Derive(`${index}`, privateKey, undefined, chainCode);
+          return bip32Derive({ path: `${index}`, ...derivedKeys });
         }),
       );
 
       // validate addresses
-      keys.forEach(([key], index) => {
-        const address = privateKeyToEthAddress(key);
+      keys.forEach(({ privateKey }, index) => {
+        const address = privateKeyToEthAddress(privateKey as Buffer);
         expect(address.toString('hex')).toStrictEqual(expectedAddresses[index]);
       });
     });
@@ -234,70 +227,62 @@ describe('derivation', () => {
       for (const input of inputs) {
         // eslint-disable-next-line no-loop-func
         await expect(
-          bip32Derive(
-            input as any,
-            Buffer.allocUnsafe(32).fill(1),
-            undefined,
-            Buffer.allocUnsafe(32).fill(1),
-          ),
+          bip32Derive({
+            path: input,
+            privateKey: Buffer.alloc(32).fill(1),
+            chainCode: Buffer.alloc(32).fill(1),
+          }),
         ).rejects.toThrow(
           'Invalid BIP-32 index: The index must be a non-negative decimal integer less than 2147483648.',
         );
       }
 
       await expect(
-        bip32Derive(`44'`, undefined, undefined, Buffer.alloc(32, 1)),
+        bip32Derive({
+          path: `44`,
+          chainCode: Buffer.alloc(32).fill(1),
+        }),
       ).rejects.toThrow(
         'Invalid parameters: Must specify either a parent private or public key.',
       );
-
-      await expect(
-        bip32Derive(
-          `44'`,
-          Buffer.allocUnsafe(31).fill(1),
-          undefined,
-          Buffer.alloc(32).fill(1),
-        ),
-      ).rejects.toThrow('Invalid parent key: Must be 32 bytes long.');
     });
 
     it('throws for an invalid private key', async () => {
       await expect(
-        bip32Derive(
-          `44'`,
-          Buffer.alloc(31).fill(1),
-          undefined,
-          Buffer.alloc(32).fill(1),
-        ),
+        bip32Derive({
+          path: `44'`,
+          privateKey: Buffer.alloc(31).fill(1),
+          chainCode: Buffer.alloc(32).fill(1),
+        }),
       ).rejects.toThrow('Invalid parent key: Must be 32 bytes long.');
     });
 
     it('throws for an invalid public key', async () => {
       await expect(
-        bip32Derive(
-          `44'`,
-          undefined,
-          Buffer.alloc(64).fill(1),
-          Buffer.alloc(32).fill(1),
-        ),
+        bip32Derive({
+          path: `44`,
+          publicKey: Buffer.alloc(31).fill(1),
+          chainCode: Buffer.alloc(32).fill(1),
+        }),
       ).rejects.toThrow('Invalid parent public key: Must be 65 bytes long.');
     });
 
     it('throws if no chain code is specified', async () => {
       await expect(
-        // @ts-expect-error Invalid chain code type.
-        bip32Derive(`44'`, Buffer.alloc(32, 1), undefined, undefined),
+        bip32Derive({
+          path: `44'`,
+          privateKey: Buffer.alloc(32, 1),
+        }),
       ).rejects.toThrow('Invalid parameters: Must specify a chain code.');
     });
 
     it('throws for an invalid chain code', async () => {
       await expect(
-        bip32Derive(
-          `44'`,
-          Buffer.alloc(32, 1),
-          undefined,
-          Buffer.alloc(31).fill(1),
-        ),
+        bip32Derive({
+          path: `44'`,
+          privateKey: Buffer.alloc(32).fill(1),
+          chainCode: Buffer.alloc(31).fill(1),
+        }),
       ).rejects.toThrow('Invalid chain code: Must be 32 bytes long.');
     });
   });

--- a/src/derivation.ts
+++ b/src/derivation.ts
@@ -41,13 +41,13 @@ type DeriveKeyFromPathArgs = {
  * WARNING: It is the consumer's responsibility to ensure that the path is valid
  * relative to its parent key.
  *
- * @param pathSegment - A full or partial HD path, e.g.:
+ * @param path - A full or partial HD path, e.g.:
  * bip39:SEED_PHRASE/bip32:44'/bip32:60'/bip32:0'/bip32:0/bip32:0
  *
  * BIP-39 seed phrases must be lowercase, space-delimited, and 12-24 words long.
- * @param parentKey - The parent key of the given path segment, if any.
- * @param parentPublicKey - The parent public key of the given path segment, if any.
- * @param parentChainCode - The chain code of the given path segment, if any.
+ * @param privateKey - The parent key of the given path segment, if any.
+ * @param publicKey - The parent public key of the given path segment, if any.
+ * @param chainCode - The chain code of the given path segment, if any.
  * @param depth - The depth of the segment.
  * @param curve - The curve to use.
  * @returns The derived key.
@@ -61,7 +61,7 @@ export async function deriveKeyFromPath({
   curve,
 }: DeriveKeyFromPathArgs): Promise<DerivedKeys> {
   if (privateKey && !Buffer.isBuffer(privateKey)) {
-    throw new Error('Parent key must be a Buffer if specified.');
+    throw new Error('Private key must be a Buffer if specified.');
   }
 
   validatePathSegment(path, Boolean(privateKey) || Boolean(publicKey), depth);

--- a/src/derivers/bip32.test.ts
+++ b/src/derivers/bip32.test.ts
@@ -59,7 +59,9 @@ describe('privateKeyToEthAddress', () => {
     const { privateKey, address } = fixtures['ethereumjs-wallet'];
 
     expect(
-      privateKeyToEthAddress(hexStringToBuffer(privateKey)).toString('hex'),
+      `0x${privateKeyToEthAddress(hexStringToBuffer(privateKey)).toString(
+        'hex',
+      )}`,
     ).toBe(address);
   });
 
@@ -80,7 +82,9 @@ describe('publicKeyToEthAddress', () => {
     const { publicKey, address } = fixtures['ethereumjs-wallet'];
 
     expect(
-      publicKeyToEthAddress(hexStringToBuffer(publicKey)).toString('hex'),
+      `0x${publicKeyToEthAddress(hexStringToBuffer(publicKey)).toString(
+        'hex',
+      )}`,
     ).toBe(address);
   });
 

--- a/src/derivers/bip32.ts
+++ b/src/derivers/bip32.ts
@@ -76,7 +76,7 @@ export async function deriveChildKey({
 
   if (isHardened && !privateKey) {
     throw new Error(
-      'Invalid path: Cannot derive hardened child keys without a private key.',
+      'Invalid parameters: Cannot derive hardened child keys without a private key.',
     );
   }
 

--- a/src/derivers/bip32.ts
+++ b/src/derivers/bip32.ts
@@ -4,6 +4,7 @@ import { sha512 } from '@noble/hashes/sha512';
 import { BIP_32_HARDENED_OFFSET, BUFFER_KEY_LENGTH } from '../constants';
 import { bytesToNumber, hexStringToBuffer, isValidBufferKey } from '../utils';
 import { Curve, mod, secp256k1 } from '../curves';
+import { DeriveChildKeyArgs, DerivedKeys } from '.';
 
 /**
  * Converts a BIP-32 private key to an Ethereum address.
@@ -59,23 +60,23 @@ export function publicKeyToEthAddress(key: Buffer) {
  * @returns A tuple containing the derived private key, public key and chain
  * code.
  */
-export async function deriveChildKey(
-  pathPart: string,
-  parentKey: Buffer | undefined,
-  parentPublicKey: Buffer | undefined,
-  chainCode: Buffer,
-  curve: Curve = secp256k1,
-): Promise<[privateKey: Buffer, publicKey: Buffer, chainCode: Buffer]> {
-  const isHardened = pathPart.includes(`'`);
+export async function deriveChildKey({
+  path,
+  privateKey,
+  publicKey,
+  chainCode,
+  curve = secp256k1,
+}: DeriveChildKeyArgs): Promise<DerivedKeys> {
+  const isHardened = path.includes(`'`);
   if (!isHardened && !curve.deriveUnhardenedKeys) {
     throw new Error(
       `Invalid path: Cannot derive unhardened child keys with ${curve.name}.`,
     );
   }
 
-  if (!parentKey && !parentPublicKey) {
+  if (isHardened && !privateKey) {
     throw new Error(
-      'Invalid parameters: Must specify either a parent private or public key.',
+      'Invalid path: Cannot derive hardened child keys without a private key.',
     );
   }
 
@@ -83,21 +84,11 @@ export async function deriveChildKey(
     throw new Error('Invalid parameters: Must specify a chain code.');
   }
 
-  if (parentKey && parentKey.length !== BUFFER_KEY_LENGTH) {
-    throw new Error('Invalid parent key: Must be 32 bytes long.');
-  }
-
-  if (parentPublicKey && parentPublicKey.length !== curve.publicKeyLength) {
-    throw new Error(
-      `Invalid parent public key: Must be ${curve.publicKeyLength} bytes long.`,
-    );
-  }
-
   if (chainCode.length !== BUFFER_KEY_LENGTH) {
     throw new Error('Invalid chain code: Must be 32 bytes long.');
   }
 
-  const indexPart = pathPart.split(`'`)[0];
+  const indexPart = path.split(`'`)[0];
   const childIndex = parseInt(indexPart, 10);
 
   if (
@@ -111,29 +102,55 @@ export async function deriveChildKey(
     );
   }
 
-  const secretExtension = await deriveSecretExtension({
-    parentPrivateKey: parentKey as Buffer,
-    childIndex,
-    isHardened,
-    curve,
-  });
+  if (privateKey) {
+    if (privateKey.length !== BUFFER_KEY_LENGTH) {
+      throw new Error('Invalid parent key: Must be 32 bytes long.');
+    }
 
-  const { privateKey, extraEntropy } = generateKey({
-    parentPrivateKey: parentKey as Buffer,
-    parentExtraEntropy: chainCode,
-    secretExtension,
-    curve,
-  });
+    const secretExtension = await deriveSecretExtension({
+      privateKey,
+      childIndex,
+      isHardened,
+      curve,
+    });
 
-  return [
-    Buffer.from(privateKey),
-    await curve.getPublicKey(privateKey),
-    Buffer.from(extraEntropy),
-  ];
+    return await generateKey({
+      privateKey,
+      chainCode,
+      secretExtension,
+      curve,
+    });
+  }
+
+  if (publicKey) {
+    if (publicKey.length !== curve.publicKeyLength) {
+      throw new Error(
+        `Invalid parent public key: Must be ${curve.publicKeyLength} bytes long.`,
+      );
+    }
+
+    const compressedPublicKey = curve.compressPublicKey(publicKey);
+    const publicExtension = await derivePublicExtension({
+      parentPublicKey: compressedPublicKey,
+      childIndex,
+      curve,
+    });
+
+    return generatePublicKey({
+      publicKey: compressedPublicKey,
+      chainCode,
+      publicExtension,
+      curve,
+    });
+  }
+
+  throw new Error(
+    'Invalid parameters: Must specify either a parent private or public key.',
+  );
 }
 
 type DeriveSecretExtensionArgs = {
-  parentPrivateKey: Buffer;
+  privateKey: Buffer;
   childIndex: number;
   isHardened: boolean;
   curve: Curve;
@@ -142,12 +159,12 @@ type DeriveSecretExtensionArgs = {
 // the bip32 secret extension is created from the parent private or public key and the child index
 /**
  * @param options
- * @param options.parentPrivateKey
+ * @param options.privateKey
  * @param options.childIndex
  * @param options.isHardened
  */
 async function deriveSecretExtension({
-  parentPrivateKey,
+  privateKey,
   childIndex,
   isHardened,
   curve,
@@ -156,7 +173,7 @@ async function deriveSecretExtension({
     // Hardened child
     const indexBuffer = Buffer.allocUnsafe(4);
     indexBuffer.writeUInt32BE(childIndex + BIP_32_HARDENED_OFFSET, 0);
-    const pk = parentPrivateKey;
+    const pk = privateKey;
     const zb = Buffer.alloc(1, 0);
     return Buffer.concat([zb, pk, indexBuffer]);
   }
@@ -164,16 +181,24 @@ async function deriveSecretExtension({
   // Normal child
   const indexBuffer = Buffer.allocUnsafe(4);
   indexBuffer.writeUInt32BE(childIndex, 0);
-  const parentPublicKey = await curve.getPublicKey(parentPrivateKey, true);
+  const parentPublicKey = await curve.getPublicKey(privateKey, true);
   return Buffer.concat([parentPublicKey, indexBuffer]);
 }
 
-type GenerateKeyArgs = {
-  parentPrivateKey: Buffer;
-  parentExtraEntropy: string | Buffer;
-  secretExtension: string | Buffer;
+type DerivePublicExtensionArgs = {
+  parentPublicKey: Buffer;
+  childIndex: number;
   curve: Curve;
 };
+
+async function derivePublicExtension({
+  parentPublicKey,
+  childIndex,
+}: DerivePublicExtensionArgs) {
+  const indexBuffer = Buffer.alloc(4);
+  indexBuffer.writeUInt32BE(childIndex, 0);
+  return Buffer.concat([parentPublicKey, indexBuffer]);
+}
 
 /**
  * Add a tweak to the private key: `(privateKey + tweak) % n`.
@@ -188,7 +213,7 @@ export function privateAdd(
   privateKeyBuffer: Uint8Array,
   tweakBuffer: Uint8Array,
   curve: Curve,
-): Uint8Array {
+): Buffer {
   const privateKey = bytesToNumber(privateKeyBuffer);
   const tweak = bytesToNumber(tweakBuffer);
 
@@ -206,29 +231,64 @@ export function privateAdd(
   return hexStringToBuffer(added.toString(16).padStart(64, '0'));
 }
 
+type GenerateKeyArgs = {
+  privateKey: Buffer;
+  chainCode: Buffer;
+  secretExtension: Buffer;
+  curve: Curve;
+};
+
 /**
  * @param options
- * @param options.parentPrivateKey
- * @param options.parentExtraEntropy
+ * @param options.privateKey
+ * @param options.chainCode
  * @param options.secretExtension
  */
-function generateKey({
-  parentPrivateKey,
-  parentExtraEntropy,
+async function generateKey({
+  privateKey,
+  chainCode,
   secretExtension,
   curve,
-}: GenerateKeyArgs) {
-  const entropy = hmac(sha512, parentExtraEntropy, secretExtension);
-  const keyMaterial = entropy.slice(0, 32);
-  // extraEntropy is also called "chaincode"
-  const extraEntropy = entropy.slice(32);
+}: GenerateKeyArgs): Promise<DerivedKeys> {
+  const entropy = hmac(sha512, chainCode, secretExtension);
+  const keyMaterial = Buffer.from(entropy.slice(0, 32));
+  const childChainCode = Buffer.from(entropy.slice(32));
 
   // If curve is ed25519: The returned child key ki is parse256(IL).
   // https://github.com/satoshilabs/slips/blob/133ea52a8e43d338b98be208907e144277e44c0e/slip-0010.md#private-parent-key--private-child-key
   if (curve.name === 'ed25519') {
-    return { privateKey: keyMaterial, extraEntropy };
+    const publicKey = await curve.getPublicKey(keyMaterial);
+    return { privateKey: keyMaterial, publicKey, chainCode: childChainCode };
   }
 
-  const privateKey = privateAdd(parentPrivateKey, keyMaterial, curve);
-  return { privateKey, extraEntropy };
+  const childPrivateKey = privateAdd(privateKey, keyMaterial, curve);
+  const publicKey = await curve.getPublicKey(childPrivateKey);
+
+  return { privateKey: childPrivateKey, publicKey, chainCode: childChainCode };
+}
+
+type GeneratePublicKeyArgs = {
+  publicKey: Buffer;
+  chainCode: Buffer;
+  publicExtension: Buffer;
+  curve: Curve;
+};
+
+function generatePublicKey({
+  publicKey,
+  chainCode,
+  publicExtension,
+  curve,
+}: GeneratePublicKeyArgs): DerivedKeys {
+  const entropy = hmac(sha512, chainCode, publicExtension);
+  const keyMaterial = entropy.slice(0, 32);
+  const childChainCode = entropy.slice(32);
+
+  // This function may fail if the resulting key is invalid.
+  const childPublicKey = curve.publicAdd(publicKey, Buffer.from(keyMaterial));
+
+  return {
+    publicKey: Buffer.from(childPublicKey),
+    chainCode: Buffer.from(childChainCode),
+  };
 }

--- a/src/derivers/index.ts
+++ b/src/derivers/index.ts
@@ -2,14 +2,25 @@ import { Curve } from '../curves';
 import * as bip32 from './bip32';
 import * as bip39 from './bip39';
 
+export type DerivedKeys = {
+  /**
+   * The derived private key, can be undefined if public key derivation was used.
+   */
+  privateKey?: Buffer;
+  publicKey: Buffer;
+  chainCode: Buffer;
+};
+
+export type DeriveChildKeyArgs = {
+  path: string;
+  privateKey?: Buffer;
+  publicKey?: Buffer;
+  chainCode?: Buffer;
+  curve?: Curve;
+};
+
 export type Deriver = {
-  deriveChildKey: (
-    pathPart: string,
-    parentKey?: Buffer,
-    parentPublicKey?: Buffer,
-    chainCode?: Buffer,
-    curve?: Curve,
-  ) => Promise<[privateKey: Buffer, publicKey: Buffer, chainCode: Buffer]>;
+  deriveChildKey: (args: DeriveChildKeyArgs) => Promise<DerivedKeys>;
 };
 
 export const derivers = {

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -4,12 +4,12 @@ export default {
     mnemonic:
       'romance hurry grit huge rifle ordinary loud toss sound congress upset twist',
     addresses: [
-      '5df603999c3d5ca2ab828339a9883585b1bce11b',
-      '441c07e32a609afd319ffbb66432b424058bcfe9',
-      '1f7c93dfe849c06dd610e77473bfaaef7f183c7c',
-      '9e28bae18e0e358b12796697c6546f77d4657527',
-      '6e7734c7f4fb973a3800b72fb1a6bf82d85d3d29',
-      'f87328a8ea5208946c60dbd9385d4c8533ad5dd8',
+      '0x5df603999c3d5ca2ab828339a9883585b1bce11b',
+      '0x441c07e32a609afd319ffbb66432b424058bcfe9',
+      '0x1f7c93dfe849c06dd610e77473bfaaef7f183c7c',
+      '0x9e28bae18e0e358b12796697c6546f77d4657527',
+      '0x6e7734c7f4fb973a3800b72fb1a6bf82d85d3d29',
+      '0xf87328a8ea5208946c60dbd9385d4c8533ad5dd8',
     ],
   },
 
@@ -36,7 +36,7 @@ export default {
       'f29d6ddd6b0cd1fd59ed99900edd5a53e905b87dfe06824751010feb5228d960',
     publicKey:
       '04f7e989b55ebf3f9acfd32303e83069a9e4220bfc128f962325e6aa87e0f11f902a188c3f22f975c064a20c12b5523c53735f42467f2b83546869180abc42751e',
-    address: 'b9f89177a4ce589e6d18c33a9748bcc8063836df',
+    address: '0xb9f89177a4ce589e6d18c33a9748bcc8063836df',
     // The path used is modified from the ethereumjs-wallet original, which
     // isn't BIP-44 compatible. Since we're testing against their
     // implementation, not any reference values, this is fine.
@@ -50,49 +50,49 @@ export default {
     sampleAddressIndices: [
       {
         index: 0,
-        address: 'c5ba325f997531b5f0f50868913f0ce2fc0386bd',
+        address: '0xc5ba325f997531b5f0f50868913f0ce2fc0386bd',
         publicKey:
           '0438e5105bf4d908b40743bd3fc0e8e4ac281872086bf3323dfb4459a8b147aaa74b2b6624479ce069d60ff41336ce7eb0613f66ee91ba72a7581144134d814624',
       },
       {
         index: 1,
-        address: '326aa42f2b600f624d800e109b1e146906bc8175',
+        address: '0x326aa42f2b600f624d800e109b1e146906bc8175',
         publicKey:
           '04fcdae40d78db4aaa196c8f421f9d9243934f4abc69de95dd27522e275de7276b486b6219ad930775127a5645a226a716a52accc456cd93ea82f56ee98994cf6e',
       },
       {
         index: 5,
-        address: '6d0cc8671c91559d5f2d43de9c33eee0497db7cd',
+        address: '0x6d0cc8671c91559d5f2d43de9c33eee0497db7cd',
         publicKey:
           '04226d57014fd0e9eea04a6de8e2071b111b42a102e416f21529698acfec7b78a0ba774dd957dfb6c71f3c597b7cb3ee9c08eeb48f7bf34a8dc24319d743339346',
       },
       {
         index: 50,
-        address: '7bf971adda7f4487ac8f3dbd7450463ff3624f94',
+        address: '0x7bf971adda7f4487ac8f3dbd7450463ff3624f94',
         publicKey:
           '04c7fa0b4154bcb1e2d854c035ba591c3b87ccfbf3fafd0ed30585a1f843e79efcea470920b3fba70524b8a9854ddcfa05192de7d54154e28a8156b5d83a3a7883',
       },
       {
         index: 500,
-        address: '564d7507d39a881d04bffc0120ebd331e7c41758',
+        address: '0x564d7507d39a881d04bffc0120ebd331e7c41758',
         publicKey:
           '0461091945ed21fa036f0e97b4135fc01fb936910989519ba9a8c1c0867f3b34fbe6941f8529d1771532d79fdb2060cecaa12f12323086aec6eeb2ba9a9d9af3e9',
       },
       {
         index: 5000,
-        address: '7496ff062c1fe3e750dff9cbbe317558161ba6db',
+        address: '0x7496ff062c1fe3e750dff9cbbe317558161ba6db',
         publicKey:
           '04cceed14fef73e6c61e648761df3489e6cd87dfbcfa20241fd001675654ecb3d8a0d3b50410a9444de6d38af04f28add1ae12280889b5816dfc66a597cea539ec',
       },
       {
         index: 4_999_999,
-        address: 'ddf1f1a72a668d5014ec57a24019291fd2a00197',
+        address: '0xddf1f1a72a668d5014ec57a24019291fd2a00197',
         publicKey:
           '04b1eed5ab048a7de8939c1a9536d04076982454d7883ec665e4e7da4d457f99842df19468193267e93ec3e4faa5be9602072a6aad69de0f1687a5f1ea57a93a4c',
       },
       {
         index: 5_000_000,
-        address: '24dd12b9df5375f3b7fc5a539d4ac1bd2c16e9a0',
+        address: '0x24dd12b9df5375f3b7fc5a539d4ac1bd2c16e9a0',
         publicKey:
           '04e2ddbc99b6e0f8fc4e62242e375a49a8d856d6865607db474d444d4b729e28e3c80172acc9473b8ba6eaa7c893864589df35ca10d42ca9937cd6c77768871374',
       },


### PR DESCRIPTION
Closes #46.

Additional to adding support for public key derivation, I changed the signatures for some functions to use objects, rather than tuples or parameters. This prevents situations where we need to pass `undefined` in place for a private key, for example.