### PR TITLE
Add extended public (`xpub`) and private (`xprv`) keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@noble/ed25519": "^1.6.0",
     "@noble/hashes": "^1.0.0",
     "@noble/secp256k1": "^1.5.5",
+    "@scure/base": "^1.0.0",
     "@scure/bip39": "^1.0.0"
   },
   "devDependencies": {

--- a/src/BIP44CoinTypeNode.test.ts
+++ b/src/BIP44CoinTypeNode.test.ts
@@ -70,30 +70,37 @@ describe('BIP44CoinTypeNode', () => {
 
     it('throws if node has invalid key', async () => {
       const arbitraryCoinType = 78;
+
+      const options = {
+        depth: 2,
+        index: 0,
+        parentFingerprint: 0,
+      };
+
       const inputs = [
         {
           privateKey: '0xf00',
           publicKey: Buffer.alloc(65, 1),
           chainCode: Buffer.alloc(32, 1),
-          depth: 2,
+          ...options,
         },
         {
           privateKey: Buffer.allocUnsafe(64).fill(1).toString('hex'),
           publicKey: Buffer.alloc(65, 1),
           chainCode: Buffer.alloc(32, 1),
-          depth: 2,
+          ...options,
         },
         {
           privateKey: Buffer.allocUnsafe(63).fill(1).toString('hex'),
           publicKey: Buffer.alloc(65, 1),
           chainCode: Buffer.alloc(32, 1),
-          depth: 2,
+          ...options,
         },
         {
           privateKey: Buffer.alloc(64).toString('hex'),
           publicKey: Buffer.alloc(65, 1),
           chainCode: Buffer.alloc(32, 1),
-          depth: 2,
+          ...options,
         },
       ];
 
@@ -350,6 +357,25 @@ describe('BIP44CoinTypeNode', () => {
       const parentNode = await BIP44CoinTypeNode.fromNode(node, coinType);
 
       expect(parentNode.publicKey).toBe(node.publicKey);
+    });
+  });
+
+  describe('compressedPublicKeyBuffer', () => {
+    it('returns the compressed public key for a node', async () => {
+      const coinType = 60;
+      const node = await BIP44Node.fromDerivationPath({
+        derivationPath: [
+          defaultBip39NodeToken,
+          BIP44PurposeNodeToken,
+          `bip32:${coinType}'`,
+        ],
+      });
+
+      const parentNode = await BIP44CoinTypeNode.fromNode(node, coinType);
+
+      expect(parentNode.compressedPublicKeyBuffer).toStrictEqual(
+        node.compressedPublicKeyBuffer,
+      );
     });
   });
 

--- a/src/BIP44CoinTypeNode.test.ts
+++ b/src/BIP44CoinTypeNode.test.ts
@@ -37,6 +37,8 @@ describe('BIP44CoinTypeNode', () => {
       expect(node.toJSON()).toStrictEqual({
         coin_type: coinType,
         depth: 2,
+        parentFingerprint: 0,
+        index: 0,
         path: pathString,
         privateKey: node.privateKey,
         publicKey: node.publicKey,
@@ -159,6 +161,8 @@ describe('BIP44CoinTypeNode', () => {
       expect(node.toJSON()).toStrictEqual({
         coin_type: coinType,
         depth: 2,
+        parentFingerprint: 0,
+        index: 0,
         path: pathString,
         privateKey: node.privateKey,
         publicKey: node.publicKey,
@@ -193,6 +197,8 @@ describe('BIP44CoinTypeNode', () => {
       expect(node.toJSON()).toStrictEqual({
         coin_type: coinType,
         depth: 2,
+        parentFingerprint: 0,
+        index: 0,
         path: pathString,
         privateKey: node.privateKey,
         publicKey: node.publicKey,
@@ -382,6 +388,8 @@ describe('BIP44CoinTypeNode', () => {
       expect(nodeJson).toStrictEqual({
         coin_type: coinType,
         depth: 2,
+        parentFingerprint: 0,
+        index: 0,
         path: pathString,
         privateKey: node.privateKey,
         publicKey: node.publicKey,
@@ -391,6 +399,8 @@ describe('BIP44CoinTypeNode', () => {
       expect(JSON.parse(JSON.stringify(nodeJson))).toStrictEqual({
         coin_type: coinType,
         depth: 2,
+        parentFingerprint: 0,
+        index: 0,
         path: pathString,
         privateKey: node.privateKey,
         publicKey: node.publicKey,

--- a/src/BIP44CoinTypeNode.test.ts
+++ b/src/BIP44CoinTypeNode.test.ts
@@ -664,6 +664,35 @@ describe('deriveBIP44AddressKey', () => {
     expect(childNode.chainCode).toStrictEqual(expectedNode.chainCode);
   });
 
+  it('derives a BIP-44 address key (extended key)', async () => {
+    const coinType = 60;
+    const node = await BIP44Node.fromDerivationPath({
+      derivationPath: [
+        defaultBip39NodeToken,
+        BIP44PurposeNodeToken,
+        `bip32:${coinType}'`,
+      ],
+    });
+
+    const expectedNode = await BIP44Node.fromDerivationPath({
+      derivationPath: [
+        defaultBip39NodeToken,
+        BIP44PurposeNodeToken,
+        `bip32:${coinType}'`,
+        `bip32:0'`,
+        `bip32:0`,
+        `bip32:0`,
+      ],
+    });
+
+    const childNode = await deriveBIP44AddressKey(node.extendedKey, {
+      address_index: 0,
+    });
+
+    expect(childNode.privateKey).toStrictEqual(expectedNode.privateKey);
+    expect(childNode.chainCode).toStrictEqual(expectedNode.chainCode);
+  });
+
   it('throws if a node value is invalid', async () => {
     const coinType = 60;
     const parentNode = await BIP44CoinTypeNode.fromDerivationPath([
@@ -1047,6 +1076,39 @@ describe('getBIP44AddressKeyDeriver', () => {
     const expectedPath = `m / bip32:44' / bip32:${coinType}' / bip32:0' / bip32:0`;
 
     const deriver = await getBIP44AddressKeyDeriver(parentNode);
+    expect(deriver.coin_type).toStrictEqual(coinType);
+    expect(deriver.path).toStrictEqual(expectedPath);
+
+    const expectedNode = await BIP44Node.fromDerivationPath({
+      derivationPath: [
+        defaultBip39NodeToken,
+        BIP44PurposeNodeToken,
+        `bip32:${coinType}'`,
+        `bip32:0'`,
+        `bip32:0`,
+        `bip32:0`,
+      ],
+    });
+
+    const childNode = await deriver(0);
+
+    expect(childNode.privateKey).toStrictEqual(expectedNode.privateKey);
+    expect(childNode.chainCode).toStrictEqual(expectedNode.chainCode);
+  });
+
+  it('returns the expected BIP-44 address key deriver function (extended key)', async () => {
+    const coinType = 60;
+    const node = await BIP44Node.fromDerivationPath({
+      derivationPath: [
+        defaultBip39NodeToken,
+        BIP44PurposeNodeToken,
+        `bip32:${coinType}'`,
+      ],
+    });
+
+    const expectedPath = `m / bip32:44' / bip32:${coinType}' / bip32:0' / bip32:0`;
+
+    const deriver = await getBIP44AddressKeyDeriver(node.extendedKey);
     expect(deriver.coin_type).toStrictEqual(coinType);
     expect(deriver.path).toStrictEqual(expectedPath);
 

--- a/src/BIP44CoinTypeNode.test.ts
+++ b/src/BIP44CoinTypeNode.test.ts
@@ -36,9 +36,9 @@ describe('BIP44CoinTypeNode', () => {
 
       expect(node.toJSON()).toStrictEqual({
         coin_type: coinType,
-        depth: 2,
-        parentFingerprint: 0,
-        index: 0,
+        depth: node.depth,
+        parentFingerprint: node.parentFingerprint,
+        index: node.index,
         path: pathString,
         privateKey: node.privateKey,
         publicKey: node.publicKey,
@@ -160,9 +160,9 @@ describe('BIP44CoinTypeNode', () => {
 
       expect(node.toJSON()).toStrictEqual({
         coin_type: coinType,
-        depth: 2,
-        parentFingerprint: 0,
-        index: 0,
+        depth: node.depth,
+        parentFingerprint: node.parentFingerprint,
+        index: node.index,
         path: pathString,
         privateKey: node.privateKey,
         publicKey: node.publicKey,
@@ -196,9 +196,9 @@ describe('BIP44CoinTypeNode', () => {
 
       expect(node.toJSON()).toStrictEqual({
         coin_type: coinType,
-        depth: 2,
-        parentFingerprint: 0,
-        index: 0,
+        depth: node.depth,
+        parentFingerprint: node.parentFingerprint,
+        index: node.index,
         path: pathString,
         privateKey: node.privateKey,
         publicKey: node.publicKey,
@@ -251,8 +251,8 @@ describe('BIP44CoinTypeNode', () => {
         address_index: 0,
       });
 
-      expect(childNode.privateKey).toStrictEqual(node.privateKeyBuffer);
-      expect(childNode.chainCode).toStrictEqual(node.chainCodeBuffer);
+      expect(childNode.privateKey).toStrictEqual(node.privateKey);
+      expect(childNode.chainCode).toStrictEqual(node.chainCode);
     });
 
     it('derives an address_index key (default inputs, different address_index)', async () => {
@@ -270,8 +270,8 @@ describe('BIP44CoinTypeNode', () => {
         address_index: 99,
       });
 
-      expect(childNode.privateKey).toStrictEqual(node.privateKeyBuffer);
-      expect(childNode.chainCode).toStrictEqual(node.chainCodeBuffer);
+      expect(childNode.privateKey).toStrictEqual(node.privateKey);
+      expect(childNode.chainCode).toStrictEqual(node.chainCode);
     });
 
     it('derives an address_index key (non-default account value)', async () => {
@@ -290,8 +290,8 @@ describe('BIP44CoinTypeNode', () => {
         address_index: 0,
       });
 
-      expect(childNode.privateKey).toStrictEqual(node.privateKeyBuffer);
-      expect(childNode.chainCode).toStrictEqual(node.chainCodeBuffer);
+      expect(childNode.privateKey).toStrictEqual(node.privateKey);
+      expect(childNode.chainCode).toStrictEqual(node.chainCode);
     });
 
     it('derives an address_index key (non-default change value)', async () => {
@@ -310,8 +310,8 @@ describe('BIP44CoinTypeNode', () => {
         address_index: 0,
       });
 
-      expect(childNode.privateKey).toStrictEqual(node.privateKeyBuffer);
-      expect(childNode.chainCode).toStrictEqual(node.chainCodeBuffer);
+      expect(childNode.privateKey).toStrictEqual(node.privateKey);
+      expect(childNode.chainCode).toStrictEqual(node.chainCode);
     });
 
     it('derives an address_index key (non-default account and change values)', async () => {
@@ -331,8 +331,8 @@ describe('BIP44CoinTypeNode', () => {
         address_index: 0,
       });
 
-      expect(childNode.privateKey).toStrictEqual(node.privateKeyBuffer);
-      expect(childNode.chainCode).toStrictEqual(node.chainCodeBuffer);
+      expect(childNode.privateKey).toStrictEqual(node.privateKey);
+      expect(childNode.chainCode).toStrictEqual(node.chainCode);
     });
   });
 
@@ -387,9 +387,9 @@ describe('BIP44CoinTypeNode', () => {
       const nodeJson = node.toJSON();
       expect(nodeJson).toStrictEqual({
         coin_type: coinType,
-        depth: 2,
-        parentFingerprint: 0,
-        index: 0,
+        depth: node.depth,
+        parentFingerprint: node.parentFingerprint,
+        index: node.index,
         path: pathString,
         privateKey: node.privateKey,
         publicKey: node.publicKey,
@@ -398,9 +398,9 @@ describe('BIP44CoinTypeNode', () => {
 
       expect(JSON.parse(JSON.stringify(nodeJson))).toStrictEqual({
         coin_type: coinType,
-        depth: 2,
-        parentFingerprint: 0,
-        index: 0,
+        depth: node.depth,
+        parentFingerprint: node.parentFingerprint,
+        index: node.index,
         path: pathString,
         privateKey: node.privateKey,
         publicKey: node.publicKey,
@@ -434,8 +434,8 @@ describe('deriveBIP44AddressKey', () => {
       address_index: 0,
     });
 
-    expect(childNode.privateKey).toStrictEqual(node.privateKeyBuffer);
-    expect(childNode.chainCode).toStrictEqual(node.chainCodeBuffer);
+    expect(childNode.privateKey).toStrictEqual(node.privateKey);
+    expect(childNode.chainCode).toStrictEqual(node.chainCode);
   });
 
   it('derives an address_index key (default inputs, different address_index)', async () => {
@@ -461,8 +461,8 @@ describe('deriveBIP44AddressKey', () => {
       address_index: 3333,
     });
 
-    expect(childNode.privateKey).toStrictEqual(node.privateKeyBuffer);
-    expect(childNode.chainCode).toStrictEqual(node.chainCodeBuffer);
+    expect(childNode.privateKey).toStrictEqual(node.privateKey);
+    expect(childNode.chainCode).toStrictEqual(node.chainCode);
   });
 
   it('derives an address_index key (default inputs, object address_index)', async () => {
@@ -491,8 +491,8 @@ describe('deriveBIP44AddressKey', () => {
       },
     });
 
-    expect(childNode.privateKey).toStrictEqual(node.privateKeyBuffer);
-    expect(childNode.chainCode).toStrictEqual(node.chainCodeBuffer);
+    expect(childNode.privateKey).toStrictEqual(node.privateKey);
+    expect(childNode.chainCode).toStrictEqual(node.chainCode);
   });
 
   it('derives an address_index key (default inputs, hardened address_index)', async () => {
@@ -521,8 +521,8 @@ describe('deriveBIP44AddressKey', () => {
       },
     });
 
-    expect(childNode.privateKey).toStrictEqual(node.privateKeyBuffer);
-    expect(childNode.chainCode).toStrictEqual(node.chainCodeBuffer);
+    expect(childNode.privateKey).toStrictEqual(node.privateKey);
+    expect(childNode.chainCode).toStrictEqual(node.chainCode);
   });
 
   it('derives a BIP-44 address key (non-default account value)', async () => {
@@ -549,8 +549,8 @@ describe('deriveBIP44AddressKey', () => {
       address_index: 0,
     });
 
-    expect(childNode.privateKey).toStrictEqual(node.privateKeyBuffer);
-    expect(childNode.chainCode).toStrictEqual(node.chainCodeBuffer);
+    expect(childNode.privateKey).toStrictEqual(node.privateKey);
+    expect(childNode.chainCode).toStrictEqual(node.chainCode);
   });
 
   it('derives a BIP-44 address key (non-default change value)', async () => {
@@ -577,8 +577,8 @@ describe('deriveBIP44AddressKey', () => {
       address_index: 0,
     });
 
-    expect(childNode.privateKey).toStrictEqual(node.privateKeyBuffer);
-    expect(childNode.chainCode).toStrictEqual(node.chainCodeBuffer);
+    expect(childNode.privateKey).toStrictEqual(node.privateKey);
+    expect(childNode.chainCode).toStrictEqual(node.chainCode);
   });
 
   it('derives a BIP-44 address key (non-default account and change values)', async () => {
@@ -606,8 +606,8 @@ describe('deriveBIP44AddressKey', () => {
       address_index: 0,
     });
 
-    expect(childNode.privateKey).toStrictEqual(node.privateKeyBuffer);
-    expect(childNode.chainCode).toStrictEqual(node.chainCodeBuffer);
+    expect(childNode.privateKey).toStrictEqual(node.privateKey);
+    expect(childNode.chainCode).toStrictEqual(node.chainCode);
   });
 
   it('derives a BIP-44 address key (JSON node)', async () => {
@@ -634,8 +634,8 @@ describe('deriveBIP44AddressKey', () => {
       address_index: 0,
     });
 
-    expect(childNode.privateKey).toStrictEqual(expectedNode.privateKeyBuffer);
-    expect(childNode.chainCode).toStrictEqual(expectedNode.chainCodeBuffer);
+    expect(childNode.privateKey).toStrictEqual(expectedNode.privateKey);
+    expect(childNode.chainCode).toStrictEqual(expectedNode.chainCode);
   });
 
   it('throws if a node value is invalid', async () => {
@@ -704,7 +704,7 @@ describe('getBIP44AddressKeyDeriver', () => {
     ]);
     const expectedPath = `m / bip32:44' / bip32:${coinType}' / bip32:0' / bip32:0`;
 
-    const deriver = getBIP44AddressKeyDeriver(parentNode);
+    const deriver = await getBIP44AddressKeyDeriver(parentNode);
     expect(deriver.coin_type).toStrictEqual(coinType);
     expect(deriver.path).toStrictEqual(expectedPath);
 
@@ -721,8 +721,8 @@ describe('getBIP44AddressKeyDeriver', () => {
 
     const childNode = await deriver(0);
 
-    expect(childNode.privateKey).toStrictEqual(node.privateKeyBuffer);
-    expect(childNode.chainCode).toStrictEqual(node.chainCodeBuffer);
+    expect(childNode.privateKey).toStrictEqual(node.privateKey);
+    expect(childNode.chainCode).toStrictEqual(node.chainCode);
   });
 
   it('returns the expected BIP-44 address key deriver function and derives a hardened index (default inputs)', async () => {
@@ -734,7 +734,7 @@ describe('getBIP44AddressKeyDeriver', () => {
     ]);
     const expectedPath = `m / bip32:44' / bip32:${coinType}' / bip32:0' / bip32:0`;
 
-    const deriver = getBIP44AddressKeyDeriver(parentNode);
+    const deriver = await getBIP44AddressKeyDeriver(parentNode);
     expect(deriver.coin_type).toStrictEqual(coinType);
     expect(deriver.path).toStrictEqual(expectedPath);
 
@@ -751,8 +751,8 @@ describe('getBIP44AddressKeyDeriver', () => {
 
     const childNode = await deriver(0, true);
 
-    expect(childNode.privateKey).toStrictEqual(node.privateKeyBuffer);
-    expect(childNode.chainCode).toStrictEqual(node.chainCodeBuffer);
+    expect(childNode.privateKey).toStrictEqual(node.privateKey);
+    expect(childNode.chainCode).toStrictEqual(node.chainCode);
   });
 
   it('returns the expected BIP-44 address key deriver function and derives a hardened index (default inputs, different address_index)', async () => {
@@ -764,7 +764,7 @@ describe('getBIP44AddressKeyDeriver', () => {
     ]);
     const expectedPath = `m / bip32:44' / bip32:${coinType}' / bip32:0' / bip32:0`;
 
-    const deriver = getBIP44AddressKeyDeriver(parentNode);
+    const deriver = await getBIP44AddressKeyDeriver(parentNode);
     expect(deriver.coin_type).toStrictEqual(coinType);
     expect(deriver.path).toStrictEqual(expectedPath);
 
@@ -781,8 +781,8 @@ describe('getBIP44AddressKeyDeriver', () => {
 
     const childNode = await deriver(9873, true);
 
-    expect(childNode.privateKey).toStrictEqual(node.privateKeyBuffer);
-    expect(childNode.chainCode).toStrictEqual(node.chainCodeBuffer);
+    expect(childNode.privateKey).toStrictEqual(node.privateKey);
+    expect(childNode.chainCode).toStrictEqual(node.chainCode);
   });
 
   it('returns the expected BIP-44 address key deriver function (different coin_type)', async () => {
@@ -794,7 +794,7 @@ describe('getBIP44AddressKeyDeriver', () => {
     ]);
     const expectedPath = `m / bip32:44' / bip32:${coinType}' / bip32:0' / bip32:0`;
 
-    const deriver = getBIP44AddressKeyDeriver(parentNode);
+    const deriver = await getBIP44AddressKeyDeriver(parentNode);
     expect(deriver.coin_type).toStrictEqual(coinType);
     expect(deriver.path).toStrictEqual(expectedPath);
 
@@ -811,8 +811,8 @@ describe('getBIP44AddressKeyDeriver', () => {
 
     const childNode = await deriver(0);
 
-    expect(childNode.privateKey).toStrictEqual(node.privateKeyBuffer);
-    expect(childNode.chainCode).toStrictEqual(node.chainCodeBuffer);
+    expect(childNode.privateKey).toStrictEqual(node.privateKey);
+    expect(childNode.chainCode).toStrictEqual(node.chainCode);
   });
 
   it('returns the expected BIP-44 address key deriver function (default inputs, different address_index)', async () => {
@@ -824,7 +824,7 @@ describe('getBIP44AddressKeyDeriver', () => {
     ]);
     const expectedPath = `m / bip32:44' / bip32:${coinType}' / bip32:0' / bip32:0`;
 
-    const deriver = getBIP44AddressKeyDeriver(parentNode);
+    const deriver = await getBIP44AddressKeyDeriver(parentNode);
     expect(deriver.coin_type).toStrictEqual(coinType);
     expect(deriver.path).toStrictEqual(expectedPath);
 
@@ -841,8 +841,8 @@ describe('getBIP44AddressKeyDeriver', () => {
 
     const childNode = await deriver(9873);
 
-    expect(childNode.privateKey).toStrictEqual(node.privateKeyBuffer);
-    expect(childNode.chainCode).toStrictEqual(node.chainCodeBuffer);
+    expect(childNode.privateKey).toStrictEqual(node.privateKey);
+    expect(childNode.chainCode).toStrictEqual(node.chainCode);
   });
 
   it('returns the expected BIP-44 address key deriver function (non-default account value)', async () => {
@@ -854,7 +854,9 @@ describe('getBIP44AddressKeyDeriver', () => {
     ]);
     const expectedPath = `m / bip32:44' / bip32:${coinType}' / bip32:46' / bip32:0`;
 
-    const deriver = getBIP44AddressKeyDeriver(parentNode, { account: 46 });
+    const deriver = await getBIP44AddressKeyDeriver(parentNode, {
+      account: 46,
+    });
     expect(deriver.coin_type).toStrictEqual(coinType);
     expect(deriver.path).toStrictEqual(expectedPath);
 
@@ -871,8 +873,8 @@ describe('getBIP44AddressKeyDeriver', () => {
 
     const childNode = await deriver(0);
 
-    expect(childNode.privateKey).toStrictEqual(node.privateKeyBuffer);
-    expect(childNode.chainCode).toStrictEqual(node.chainCodeBuffer);
+    expect(childNode.privateKey).toStrictEqual(node.privateKey);
+    expect(childNode.chainCode).toStrictEqual(node.chainCode);
   });
 
   it('returns the expected BIP-44 address key deriver function (non-default change value)', async () => {
@@ -884,7 +886,7 @@ describe('getBIP44AddressKeyDeriver', () => {
     ]);
     const expectedPath = `m / bip32:44' / bip32:${coinType}' / bip32:0' / bip32:2`;
 
-    const deriver = getBIP44AddressKeyDeriver(parentNode, { change: 2 });
+    const deriver = await getBIP44AddressKeyDeriver(parentNode, { change: 2 });
     expect(deriver.coin_type).toStrictEqual(coinType);
     expect(deriver.path).toStrictEqual(expectedPath);
 
@@ -901,8 +903,8 @@ describe('getBIP44AddressKeyDeriver', () => {
 
     const childNode = await deriver(0);
 
-    expect(childNode.privateKey).toStrictEqual(node.privateKeyBuffer);
-    expect(childNode.chainCode).toStrictEqual(node.chainCodeBuffer);
+    expect(childNode.privateKey).toStrictEqual(node.privateKey);
+    expect(childNode.chainCode).toStrictEqual(node.chainCode);
   });
 
   it('returns the expected BIP-44 address key deriver function (object change value)', async () => {
@@ -914,7 +916,7 @@ describe('getBIP44AddressKeyDeriver', () => {
     ]);
     const expectedPath = `m / bip32:44' / bip32:${coinType}' / bip32:0' / bip32:2`;
 
-    const deriver = getBIP44AddressKeyDeriver(parentNode, {
+    const deriver = await getBIP44AddressKeyDeriver(parentNode, {
       change: {
         index: 2,
         hardened: false,
@@ -936,8 +938,8 @@ describe('getBIP44AddressKeyDeriver', () => {
 
     const childNode = await deriver(0);
 
-    expect(childNode.privateKey).toStrictEqual(node.privateKeyBuffer);
-    expect(childNode.chainCode).toStrictEqual(node.chainCodeBuffer);
+    expect(childNode.privateKey).toStrictEqual(node.privateKey);
+    expect(childNode.chainCode).toStrictEqual(node.chainCode);
   });
 
   it('returns the expected BIP-44 address key deriver function (hardened change value)', async () => {
@@ -949,7 +951,7 @@ describe('getBIP44AddressKeyDeriver', () => {
     ]);
     const expectedPath = `m / bip32:44' / bip32:${coinType}' / bip32:0' / bip32:2'`;
 
-    const deriver = getBIP44AddressKeyDeriver(parentNode, {
+    const deriver = await getBIP44AddressKeyDeriver(parentNode, {
       change: {
         index: 2,
         hardened: true,
@@ -971,8 +973,8 @@ describe('getBIP44AddressKeyDeriver', () => {
 
     const childNode = await deriver(0);
 
-    expect(childNode.privateKey).toStrictEqual(node.privateKeyBuffer);
-    expect(childNode.chainCode).toStrictEqual(node.chainCodeBuffer);
+    expect(childNode.privateKey).toStrictEqual(node.privateKey);
+    expect(childNode.chainCode).toStrictEqual(node.chainCode);
   });
 
   it('returns the expected BIP-44 address key deriver function (non-default account and change values)', async () => {
@@ -984,7 +986,7 @@ describe('getBIP44AddressKeyDeriver', () => {
     ]);
     const expectedPath = `m / bip32:44' / bip32:${coinType}' / bip32:46' / bip32:2`;
 
-    const deriver = getBIP44AddressKeyDeriver(parentNode, {
+    const deriver = await getBIP44AddressKeyDeriver(parentNode, {
       account: 46,
       change: 2,
     });
@@ -1004,8 +1006,8 @@ describe('getBIP44AddressKeyDeriver', () => {
 
     const childNode = await deriver(0);
 
-    expect(childNode.privateKey).toStrictEqual(node.privateKeyBuffer);
-    expect(childNode.chainCode).toStrictEqual(node.chainCodeBuffer);
+    expect(childNode.privateKey).toStrictEqual(node.privateKey);
+    expect(childNode.chainCode).toStrictEqual(node.chainCode);
   });
 
   it('returns the expected BIP-44 address key deriver function (JSON node)', async () => {
@@ -1018,7 +1020,7 @@ describe('getBIP44AddressKeyDeriver', () => {
     const parentNode = node.toJSON();
     const expectedPath = `m / bip32:44' / bip32:${coinType}' / bip32:0' / bip32:0`;
 
-    const deriver = getBIP44AddressKeyDeriver(parentNode);
+    const deriver = await getBIP44AddressKeyDeriver(parentNode);
     expect(deriver.coin_type).toStrictEqual(coinType);
     expect(deriver.path).toStrictEqual(expectedPath);
 
@@ -1035,8 +1037,8 @@ describe('getBIP44AddressKeyDeriver', () => {
 
     const childNode = await deriver(0);
 
-    expect(childNode.privateKey).toStrictEqual(expectedNode.privateKeyBuffer);
-    expect(childNode.chainCode).toStrictEqual(expectedNode.chainCodeBuffer);
+    expect(childNode.privateKey).toStrictEqual(expectedNode.privateKey);
+    expect(childNode.chainCode).toStrictEqual(expectedNode.chainCode);
   });
 
   it('throws if a node value is invalid', async () => {
@@ -1047,17 +1049,21 @@ describe('getBIP44AddressKeyDeriver', () => {
       `bip32:${coinType}'`,
     ]);
 
-    [
+    const inputs = [
       { account: -1 },
       { change: 1.1 },
       { account: NaN },
       { account: null },
       { account: {} },
-    ].forEach((invalidInput) => {
-      expect(() =>
+    ];
+
+    for (const invalidInput of inputs) {
+      await expect(
         getBIP44AddressKeyDeriver(parentNode, invalidInput as any),
-      ).toThrow(`Invalid BIP-32 index: Must be a non-negative integer.`);
-    });
+      ).rejects.toThrow(
+        `Invalid BIP-32 index: Must be a non-negative integer.`,
+      );
+    }
   });
 
   it('deriver throws if address_index value is invalid', async () => {
@@ -1070,7 +1076,7 @@ describe('getBIP44AddressKeyDeriver', () => {
 
     const expectedPath = `m / bip32:44' / bip32:${coinType}' / bip32:0' / bip32:0`;
 
-    const deriver = getBIP44AddressKeyDeriver(parentNode);
+    const deriver = await getBIP44AddressKeyDeriver(parentNode);
     expect(deriver.coin_type).toStrictEqual(coinType);
     expect(deriver.path).toStrictEqual(expectedPath);
 

--- a/src/BIP44CoinTypeNode.ts
+++ b/src/BIP44CoinTypeNode.ts
@@ -77,6 +77,8 @@ export class BIP44CoinTypeNode implements BIP44CoinTypeNodeInterface {
 
     const node = await BIP44Node.fromExtendedKey({
       depth: json.depth,
+      index: json.index,
+      parentFingerprint: json.parentFingerprint,
       chainCode: hexStringToBuffer(json.chainCode),
       privateKey: nullableHexStringToBuffer(json.privateKey),
       publicKey: hexStringToBuffer(json.publicKey),
@@ -190,6 +192,14 @@ export class BIP44CoinTypeNode implements BIP44CoinTypeNodeInterface {
 
   public get address(): string {
     return this.#node.address;
+  }
+
+  public get parentFingerprint(): number {
+    return this.#node.parentFingerprint;
+  }
+
+  public get index(): number {
+    return this.#node.index;
   }
 
   /**

--- a/src/BIP44CoinTypeNode.ts
+++ b/src/BIP44CoinTypeNode.ts
@@ -186,6 +186,10 @@ export class BIP44CoinTypeNode implements BIP44CoinTypeNodeInterface {
     return this.#node.publicKey;
   }
 
+  public get compressedPublicKeyBuffer(): Buffer {
+    return this.#node.compressedPublicKeyBuffer;
+  }
+
   public get chainCode(): string {
     return this.#node.chainCode;
   }
@@ -196,6 +200,10 @@ export class BIP44CoinTypeNode implements BIP44CoinTypeNodeInterface {
 
   public get parentFingerprint(): number {
     return this.#node.parentFingerprint;
+  }
+
+  public get fingerprint(): number {
+    return this.#node.fingerprint;
   }
 
   public get index(): number {

--- a/src/BIP44CoinTypeNode.ts
+++ b/src/BIP44CoinTypeNode.ts
@@ -18,7 +18,7 @@ import {
   hexStringToBuffer,
   nullableHexStringToBuffer,
 } from './utils';
-import { deriveChildNode, SLIP10Node } from './SLIP10Node';
+import { deriveChildNode } from './SLIP10Node';
 import { SupportedCurve } from './curves';
 
 export type CoinTypeHDPathTuple = [

--- a/src/BIP44Node.test.ts
+++ b/src/BIP44Node.test.ts
@@ -263,10 +263,8 @@ describe('BIP44Node', () => {
       const childNode = await node.neuter().derive([`bip32:0`]);
 
       expect(childNode.privateKey).toBeUndefined();
-      expect(childNode).toMatchObject({
-        depth: targetNode.depth,
-        publicKey: targetNode.publicKey,
-      });
+      expect(childNode.depth).toBe(targetNode.depth);
+      expect(childNode.publicKey).toBe(targetNode.publicKey);
     });
 
     it('throws if the parent node is already a leaf node', async () => {

--- a/src/BIP44Node.test.ts
+++ b/src/BIP44Node.test.ts
@@ -17,11 +17,15 @@ describe('BIP44Node', () => {
         privateKey,
         chainCode,
         depth: 2,
+        parentFingerprint: 0,
+        index: 0,
       });
 
       expect(node.depth).toStrictEqual(2);
       expect(node.toJSON()).toStrictEqual({
-        depth: 2,
+        depth: node.depth,
+        parentFingerprint: node.parentFingerprint,
+        index: node.index,
         privateKey: node.privateKey,
         publicKey: node.publicKey,
         chainCode: node.chainCode,
@@ -38,10 +42,34 @@ describe('BIP44Node', () => {
         privateKey,
         chainCode,
         depth: 2,
+        parentFingerprint: 0,
+        index: 0,
       });
 
       expect(await BIP44Node.fromJSON(node.toJSON())).toStrictEqual(node);
     });
+
+    it.each(fixtures.bip32)(
+      'initializes a node from an extended public key',
+      async ({ keys }) => {
+        for (const key of keys) {
+          const node = await BIP44Node.fromExtendedKey(key.extPubKey);
+          expect(node.privateKey).toBeUndefined();
+          expect(node.publicKey).toBe(key.publicKey);
+        }
+      },
+    );
+
+    it.each(fixtures.bip32)(
+      'initializes a node from an extended private key',
+      async ({ keys }) => {
+        for (const key of keys) {
+          const node = await BIP44Node.fromExtendedKey(key.extPrivKey);
+          expect(node.privateKey).toBe(key.privateKey);
+          expect(node.publicKey).toBe(key.publicKey);
+        }
+      },
+    );
 
     it('throws if the depth is invalid', async () => {
       const { privateKey, chainCode } = await deriveChildKey({
@@ -53,6 +81,8 @@ describe('BIP44Node', () => {
           depth: 6,
           privateKey,
           chainCode,
+          parentFingerprint: 0,
+          index: 0,
         }),
       ).rejects.toThrow(
         `Invalid HD tree path depth: The depth must be a positive integer N such that 0 <= N <= 5. Received: "6"`,
@@ -73,7 +103,9 @@ describe('BIP44Node', () => {
 
       expect(node.depth).toStrictEqual(2);
       expect(node.toJSON()).toStrictEqual({
-        depth: 2,
+        depth: node.depth,
+        parentFingerprint: node.parentFingerprint,
+        index: node.index,
         privateKey: node.privateKey,
         publicKey: node.publicKey,
         chainCode: node.chainCode,
@@ -350,6 +382,8 @@ describe('BIP44Node', () => {
           privateKey,
           chainCode,
           depth: 0,
+          parentFingerprint: 0,
+          index: 0,
         });
 
         const childNode = await node.derive([
@@ -377,6 +411,8 @@ describe('BIP44Node', () => {
           privateKey,
           chainCode,
           depth: 0,
+          parentFingerprint: 0,
+          index: 0,
         });
 
         const childNode = await node.derive([
@@ -423,6 +459,8 @@ describe('BIP44Node', () => {
       const nodeJson = node.toJSON();
       expect(nodeJson).toStrictEqual({
         depth: node.depth,
+        parentFingerprint: node.parentFingerprint,
+        index: node.index,
         privateKey: node.privateKey,
         publicKey: node.publicKey,
         chainCode: node.chainCode,
@@ -430,6 +468,8 @@ describe('BIP44Node', () => {
 
       expect(JSON.parse(JSON.stringify(nodeJson))).toStrictEqual({
         depth: node.depth,
+        parentFingerprint: node.parentFingerprint,
+        index: node.index,
         privateKey: node.privateKey,
         publicKey: node.publicKey,
         chainCode: node.chainCode,

--- a/src/BIP44Node.ts
+++ b/src/BIP44Node.ts
@@ -128,18 +128,6 @@ export class BIP44Node implements BIP44NodeInterface {
 
       const { chainCode, depth, parentFingerprint, index } = extendedKey;
 
-      if (extendedKey.version === PUBLIC_KEY_VERSION) {
-        const { publicKey } = extendedKey;
-
-        return BIP44Node.fromExtendedKey({
-          depth,
-          parentFingerprint,
-          index,
-          publicKey,
-          chainCode,
-        });
-      }
-
       if (extendedKey.version === PRIVATE_KEY_VERSION) {
         const { privateKey } = extendedKey;
 
@@ -152,9 +140,15 @@ export class BIP44Node implements BIP44NodeInterface {
         });
       }
 
-      throw new Error(
-        'Invalid extended key: Expected public or private key version.',
-      );
+      const { publicKey } = extendedKey;
+
+      return BIP44Node.fromExtendedKey({
+        depth,
+        parentFingerprint,
+        index,
+        publicKey,
+        chainCode,
+      });
     }
 
     const {

--- a/src/BIP44Node.ts
+++ b/src/BIP44Node.ts
@@ -17,6 +17,7 @@ import {
   PRIVATE_KEY_VERSION,
   PUBLIC_KEY_VERSION,
 } from './extended-keys';
+import { SupportedCurve } from './curves';
 
 type BIP44ExtendedKeyOptions = {
   readonly depth: number;
@@ -240,6 +241,10 @@ export class BIP44Node implements BIP44NodeInterface {
     return this.#node.publicKey;
   }
 
+  public get compressedPublicKeyBuffer(): Buffer {
+    return this.#node.compressedPublicKeyBuffer;
+  }
+
   public get chainCode(): string {
     return this.#node.chainCode;
   }
@@ -250,6 +255,10 @@ export class BIP44Node implements BIP44NodeInterface {
 
   public get parentFingerprint(): number {
     return this.#node.parentFingerprint;
+  }
+
+  public get fingerprint(): number {
+    return this.#node.fingerprint;
   }
 
   public get index(): number {
@@ -277,6 +286,10 @@ export class BIP44Node implements BIP44NodeInterface {
       version: PUBLIC_KEY_VERSION,
       publicKey: this.publicKeyBuffer,
     });
+  }
+
+  public get curve(): SupportedCurve {
+    return this.#node.curve;
   }
 
   constructor(node: SLIP10Node) {

--- a/src/SLIP10Node.test.ts
+++ b/src/SLIP10Node.test.ts
@@ -18,6 +18,8 @@ describe('SLIP10Node', () => {
         privateKey,
         chainCode,
         depth: 0,
+        parentFingerprint: 0,
+        index: 0,
         curve: 'secp256k1',
       });
 
@@ -35,6 +37,8 @@ describe('SLIP10Node', () => {
         privateKey: privateKey.toString('hex'),
         chainCode: chainCode.toString('hex'),
         depth: 0,
+        parentFingerprint: 0,
+        index: 0,
         curve: 'secp256k1',
       });
 
@@ -52,6 +56,8 @@ describe('SLIP10Node', () => {
         privateKey,
         chainCode,
         depth: 0,
+        parentFingerprint: 0,
+        index: 0,
         curve: 'ed25519',
       });
 
@@ -69,6 +75,8 @@ describe('SLIP10Node', () => {
         privateKey,
         chainCode,
         depth: 0,
+        parentFingerprint: 0,
+        index: 0,
         curve: 'secp256k1',
       });
 
@@ -76,6 +84,8 @@ describe('SLIP10Node', () => {
         publicKey: privateNode.publicKeyBuffer,
         chainCode: privateNode.chainCodeBuffer,
         depth: 0,
+        parentFingerprint: 0,
+        index: 0,
         curve: 'secp256k1',
       });
 
@@ -93,6 +103,8 @@ describe('SLIP10Node', () => {
         privateKey,
         chainCode,
         depth: 0,
+        parentFingerprint: 0,
+        index: 0,
         curve: 'ed25519',
       });
 
@@ -100,6 +112,8 @@ describe('SLIP10Node', () => {
         publicKey: privateNode.publicKeyBuffer,
         chainCode: privateNode.chainCodeBuffer,
         depth: 0,
+        parentFingerprint: 0,
+        index: 0,
         curve: 'ed25519',
       });
 
@@ -117,6 +131,8 @@ describe('SLIP10Node', () => {
         privateKey,
         chainCode,
         depth: 0,
+        parentFingerprint: 0,
+        index: 0,
         curve: 'secp256k1',
       });
 
@@ -124,6 +140,8 @@ describe('SLIP10Node', () => {
         publicKey: privateNode.publicKey,
         chainCode: privateNode.chainCode,
         depth: 0,
+        parentFingerprint: 0,
+        index: 0,
         curve: 'secp256k1',
       });
 
@@ -141,6 +159,8 @@ describe('SLIP10Node', () => {
         privateKey,
         chainCode,
         depth: 0,
+        parentFingerprint: 0,
+        index: 0,
         curve: 'secp256k1',
       });
 
@@ -156,6 +176,8 @@ describe('SLIP10Node', () => {
         privateKey,
         chainCode,
         depth: 0,
+        parentFingerprint: 0,
+        index: 0,
         curve: 'secp256k1',
       });
 
@@ -171,6 +193,8 @@ describe('SLIP10Node', () => {
         SLIP10Node.fromExtendedKey({
           chainCode: Buffer.alloc(32, 1),
           depth: 0,
+          parentFingerprint: 0,
+          index: 0,
           curve: 'secp256k1',
         }),
       ).rejects.toThrow(
@@ -196,6 +220,8 @@ describe('SLIP10Node', () => {
         await expect(
           SLIP10Node.fromExtendedKey({
             depth: input as any,
+            parentFingerprint: 0,
+            index: 0,
             publicKey: Buffer.alloc(65, 1),
             chainCode: Buffer.alloc(32, 1),
             curve: 'secp256k1',
@@ -212,6 +238,8 @@ describe('SLIP10Node', () => {
           privateKey: 'foo',
           chainCode: Buffer.alloc(32, 1),
           depth: 0,
+          parentFingerprint: 0,
+          index: 0,
           curve: 'secp256k1',
         }),
       ).rejects.toThrow(
@@ -248,7 +276,9 @@ describe('SLIP10Node', () => {
 
       expect(node.depth).toStrictEqual(2);
       expect(node.toJSON()).toStrictEqual({
-        depth: 2,
+        depth: node.depth,
+        parentFingerprint: node.parentFingerprint,
+        index: node.index,
         curve: 'secp256k1',
         privateKey: node.privateKey,
         publicKey: node.publicKey,
@@ -447,6 +477,8 @@ describe('SLIP10Node', () => {
             chainCode,
             curve: 'ed25519',
             depth: 0,
+            parentFingerprint: 0,
+            index: 0,
           });
 
           if (path.ours.tuple.length === 0) {
@@ -473,6 +505,8 @@ describe('SLIP10Node', () => {
             chainCode,
             curve: 'secp256k1',
             depth: 0,
+            parentFingerprint: 0,
+            index: 0,
           });
 
           if (path.ours.tuple.length === 0) {
@@ -503,6 +537,8 @@ describe('SLIP10Node', () => {
           chainCode,
           curve: 'secp256k1',
           depth: 0,
+          parentFingerprint: 0,
+          index: 0,
         });
 
         const childNode = await node.derive([
@@ -566,6 +602,8 @@ describe('SLIP10Node', () => {
       const nodeJson = node.toJSON();
       expect(nodeJson).toStrictEqual({
         depth: node.depth,
+        parentFingerprint: node.parentFingerprint,
+        index: node.index,
         curve: 'secp256k1',
         privateKey: node.privateKey,
         publicKey: node.publicKey,
@@ -574,6 +612,8 @@ describe('SLIP10Node', () => {
 
       expect(JSON.parse(JSON.stringify(nodeJson))).toStrictEqual({
         depth: node.depth,
+        parentFingerprint: node.parentFingerprint,
+        index: node.index,
         curve: 'secp256k1',
         privateKey: node.privateKey,
         publicKey: node.publicKey,

--- a/src/SLIP10Node.test.ts
+++ b/src/SLIP10Node.test.ts
@@ -34,8 +34,8 @@ describe('SLIP10Node', () => {
       });
 
       const node = await SLIP10Node.fromExtendedKey({
-        privateKey: privateKey.toString('hex'),
-        chainCode: chainCode.toString('hex'),
+        privateKey,
+        chainCode,
         depth: 0,
         parentFingerprint: 0,
         index: 0,
@@ -67,22 +67,13 @@ describe('SLIP10Node', () => {
     });
 
     it('initializes a new node from a public key', async () => {
-      const { privateKey, chainCode } = await deriveChildKey({
+      const { publicKeyBuffer, chainCodeBuffer } = await deriveChildKey({
         path: fixtures.local.mnemonic,
       });
 
-      const privateNode = await SLIP10Node.fromExtendedKey({
-        privateKey,
-        chainCode,
-        depth: 0,
-        parentFingerprint: 0,
-        index: 0,
-        curve: 'secp256k1',
-      });
-
       const node = await SLIP10Node.fromExtendedKey({
-        publicKey: privateNode.publicKeyBuffer,
-        chainCode: privateNode.chainCodeBuffer,
+        publicKey: publicKeyBuffer,
+        chainCode: chainCodeBuffer,
         depth: 0,
         parentFingerprint: 0,
         index: 0,
@@ -95,22 +86,14 @@ describe('SLIP10Node', () => {
     });
 
     it('initializes a new ed25519 node from a public key', async () => {
-      const { privateKey, chainCode } = await deriveChildKey({
+      const { publicKeyBuffer, chainCodeBuffer } = await deriveChildKey({
         path: fixtures.local.mnemonic,
-      });
-
-      const privateNode = await SLIP10Node.fromExtendedKey({
-        privateKey,
-        chainCode,
-        depth: 0,
-        parentFingerprint: 0,
-        index: 0,
-        curve: 'ed25519',
+        curve: ed25519,
       });
 
       const node = await SLIP10Node.fromExtendedKey({
-        publicKey: privateNode.publicKeyBuffer,
-        chainCode: privateNode.chainCodeBuffer,
+        publicKey: publicKeyBuffer,
+        chainCode: chainCodeBuffer,
         depth: 0,
         parentFingerprint: 0,
         index: 0,
@@ -123,22 +106,13 @@ describe('SLIP10Node', () => {
     });
 
     it('initializes a new node from a hexadecimal public key and chain code', async () => {
-      const { privateKey, chainCode } = await deriveChildKey({
+      const { publicKey, chainCode } = await deriveChildKey({
         path: fixtures.local.mnemonic,
       });
 
-      const privateNode = await SLIP10Node.fromExtendedKey({
-        privateKey,
-        chainCode,
-        depth: 0,
-        parentFingerprint: 0,
-        index: 0,
-        curve: 'secp256k1',
-      });
-
       const node = await SLIP10Node.fromExtendedKey({
-        publicKey: privateNode.publicKey,
-        chainCode: privateNode.chainCode,
+        publicKey,
+        chainCode,
         depth: 0,
         parentFingerprint: 0,
         index: 0,
@@ -151,17 +125,8 @@ describe('SLIP10Node', () => {
     });
 
     it('initializes a new node from JSON', async () => {
-      const { privateKey, chainCode } = await deriveChildKey({
+      const node = await deriveChildKey({
         path: fixtures.local.mnemonic,
-      });
-
-      const node = await SLIP10Node.fromExtendedKey({
-        privateKey,
-        chainCode,
-        depth: 0,
-        parentFingerprint: 0,
-        index: 0,
-        curve: 'secp256k1',
       });
 
       expect(await SLIP10Node.fromJSON(node.toJSON())).toStrictEqual(node);

--- a/src/SLIP10Node.ts
+++ b/src/SLIP10Node.ts
@@ -6,7 +6,12 @@ import {
 import { curves, getCurveByName, SupportedCurve } from './curves';
 import { deriveKeyFromPath } from './derivation';
 import { publicKeyToEthAddress } from './derivers/bip32';
-import { getBuffer, getFingerprint, isValidInteger } from './utils';
+import {
+  getBuffer,
+  getFingerprint,
+  isValidInteger,
+  validateBIP32Index,
+} from './utils';
 import { BIP44Node } from './BIP44Node';
 import { BIP44CoinTypeNode } from './BIP44CoinTypeNode';
 
@@ -139,6 +144,7 @@ export class SLIP10Node implements SLIP10NodeInterface {
 
     validateCurve(curve);
     validateBIP32Depth(depth);
+    validateBIP32Index(index);
     validateParentFingerprint(parentFingerprint);
 
     if (privateKey) {

--- a/src/curves/curve.ts
+++ b/src/curves/curve.ts
@@ -24,6 +24,7 @@ export type Curve = {
   isValidPrivateKey: (privateKey: Uint8Array | string | bigint) => boolean;
   publicAdd: (publicKey: Buffer, tweak: Buffer) => Buffer;
   compressPublicKey: (publicKey: Buffer) => Buffer;
+  decompressPublicKey: (publicKey: Buffer) => Buffer;
 };
 
 // As long as both parameters are specified, this function is the same for all curves.

--- a/src/curves/curve.ts
+++ b/src/curves/curve.ts
@@ -27,5 +27,14 @@ export type Curve = {
   decompressPublicKey: (publicKey: Buffer) => Buffer;
 };
 
+/**
+ * Get a curve by name.
+ *
+ * @param curveName - The name of the curve to get.
+ */
+export function getCurveByName(curveName: SupportedCurve): Curve {
+  return curves[curveName];
+}
+
 // As long as both parameters are specified, this function is the same for all curves.
 export const { mod } = utils;

--- a/src/curves/ed25519.test.ts
+++ b/src/curves/ed25519.test.ts
@@ -4,6 +4,7 @@ import { hexStringToBuffer } from '../utils';
 import {
   compressPublicKey,
   curve,
+  decompressPublicKey,
   getPublicKey,
   isValidPrivateKey,
   publicAdd,
@@ -61,6 +62,19 @@ describe('ed25519', () => {
       for (const { publicKey } of keys) {
         const publicKeyBuffer = hexStringToBuffer(publicKey);
         expect(compressPublicKey(publicKeyBuffer)).toStrictEqual(
+          publicKeyBuffer,
+        );
+      }
+    });
+  });
+
+  describe('decompressPublicKey', () => {
+    const { slip10 } = fixtures.ed25519;
+
+    it.each(slip10)('returns the same public key', async ({ keys }) => {
+      for (const { publicKey } of keys) {
+        const publicKeyBuffer = hexStringToBuffer(publicKey);
+        expect(decompressPublicKey(publicKeyBuffer)).toStrictEqual(
           publicKeyBuffer,
         );
       }

--- a/src/curves/ed25519.ts
+++ b/src/curves/ed25519.ts
@@ -33,3 +33,8 @@ export const compressPublicKey = (publicKey: Buffer): Buffer => {
   // Ed25519 public keys don't have a compressed form.
   return publicKey;
 };
+
+export const decompressPublicKey = (publicKey: Buffer): Buffer => {
+  // Ed25519 public keys don't have a compressed form.
+  return publicKey;
+};

--- a/src/curves/secp256k1.ts
+++ b/src/curves/secp256k1.ts
@@ -40,3 +40,8 @@ export const compressPublicKey = (publicKey: Uint8Array): Buffer => {
   const point = Point.fromHex(publicKey);
   return Buffer.from(point.toRawBytes(true));
 };
+
+export const decompressPublicKey = (publicKey: Uint8Array): Buffer => {
+  const point = Point.fromHex(publicKey);
+  return Buffer.from(point.toRawBytes(false));
+};

--- a/src/curves/secp256k1.ts
+++ b/src/curves/secp256k1.ts
@@ -42,6 +42,8 @@ export const compressPublicKey = (publicKey: Uint8Array): Buffer => {
 };
 
 export const decompressPublicKey = (publicKey: Uint8Array): Buffer => {
+  // This calculates a point on the elliptic curve from a compressed public key. We can then use
+  // this to get the uncompressed version of the public key.
   const point = Point.fromHex(publicKey);
   return Buffer.from(point.toRawBytes(false));
 };

--- a/src/derivation.test.ts
+++ b/src/derivation.test.ts
@@ -191,6 +191,18 @@ describe('derivation', () => {
         'Invalid arguments: Must specify either a parent node or curve.',
       );
     });
+
+    it('throws when an invalid node is provided', async () => {
+      await expect(
+        deriveKeyFromPath({
+          // @ts-expect-error Invalid node type.
+          node: {},
+          path: [bip39MnemonicToMultipath(mnemonic)],
+        }),
+      ).rejects.toThrow(
+        'Invalid arguments: Node must be a SLIP-10 node or a BIP-44 node when provided.',
+      );
+    });
   });
 
   describe('bip32Derive', () => {

--- a/src/derivation.test.ts
+++ b/src/derivation.test.ts
@@ -183,6 +183,14 @@ describe('derivation', () => {
         /Invalid derivation parameters: Must specify parent key if the first node of the path segment is not a BIP-39 node\./u,
       );
     });
+
+    it('throws when no curve or node is specified', async () => {
+      await expect(
+        deriveKeyFromPath({ path: [bip39MnemonicToMultipath(mnemonic)] }),
+      ).rejects.toThrow(
+        'Invalid arguments: Must specify either a parent node or curve.',
+      );
+    });
   });
 
   describe('bip32Derive', () => {
@@ -247,6 +255,30 @@ describe('derivation', () => {
           'Invalid BIP-32 index: The index must be a non-negative decimal integer less than 2147483648.',
         );
       }
+    });
+
+    it('throws when no node is specified', async () => {
+      await expect(
+        bip32Derive({
+          path: '0',
+        }),
+      ).rejects.toThrow(
+        'Invalid parameters: Must specify a node to derive from.',
+      );
+    });
+
+    it('throws when trying to derive from a public key node', async () => {
+      const node = await bip39Derive({ path: mnemonic });
+      const publicNode = node.neuter();
+
+      await expect(
+        bip32Derive({
+          path: `0'`,
+          node: publicNode,
+        }),
+      ).rejects.toThrow(
+        'Invalid parameters: Cannot derive hardened child keys without a private key.',
+      );
     });
   });
 

--- a/src/derivation.ts
+++ b/src/derivation.ts
@@ -69,6 +69,17 @@ export async function deriveKeyFromPath(
   const node = 'node' in args ? args.node : undefined;
   const curve = 'curve' in args ? args.curve : node?.curve;
 
+  if (
+    node &&
+    !(node instanceof SLIP10Node) &&
+    !(node instanceof BIP44Node) &&
+    !(node instanceof BIP44CoinTypeNode)
+  ) {
+    throw new Error(
+      'Invalid arguments: Node must be a SLIP-10 node or a BIP-44 node when provided.',
+    );
+  }
+
   if (!curve) {
     throw new Error(
       'Invalid arguments: Must specify either a parent node or curve.',

--- a/src/derivation.ts
+++ b/src/derivation.ts
@@ -6,10 +6,10 @@ import {
   SLIP10Path,
 } from './constants';
 import { Deriver, derivers } from './derivers';
-import { getCurveByName, SLIP10Node } from './SLIP10Node';
+import { SLIP10Node } from './SLIP10Node';
 import { BIP44Node } from './BIP44Node';
 import { BIP44CoinTypeNode } from './BIP44CoinTypeNode';
-import { SupportedCurve } from './curves';
+import { getCurveByName, SupportedCurve } from './curves';
 
 /**
  * Ethereum default seed path: "m/44'/60'/0'/0/{account_index}"

--- a/src/derivers/bip32.ts
+++ b/src/derivers/bip32.ts
@@ -2,13 +2,8 @@ import { keccak_256 as keccak256 } from '@noble/hashes/sha3';
 import { hmac } from '@noble/hashes/hmac';
 import { sha512 } from '@noble/hashes/sha512';
 import { BIP_32_HARDENED_OFFSET, BUFFER_KEY_LENGTH } from '../constants';
-import {
-  bytesToNumber,
-  getFingerprint,
-  hexStringToBuffer,
-  isValidBufferKey,
-} from '../utils';
-import { Curve, getCurveByName, mod, secp256k1 } from '../curves';
+import { bytesToNumber, hexStringToBuffer, isValidBufferKey } from '../utils';
+import { Curve, mod, secp256k1 } from '../curves';
 import { SLIP10Node } from '../SLIP10Node';
 import { DeriveChildKeyArgs, DerivedKeys } from '.';
 

--- a/src/derivers/bip32.ts
+++ b/src/derivers/bip32.ts
@@ -52,7 +52,7 @@ export function publicKeyToEthAddress(key: Buffer) {
 /**
  * Derive a BIP-32 child key with a given path from a parent key.
  *
- * @param pathPart - The derivation path part to derive.
+ * @param path - The derivation path part to derive.
  * @param node - The node to derive from.
  * @param curve - The curve to use for derivation.
  * @returns A tuple containing the derived private key, public key and chain

--- a/src/derivers/bip32.ts
+++ b/src/derivers/bip32.ts
@@ -2,8 +2,13 @@ import { keccak_256 as keccak256 } from '@noble/hashes/sha3';
 import { hmac } from '@noble/hashes/hmac';
 import { sha512 } from '@noble/hashes/sha512';
 import { BIP_32_HARDENED_OFFSET, BUFFER_KEY_LENGTH } from '../constants';
-import { bytesToNumber, hexStringToBuffer, isValidBufferKey } from '../utils';
-import { Curve, mod, secp256k1 } from '../curves';
+import {
+  bytesToNumber,
+  getFingerprint,
+  hexStringToBuffer,
+  isValidBufferKey,
+} from '../utils';
+import { Curve, getCurveByName, mod, secp256k1 } from '../curves';
 import { SLIP10Node } from '../SLIP10Node';
 import { DeriveChildKeyArgs, DerivedKeys } from '.';
 
@@ -74,7 +79,7 @@ export async function deriveChildKey({
     throw new Error('Invalid parameters: Must specify a node to derive from.');
   }
 
-  if (isHardened && !node?.privateKey) {
+  if (isHardened && !node.privateKey) {
     throw new Error(
       'Invalid parameters: Cannot derive hardened child keys without a private key.',
     );
@@ -137,7 +142,7 @@ export async function deriveChildKey({
     chainCode,
     depth: node.depth + 1,
     parentFingerprint: node.fingerprint,
-    index: childIndex + (isHardened ? BIP_32_HARDENED_OFFSET : 0),
+    index: childIndex,
     curve: curve.name,
   });
 }

--- a/src/derivers/index.ts
+++ b/src/derivers/index.ts
@@ -1,4 +1,5 @@
 import { Curve } from '../curves';
+import { SLIP10Node } from '../SLIP10Node';
 import * as bip32 from './bip32';
 import * as bip39 from './bip39';
 
@@ -13,14 +14,12 @@ export type DerivedKeys = {
 
 export type DeriveChildKeyArgs = {
   path: string;
-  privateKey?: Buffer;
-  publicKey?: Buffer;
-  chainCode?: Buffer;
   curve?: Curve;
+  node?: SLIP10Node;
 };
 
 export type Deriver = {
-  deriveChildKey: (args: DeriveChildKeyArgs) => Promise<DerivedKeys>;
+  deriveChildKey: (args: DeriveChildKeyArgs) => Promise<SLIP10Node>;
 };
 
 export const derivers = {

--- a/src/extended-keys.test.ts
+++ b/src/extended-keys.test.ts
@@ -1,0 +1,86 @@
+import {
+  decodeExtendedKey,
+  encodeExtendedKey,
+  ExtendedKey,
+  PRIVATE_KEY_VERSION,
+  PUBLIC_KEY_VERSION,
+} from './extended-keys';
+import { hexStringToBuffer } from './utils';
+
+describe('decodeExtendedKey', () => {
+  it('decodes an extended public key', () => {
+    const extendedKey =
+      'xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8';
+
+    expect(decodeExtendedKey(extendedKey)).toStrictEqual({
+      depth: 0,
+      parentFingerprint: 0,
+      index: 0,
+      chainCode: hexStringToBuffer(
+        '873dff81c02f525623fd1fe5167eac3a55a049de3d314bb42ee227ffed37d508',
+      ),
+      publicKey: hexStringToBuffer(
+        '0439a36013301597daef41fbe593a02cc513d0b55527ec2df1050e2e8ff49c85c23cbe7ded0e7ce6a594896b8f62888fdbc5c8821305e2ea42bf01e37300116281',
+      ),
+      version: PUBLIC_KEY_VERSION,
+    });
+  });
+
+  it('decodes an extended private key', () => {
+    const extendedKey =
+      'xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi';
+
+    expect(decodeExtendedKey(extendedKey)).toStrictEqual({
+      depth: 0,
+      parentFingerprint: 0,
+      index: 0,
+      chainCode: hexStringToBuffer(
+        '873dff81c02f525623fd1fe5167eac3a55a049de3d314bb42ee227ffed37d508',
+      ),
+      privateKey: hexStringToBuffer(
+        'e8f32e723decf4051aefac8e2c93c9c5b214313817cdb01a1494b917c8436b35',
+      ),
+      version: PRIVATE_KEY_VERSION,
+    });
+  });
+});
+
+describe('encodeExtendedKey', () => {
+  it('encodes an extended public key', () => {
+    const extendedKey: ExtendedKey = {
+      depth: 0,
+      parentFingerprint: 0,
+      index: 0,
+      chainCode: hexStringToBuffer(
+        '873dff81c02f525623fd1fe5167eac3a55a049de3d314bb42ee227ffed37d508',
+      ),
+      publicKey: hexStringToBuffer(
+        '0439a36013301597daef41fbe593a02cc513d0b55527ec2df1050e2e8ff49c85c23cbe7ded0e7ce6a594896b8f62888fdbc5c8821305e2ea42bf01e37300116281',
+      ),
+      version: PUBLIC_KEY_VERSION,
+    };
+
+    expect(encodeExtendedKey(extendedKey)).toBe(
+      'xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8',
+    );
+  });
+
+  it('encodes an extended private key', () => {
+    const extendedKey: ExtendedKey = {
+      depth: 0,
+      parentFingerprint: 0,
+      index: 0,
+      chainCode: hexStringToBuffer(
+        '873dff81c02f525623fd1fe5167eac3a55a049de3d314bb42ee227ffed37d508',
+      ),
+      privateKey: hexStringToBuffer(
+        'e8f32e723decf4051aefac8e2c93c9c5b214313817cdb01a1494b917c8436b35',
+      ),
+      version: PRIVATE_KEY_VERSION,
+    };
+
+    expect(encodeExtendedKey(extendedKey)).toBe(
+      'xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi',
+    );
+  });
+});

--- a/src/extended-keys.test.ts
+++ b/src/extended-keys.test.ts
@@ -43,6 +43,68 @@ describe('decodeExtendedKey', () => {
       version: PRIVATE_KEY_VERSION,
     });
   });
+
+  it('throws if the extended key is not a valid Base58 string', () => {
+    const extendedKey =
+      'xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMP';
+
+    expect(() => decodeExtendedKey(extendedKey)).toThrow(
+      'Invalid value: Value is not base58-encoded, or the checksum is invalid.',
+    );
+  });
+
+  it('throws if the extended key is not 78 bytes long', () => {
+    const extendedKey = '3kSkWR5gTP';
+
+    expect(() => decodeExtendedKey(extendedKey)).toThrow(
+      'Invalid extended key: Expected a length of 78, got 3.',
+    );
+  });
+
+  it('throws if the chain code is invalid', () => {
+    const extendedKey =
+      'xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzFAp8UkorEcJ4wSbGzEaLySRnFibyHm9Wvj72EK5vSiRn21B5B1e';
+
+    expect(() => decodeExtendedKey(extendedKey)).toThrow(
+      'Invalid extended key: Chain code must be a 32-byte non-zero Buffer.',
+    );
+  });
+
+  it('throws if the key is invalid', () => {
+    const extendedKey =
+      'xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChijLXZSun8bsGj49MuvWWsqL9fqS5fhiDUkRQvq8cj8L42RGwHP';
+
+    expect(() => decodeExtendedKey(extendedKey)).toThrow(
+      'Invalid extended key: Key must be a 33-byte non-zero Buffer.',
+    );
+  });
+
+  it('throws if the public key does not start with 0x02 or 0x03', () => {
+    const extendedKey =
+      'xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gYxFk5nqmbwrSjnkQvUtYydeKpRyanfmc6qmeyusqpnVEF2j8DGn';
+
+    expect(() => decodeExtendedKey(extendedKey)).toThrow(
+      'Invalid extended key: Public key must start with 0x02 or 0x03.',
+    );
+  });
+
+  it('throws if the private key does not start with 0x00', () => {
+    const extendedKey =
+      'xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiCqXZ9CTurr9xyzDFnddSPdB3k1pPUqfyv5k5KrkLa5wTGuBuaXXE';
+
+    expect(() => decodeExtendedKey(extendedKey)).toThrow(
+      'Invalid extended key: Private key must start with 0x00.',
+    );
+  });
+
+  it('throws if the version is invalid', () => {
+    const extendedKey =
+      'xpuawnJgETRpXRUEauaMeTjxFtUTpGU6atj1BvkT6gWzaHrxtD2MWRCJkqjJE5j5VQuSNXkpoT7VPMHTTsFeySMd9WrjsTy28qcuJywWdgp5PfV';
+
+    expect(() => decodeExtendedKey(extendedKey)).toThrow(
+      'Invalid extended key: Expected a public (xpub) or private key (xprv) version.',
+    );
+  });
 });
 
 describe('encodeExtendedKey', () => {

--- a/src/extended-keys.ts
+++ b/src/extended-keys.ts
@@ -1,0 +1,146 @@
+import {
+  decodeBase58check,
+  encodeBase58check,
+  isValidBufferKey,
+} from './utils';
+import { validateBIP44Depth } from './BIP44Node';
+import { compressPublicKey, decompressPublicKey } from './curves/secp256k1';
+
+export const PUBLIC_KEY_VERSION = 0x0488b21e;
+export const PRIVATE_KEY_VERSION = 0x0488ade4;
+
+export type ExtendedKeyVersion =
+  | typeof PUBLIC_KEY_VERSION
+  | typeof PRIVATE_KEY_VERSION;
+
+/**
+ * An extended public or private key. Contains either a public or private key,
+ * depending on the version.
+ */
+type ExtendedKeyLike = {
+  version: ExtendedKeyVersion;
+  depth: number;
+  parentFingerprint: number;
+  index: number;
+  chainCode: Buffer;
+};
+
+type ExtendedPublicKey = ExtendedKeyLike & {
+  version: typeof PUBLIC_KEY_VERSION;
+  publicKey: Buffer;
+};
+
+type ExtendedPrivateKey = ExtendedKeyLike & {
+  version: typeof PRIVATE_KEY_VERSION;
+  privateKey: Buffer;
+};
+
+export type ExtendedKey = ExtendedPublicKey | ExtendedPrivateKey;
+
+/**
+ * Decodes an extended public or private key. In the case of an extended public key, the public key
+ * is returned in the uncompressed form.
+ *
+ * Throws an error if the extended key is invalid.
+ *
+ * @param extendedKey - The extended key string to attempt to decode.
+ */
+export const decodeExtendedKey = (extendedKey: string): ExtendedKey => {
+  const buffer = decodeBase58check(extendedKey);
+
+  if (buffer.length !== 78) {
+    throw new Error(
+      `Invalid extended key: Expected a length of 78, got ${buffer.length}.`,
+    );
+  }
+
+  const version = buffer.readUInt32BE(0);
+  const depth = buffer.readUInt8(4);
+  validateBIP44Depth(depth);
+
+  const parentFingerprint = buffer.readUInt32BE(5);
+  const index = buffer.readUInt32BE(9);
+
+  const chainCode = buffer.slice(13, 45);
+  if (!isValidBufferKey(chainCode, 32)) {
+    throw new Error(
+      `Invalid extended key: Chain code must be a 32-byte non-zero Buffer.`,
+    );
+  }
+
+  const key = buffer.slice(45, 78);
+  if (!isValidBufferKey(key, 33)) {
+    throw new Error(
+      `Invalid extended key: Key must be a 33-byte non-zero Buffer.`,
+    );
+  }
+
+  if (version === PUBLIC_KEY_VERSION) {
+    if (key.readUInt8(0) !== 0x02 && key.readUInt8(0) !== 0x03) {
+      throw new Error(
+        `Invalid extended key: Public key must start with 0x02 or 0x03.`,
+      );
+    }
+
+    return {
+      version,
+      depth,
+      parentFingerprint,
+      index,
+      chainCode,
+      publicKey: decompressPublicKey(key),
+    };
+  }
+
+  if (version === PRIVATE_KEY_VERSION) {
+    if (key.readUInt8(0) !== 0x00) {
+      throw new Error(
+        `Invalid extended key: Private key must start with 0x00.`,
+      );
+    }
+
+    return {
+      version,
+      depth,
+      parentFingerprint,
+      index,
+      chainCode,
+      privateKey: key.slice(1),
+    };
+  }
+
+  throw new Error(
+    `Invalid extended key: Expected a public (xpub) or private key (xprv) version.`,
+  );
+};
+
+/**
+ * Encodes an extended public or private key. Assumes that all the inputs are verified beforehand.
+ *
+ * @param extendedKey - The extended key data to encode.
+ */
+export const encodeExtendedKey = (extendedKey: ExtendedKey): string => {
+  const { version, depth, parentFingerprint, index, chainCode } = extendedKey;
+  const buffer = Buffer.alloc(78);
+
+  buffer.writeUInt32BE(version, 0);
+  buffer.writeUInt8(depth, 4);
+  buffer.writeUInt32BE(parentFingerprint, 5);
+  buffer.writeUInt32BE(index, 9);
+
+  chainCode.copy(buffer, 13);
+
+  if (extendedKey.version === PUBLIC_KEY_VERSION) {
+    const { publicKey } = extendedKey;
+    const compressedPublicKey = compressPublicKey(publicKey);
+
+    compressedPublicKey.copy(buffer, 45);
+  }
+
+  if (extendedKey.version === PRIVATE_KEY_VERSION) {
+    const { privateKey } = extendedKey;
+    privateKey.copy(buffer, 46);
+  }
+
+  return encodeBase58check(buffer);
+};

--- a/src/extended-keys.ts
+++ b/src/extended-keys.ts
@@ -6,6 +6,7 @@ import {
 import { validateBIP44Depth } from './BIP44Node';
 import { compressPublicKey, decompressPublicKey } from './curves/secp256k1';
 
+// https://github.com/bitcoin/bips/blob/274fa400d630ba757bec0c03b35ebe2345197108/bip-0032.mediawiki#Serialization_format
 export const PUBLIC_KEY_VERSION = 0x0488b21e;
 export const PRIVATE_KEY_VERSION = 0x0488ade4;
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -5,7 +5,6 @@ import {
   isValidBufferKey,
   nullableHexStringToBuffer,
 } from './utils';
-import { SLIP10Node } from './SLIP10Node';
 import { BIP44Node } from './BIP44Node';
 
 describe('nullableHexStringToBuffer', () => {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,9 +1,12 @@
 import {
   getBuffer,
+  getFingerprint,
   hexStringToBuffer,
   isValidBufferKey,
   nullableHexStringToBuffer,
 } from './utils';
+import { SLIP10Node } from './SLIP10Node';
+import { BIP44Node } from './BIP44Node';
 
 describe('nullableHexStringToBuffer', () => {
   it('returns a buffer for a hexadecimal string', () => {
@@ -53,6 +56,26 @@ describe('getBuffer', () => {
 
     expect(() => getBuffer(hexStringToBuffer('1234'), 1)).toThrow(
       'Invalid value: Must be a non-zero 1-byte buffer.',
+    );
+  });
+});
+
+describe('getFingerprint', () => {
+  it('returns the fingerprint for a compressed public key', async () => {
+    const node = await BIP44Node.fromExtendedKey(
+      'xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi',
+    );
+
+    expect(getFingerprint(node.compressedPublicKeyBuffer)).toBe(2391500305);
+  });
+
+  it('throws if the public key is not a valid buffer', async () => {
+    expect(() => getFingerprint(Buffer.alloc(33).fill(0))).toThrow(
+      'Invalid public key: The key must be a 33-byte, non-zero Buffer.',
+    );
+
+    expect(() => getFingerprint(Buffer.alloc(65).fill(1))).toThrow(
+      'Invalid public key: The key must be a 33-byte, non-zero Buffer.',
     );
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -161,7 +161,7 @@ export function validateBIP32Index(addressIndex: number) {
  * @returns Whether the index is a non-negative integer number.
  */
 export function isValidBIP32Index(index: number): boolean {
-  return Number.isInteger(index) && index >= 0;
+  return isValidInteger(index);
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -247,6 +247,16 @@ export function isValidBufferKey(
 }
 
 /**
+ * Tests whether the specified number is a valid integer equal to or greater than 0.
+ *
+ * @param value - The number to test.
+ * @returns Whether the number is a valid integer.
+ */
+export function isValidInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0;
+}
+
+/**
  * Get a BigInt from a byte array.
  *
  * @param bytes - The byte array to get the BigInt for.

--- a/test/reference-implementations.test.ts
+++ b/test/reference-implementations.test.ts
@@ -155,6 +155,8 @@ describe('reference implementation tests', () => {
 
         const parentNode = await BIP44Node.fromExtendedKey({
           depth: 0,
+          parentFingerprint: 0,
+          index: 0,
           ...derivedKeys,
         });
         const node = await parentNode.derive(path.ours.tuple);
@@ -176,6 +178,8 @@ describe('reference implementation tests', () => {
 
         const parentNode = await BIP44Node.fromExtendedKey({
           depth: 0,
+          parentFingerprint: 0,
+          index: 0,
           ...derivedKeys,
         });
         const node = await parentNode.derive(path.ours.tuple);
@@ -305,6 +309,8 @@ describe('reference implementation tests', () => {
 
           const parentNode = await SLIP10Node.fromExtendedKey({
             depth: 0,
+            parentFingerprint: 0,
+            index: 0,
             curve: 'ed25519',
             ...derivedKeys,
           });

--- a/test/reference-implementations.test.ts
+++ b/test/reference-implementations.test.ts
@@ -1,18 +1,13 @@
-import { BIP44Node } from '../src';
+import { BIP44Node, SLIP10Node } from '../src';
 import { BIP44PurposeNodeToken, HDPathTuple } from '../src/constants';
 import { ed25519 } from '../src/curves';
 import { deriveKeyFromPath } from '../src/derivation';
-import {
-  privateKeyToEthAddress,
-  publicKeyToEthAddress,
-} from '../src/derivers/bip32';
 import { createBip39KeyFromSeed } from '../src/derivers/bip39';
 import {
   getBIP44CoinTypeToAddressPathTuple,
   hexStringToBuffer,
 } from '../src/utils';
-import { SLIP10Node } from '../src/SLIP10Node';
-import { DerivedKeys } from '../src/derivers';
+
 import fixtures from './fixtures';
 
 describe('reference implementation tests', () => {
@@ -45,20 +40,19 @@ describe('reference implementation tests', () => {
     describe('deriveKeyFromPath', () => {
       it('derives the expected keys', async () => {
         // Ethereum coin type key
-        const derivedKeys = await deriveKeyFromPath({
+        const node = await deriveKeyFromPath({
           path: [mnemonicBip39Node, BIP44PurposeNodeToken, `bip32:60'`],
+          curve: 'secp256k1',
         });
 
         for (let index = 0; index < addresses.length; index++) {
           const expectedAddress = addresses[index];
-          const { publicKey } = await deriveKeyFromPath({
+          const { address } = await deriveKeyFromPath({
             path: getBIP44CoinTypeToAddressPathTuple({ address_index: index }),
-            ...derivedKeys,
+            node,
           });
 
-          expect(
-            `0x${publicKeyToEthAddress(publicKey).toString('hex')}`,
-          ).toStrictEqual(expectedAddress);
+          expect(address).toStrictEqual(expectedAddress);
         }
       });
     });
@@ -120,26 +114,23 @@ describe('reference implementation tests', () => {
     describe('deriveKeyFromPath', () => {
       it('derives the same keys as the reference implementation', async () => {
         // Ethereum coin type key
-        const derivedKeys = await deriveKeyFromPath({
+        const node = await deriveKeyFromPath({
           path: [mnemonicBip39Node, BIP44PurposeNodeToken, `bip32:60'`],
+          curve: 'secp256k1',
         });
 
         const numberOfAccounts = 5;
         const ourAccounts = [];
         for (let i = 0; i < numberOfAccounts; i++) {
           ourAccounts.push(
-            publicKeyToEthAddress(
-              await deriveKeyFromPath({
-                path: getBIP44CoinTypeToAddressPathTuple({ address_index: i }),
-                ...derivedKeys,
-              }).then(({ publicKey }) => publicKey),
-            ).toString('hex'),
+            await deriveKeyFromPath({
+              path: getBIP44CoinTypeToAddressPathTuple({ address_index: i }),
+              node,
+            }).then(({ address }) => address),
           );
         }
 
-        expect(addresses).toStrictEqual(
-          ourAccounts.map((account) => `0x${account}`),
-        );
+        expect(addresses).toStrictEqual(ourAccounts);
       });
     });
   });
@@ -151,14 +142,7 @@ describe('reference implementation tests', () => {
 
     describe('BIP44Node', () => {
       it('derives the same keys as the reference implementation', async () => {
-        const derivedKeys = await createBip39KeyFromSeed(seed);
-
-        const parentNode = await BIP44Node.fromExtendedKey({
-          depth: 0,
-          parentFingerprint: 0,
-          index: 0,
-          ...derivedKeys,
-        });
+        const parentNode = await createBip39KeyFromSeed(seed);
         const node = await parentNode.derive(path.ours.tuple);
 
         expect(node.privateKey).toStrictEqual(privateKey);
@@ -174,14 +158,7 @@ describe('reference implementation tests', () => {
       });
 
       it('derives the same keys as the reference implementation using public key derivation', async () => {
-        const derivedKeys = await createBip39KeyFromSeed(seed);
-
-        const parentNode = await BIP44Node.fromExtendedKey({
-          depth: 0,
-          parentFingerprint: 0,
-          index: 0,
-          ...derivedKeys,
-        });
+        const parentNode = await createBip39KeyFromSeed(seed);
         const node = await parentNode.derive(path.ours.tuple);
 
         expect(node.privateKey).toStrictEqual(privateKey);
@@ -200,28 +177,22 @@ describe('reference implementation tests', () => {
 
     describe('deriveKeyFromPath', () => {
       it('derives the same keys as the reference implementation', async () => {
-        const derivedKeys = await createBip39KeyFromSeed(seed);
-        const { privateKey: parentKey, chainCode } = await deriveKeyFromPath({
+        const node = await createBip39KeyFromSeed(seed);
+        const childNode = await deriveKeyFromPath({
           path: path.ours.tuple,
-          ...derivedKeys,
+          node,
         });
 
-        expect(parentKey).toStrictEqual(hexStringToBuffer(privateKey));
-        expect(
-          `0x${privateKeyToEthAddress(parentKey as Buffer).toString('hex')}`,
-        ).toStrictEqual(address);
+        expect(childNode.privateKey).toStrictEqual(privateKey);
+        expect(childNode.address).toStrictEqual(address);
 
         for (const { index, address: theirAddress } of sampleAddressIndices) {
-          const { publicKey } = await deriveKeyFromPath({
+          const childChildNode = await deriveKeyFromPath({
             path: [`bip32:${index}`],
-            privateKey: parentKey,
-            chainCode,
+            node: childNode,
           });
 
-          const ourAddress = `0x${publicKeyToEthAddress(publicKey).toString(
-            'hex',
-          )}`;
-          expect(ourAddress).toStrictEqual(theirAddress);
+          expect(childChildNode.address).toStrictEqual(theirAddress);
         }
       });
     });
@@ -236,26 +207,24 @@ describe('reference implementation tests', () => {
       it('derives the test vector keys', async () => {
         for (const vector of vectors) {
           const seed = hexStringToBuffer(vector.hexSeed);
-          const derivedKeys = await createBip39KeyFromSeed(seed);
+          const node = await createBip39KeyFromSeed(seed);
 
           for (const keyObj of vector.keys) {
             const { path, privateKey } = keyObj;
 
-            let targetKey: DerivedKeys;
+            let targetNode: SLIP10Node;
 
             // If the path is empty, use the master node
             if (path.ours.string === '') {
-              targetKey = derivedKeys;
+              targetNode = node;
             } else {
-              targetKey = await deriveKeyFromPath({
+              targetNode = await deriveKeyFromPath({
                 path: path.ours.tuple as HDPathTuple,
-                ...derivedKeys,
+                node,
               });
             }
 
-            expect(
-              (targetKey.privateKey as Buffer).toString('hex'),
-            ).toStrictEqual(privateKey);
+            expect(targetNode.privateKey).toStrictEqual(privateKey);
           }
         }
       });
@@ -269,28 +238,24 @@ describe('reference implementation tests', () => {
       describe('deriveKeyFromPath', () => {
         it('derives the test vector keys', async () => {
           for (const { hexSeed, keys } of vectors) {
-            const derivedKeys = await createBip39KeyFromSeed(
+            const node = await createBip39KeyFromSeed(
               hexStringToBuffer(hexSeed),
               ed25519,
             );
 
             for (const { path, privateKey, publicKey } of keys) {
-              let targetKey: DerivedKeys;
+              let targetNode: SLIP10Node;
               if (path.ours.string === '') {
-                targetKey = derivedKeys;
+                targetNode = node;
               } else {
-                targetKey = await deriveKeyFromPath({
+                targetNode = await deriveKeyFromPath({
                   path: path.ours.tuple as HDPathTuple,
-                  depth: path.ours.tuple.length,
-                  curve: ed25519,
-                  ...derivedKeys,
+                  node,
                 });
               }
 
-              expect((targetKey.privateKey as Buffer).toString('hex')).toBe(
-                privateKey,
-              );
-              expect(targetKey.publicKey.toString('hex')).toBe(publicKey);
+              expect(targetNode.privateKey).toBe(privateKey);
+              expect(targetNode.publicKey).toBe(publicKey);
             }
           }
         });
@@ -305,15 +270,7 @@ describe('reference implementation tests', () => {
       describe('SLIP10Node', () => {
         it('derives the same keys as the reference implementation', async () => {
           // Ethereum coin type node
-          const derivedKeys = await createBip39KeyFromSeed(seed, ed25519);
-
-          const parentNode = await SLIP10Node.fromExtendedKey({
-            depth: 0,
-            parentFingerprint: 0,
-            index: 0,
-            curve: 'ed25519',
-            ...derivedKeys,
-          });
+          const parentNode = await createBip39KeyFromSeed(seed, ed25519);
           const node = await parentNode.derive(path.ours.tuple);
 
           expect(node.privateKey).toStrictEqual(privateKey);
@@ -334,12 +291,10 @@ describe('reference implementation tests', () => {
       describe('deriveKeyFromPath', () => {
         it('derives the same keys as the reference implementation', async () => {
           // Ethereum coin type key
-          const derivedKeys = await createBip39KeyFromSeed(seed, ed25519);
-          const derivedChildKeys = await deriveKeyFromPath({
+          const node = await createBip39KeyFromSeed(seed, ed25519);
+          const childNode = await deriveKeyFromPath({
             path: [BIP44PurposeNodeToken, `bip32:0'`, `bip32:0'`, `bip32:1'`],
-            depth: 2,
-            curve: ed25519,
-            ...derivedKeys,
+            node,
           });
 
           for (const {
@@ -348,14 +303,10 @@ describe('reference implementation tests', () => {
           } of sampleKeyIndices) {
             const { privateKey: ourPrivateKey } = await deriveKeyFromPath({
               path: [`bip32:${index}'`],
-              depth: 1,
-              curve: ed25519,
-              ...derivedChildKeys,
+              node: childNode,
             });
 
-            expect((ourPrivateKey as Buffer).toString('hex')).toStrictEqual(
-              theirPrivateKey,
-            );
+            expect(ourPrivateKey).toStrictEqual(theirPrivateKey);
           }
         });
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -638,7 +638,7 @@
     node-gyp "^7.1.0"
     read-package-json-fast "^2.0.1"
 
-"@scure/base@~1.0.0":
+"@scure/base@^1.0.0", "@scure/base@~1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.0.0.tgz#109fb595021de285f05a7db6806f2f48296fcee7"
   integrity sha512-gIVaYhUsy+9s58m/ETjSJVKHhKTBMmcRb9cEV5/5dwvfDlfORjKrFsDeDHWRrm6RjcPvCLZFwGJjAjLj1gg4HA==


### PR DESCRIPTION
Closes #44.

This PR adds a getter to the `BIP44Node` class to get an extended public or private key, and expands the `fromExtendedKey` function to make it possible to create a node from a stringified extended public or private key.

To make this possible, two new fields are introduced in `SLIP10Node`, `index` and `parentFingerprint`. These are part of the extended keys, so need to be kept track of. Additionally, to reduce complexity in the derivation code, all derivation functions now return a `SLIP10Node` instance, rather than an object containing the new key, chain code, etc.

Note that extended keys are not available for `SLIP10Node`s, since they are not defined in SLIP-10. Its only possible to use extended keys with BIP-44 nodes using `secp256k1`.