### PR TITLE
Add convenience field for getting the compressed public key

### DIFF
--- a/src/BIP44CoinTypeNode.test.ts
+++ b/src/BIP44CoinTypeNode.test.ts
@@ -364,6 +364,25 @@ describe('BIP44CoinTypeNode', () => {
     });
   });
 
+  describe('compressedPublicKey', () => {
+    it('returns the compressed public key for a node', async () => {
+      const coinType = 60;
+      const node = await BIP44Node.fromDerivationPath({
+        derivationPath: [
+          defaultBip39NodeToken,
+          BIP44PurposeNodeToken,
+          `bip32:${coinType}'`,
+        ],
+      });
+
+      const parentNode = await BIP44CoinTypeNode.fromNode(node, coinType);
+
+      expect(parentNode.compressedPublicKey).toStrictEqual(
+        node.compressedPublicKey,
+      );
+    });
+  });
+
   describe('compressedPublicKeyBuffer', () => {
     it('returns the compressed public key for a node', async () => {
       const coinType = 60;

--- a/src/BIP44CoinTypeNode.ts
+++ b/src/BIP44CoinTypeNode.ts
@@ -187,6 +187,10 @@ export class BIP44CoinTypeNode implements BIP44CoinTypeNodeInterface {
     return this.#node.publicKey;
   }
 
+  public get compressedPublicKey(): string {
+    return this.#node.compressedPublicKey;
+  }
+
   public get compressedPublicKeyBuffer(): Buffer {
     return this.#node.compressedPublicKeyBuffer;
   }

--- a/src/BIP44Node.test.ts
+++ b/src/BIP44Node.test.ts
@@ -431,6 +431,23 @@ describe('BIP44Node', () => {
     );
   });
 
+  describe('compressedPublicKey', () => {
+    it('returns the public key in compressed form', async () => {
+      const node = await BIP44Node.fromDerivationPath({
+        derivationPath: [
+          defaultBip39NodeToken,
+          BIP44PurposeNodeToken,
+          `bip32:0'`,
+          `bip32:0'`,
+        ],
+      });
+
+      expect(node.compressedPublicKey).toStrictEqual(
+        compressPublicKey(node.publicKeyBuffer).toString('hex'),
+      );
+    });
+  });
+
   describe('compressedPublicKeyBuffer', () => {
     it('returns the public key in compressed form', async () => {
       const node = await BIP44Node.fromDerivationPath({

--- a/src/BIP44Node.ts
+++ b/src/BIP44Node.ts
@@ -241,6 +241,10 @@ export class BIP44Node implements BIP44NodeInterface {
     return this.#node.publicKey;
   }
 
+  public get compressedPublicKey(): string {
+    return this.#node.compressedPublicKey;
+  }
+
   public get compressedPublicKeyBuffer(): Buffer {
     return this.#node.compressedPublicKeyBuffer;
   }

--- a/src/SLIP10Node.test.ts
+++ b/src/SLIP10Node.test.ts
@@ -519,6 +519,24 @@ describe('SLIP10Node', () => {
     );
   });
 
+  describe('compressedPublicKey', () => {
+    it('returns the public key in compressed form', async () => {
+      const node = await SLIP10Node.fromDerivationPath({
+        derivationPath: [
+          defaultBip39NodeToken,
+          BIP44PurposeNodeToken,
+          `bip32:0'`,
+          `bip32:0'`,
+        ],
+        curve: 'secp256k1',
+      });
+
+      expect(node.compressedPublicKey).toStrictEqual(
+        compressPublicKey(node.publicKeyBuffer).toString('hex'),
+      );
+    });
+  });
+
   describe('compressedPublicKeyBuffer', () => {
     it('returns the public key in compressed form', async () => {
       const node = await SLIP10Node.fromDerivationPath({

--- a/src/SLIP10Node.ts
+++ b/src/SLIP10Node.ts
@@ -291,6 +291,10 @@ export class SLIP10Node implements SLIP10NodeInterface {
     return getCurveByName(this.curve).compressPublicKey(this.publicKeyBuffer);
   }
 
+  public get compressedPublicKey(): string {
+    return this.compressedPublicKeyBuffer.toString('hex');
+  }
+
   public get address(): string {
     if (this.curve !== 'secp256k1') {
       throw new Error(


### PR DESCRIPTION
Before this change, we only exposed the compressed public key as `Buffer`. For convenience, this adds a new field which returns the compressed public key as hexadecimal string, similar to the `publicKey` (uncompressed public key as hexadecimal) field.