### PR TITLE
Replace postinstall script with Yarn plugin

### DIFF
--- a/.yarn/plugins/plugin-git-hooks.js
+++ b/.yarn/plugins/plugin-git-hooks.js
@@ -1,14 +1,7 @@
-const { execute } = require('@yarnpkg/shell');
+const { execSync } = require('child_process');
 
-const afterAllInstalled = async () => {
-  const exitCode = await execute('yarn simple-git-hooks');
-
-  if (exitCode !== 0) {
-    // We have to use `process.exit` here rather than setting `process.exitCode`
-    // because Yarn will override any exit code set in this hook.
-    // eslint-disable-next-line node/no-process-exit
-    process.exit(exitCode);
-  }
+const afterAllInstalled = (project) => {
+  execSync('yarn simple-git-hooks', { cwd: project.cwd, stdio: 'inherit' });
 };
 
 module.exports = {

--- a/.yarn/plugins/plugin-git-hooks.js
+++ b/.yarn/plugins/plugin-git-hooks.js
@@ -1,7 +1,14 @@
-const { execSync } = require('child_process');
+const { execute } = require('@yarnpkg/shell');
 
-const afterAllInstalled = (project) => {
-  execSync('yarn simple-git-hooks', { cwd: project.cwd, stdio: 'inherit' });
+const afterAllInstalled = async () => {
+  const exitCode = await execute('yarn simple-git-hooks');
+
+  if (exitCode !== 0) {
+    // We have to use `process.exit` here rather than setting `process.exitCode`
+    // because Yarn will override any exit code set in this hook.
+    // eslint-disable-next-line node/no-process-exit
+    process.exit(exitCode);
+  }
 };
 
 module.exports = {

--- a/.yarn/plugins/plugin-git-hooks.js
+++ b/.yarn/plugins/plugin-git-hooks.js
@@ -1,0 +1,18 @@
+const { execSync } = require('child_process');
+
+const afterAllInstalled = (project) => {
+  execSync('yarn simple-git-hooks', { cwd: project.cwd, stdio: 'inherit' });
+};
+
+module.exports = {
+  name: 'plugin-git-hooks',
+  factory: () => {
+    return {
+      default: {
+        hooks: {
+          afterAllInstalled
+        }
+      }
+    };
+  }
+};

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -5,5 +5,6 @@ nodeLinker: node-modules
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-allow-scripts.cjs
     spec: 'https://raw.githubusercontent.com/LavaMoat/LavaMoat/main/packages/yarn-plugin-allow-scripts/bundles/@yarnpkg/plugin-allow-scripts.js'
+  - path: .yarn/plugins/plugin-git-hooks.js
 
 yarnPath: .yarn/releases/yarn-3.2.3.cjs

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@types/jest": "^27.0.2",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
+    "@yarnpkg/shell": "^4.0.0-rc.18",
     "eslint": "^7.23.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.22.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@types/jest": "^27.0.2",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
-    "@yarnpkg/shell": "^4.0.0-rc.18",
     "eslint": "^7.23.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.22.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
     "build:clean": "rimraf dist && yarn build",
-    "postinstall": "simple-git-hooks",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",

--- a/yarn.lock
+++ b/yarn.lock
@@ -836,6 +836,7 @@ __metadata:
     "@types/jest": ^27.0.2
     "@typescript-eslint/eslint-plugin": ^5.0.0
     "@typescript-eslint/parser": ^5.0.0
+    "@yarnpkg/shell": ^4.0.0-rc.18
     eslint: ^7.23.0
     eslint-config-prettier: ^8.3.0
     eslint-plugin-import: ^2.22.1
@@ -1037,6 +1038,13 @@ __metadata:
   dependencies:
     "@babel/types": ^7.3.0
   checksum: a7158b13e5e4b844565217d04a0a09c1cf04e67de90972318960028effbd5e7400f2567b72c5f790acffdab9b4adce8d68f435a2f0c2b16e2c9c45994ace98f2
+  languageName: node
+  linkType: hard
+
+"@types/emscripten@npm:^1.39.6":
+  version: 1.39.6
+  resolution: "@types/emscripten@npm:1.39.6"
+  checksum: 437f2f9cdfd9057255662508fa9a415fe704ba484c6198f3549c5b05feebcdcd612b1ec7b10026d2566935d05d3c36f9366087cb42bc90bd25772a88fcfc9343
   languageName: node
   linkType: hard
 
@@ -1328,6 +1336,54 @@ __metadata:
     "@typescript-eslint/types": 5.36.2
     eslint-visitor-keys: ^3.3.0
   checksum: 87ccdcfa5cdedaa3a1aac30d656969f4f5910b62bcaacdf80a514dbf0cbbd8e79b55f8e987eab34cc79ece8ce4b8c19d5caf8b0afb74e0b0d7ab39fb29aa8eba
+  languageName: node
+  linkType: hard
+
+"@yarnpkg/fslib@npm:^3.0.0-rc.18":
+  version: 3.0.0-rc.18
+  resolution: "@yarnpkg/fslib@npm:3.0.0-rc.18"
+  dependencies:
+    "@yarnpkg/libzip": ^3.0.0-rc.18
+    tslib: ^2.4.0
+  checksum: 28409ffd3b885958bec924e9d2105e16778d9c69f1efc094d496480e14852a062158512039c93eb803cf90bd023112e68acc22d41bc0d5a01a41b68f9d59e7af
+  languageName: node
+  linkType: hard
+
+"@yarnpkg/libzip@npm:^3.0.0-rc.18":
+  version: 3.0.0-rc.18
+  resolution: "@yarnpkg/libzip@npm:3.0.0-rc.18"
+  dependencies:
+    "@types/emscripten": ^1.39.6
+    tslib: ^2.4.0
+  checksum: b732a2c9cc6766624b57cf1c9d1597af9456408bf361c0285a1995334c25a683a91239444b688ce5a3e4aa9e486e6cd276b0185cd0d5766b20f44d6963a19b50
+  languageName: node
+  linkType: hard
+
+"@yarnpkg/parsers@npm:^3.0.0-rc.18":
+  version: 3.0.0-rc.18
+  resolution: "@yarnpkg/parsers@npm:3.0.0-rc.18"
+  dependencies:
+    js-yaml: ^3.10.0
+    tslib: ^2.4.0
+  checksum: 73cc59cb2349ce78a376d6ad7953117360de9aff866f42329a3e957ebabbbd4cbd91bfe79e30aa3bf07f126af66b72c00a7fc733724ac93d7f46d420ba81beec
+  languageName: node
+  linkType: hard
+
+"@yarnpkg/shell@npm:^4.0.0-rc.18":
+  version: 4.0.0-rc.18
+  resolution: "@yarnpkg/shell@npm:4.0.0-rc.18"
+  dependencies:
+    "@yarnpkg/fslib": ^3.0.0-rc.18
+    "@yarnpkg/parsers": ^3.0.0-rc.18
+    chalk: ^3.0.0
+    clipanion: ^3.2.0-rc.10
+    cross-spawn: 7.0.3
+    fast-glob: ^3.2.2
+    micromatch: ^4.0.2
+    tslib: ^2.4.0
+  bin:
+    shell: ./lib/cli.js
+  checksum: eca01879e4004a96b5a666adbe211ed885b595d726fee028cd3791867b8b8783b481230e2164d4964452d9387077fb10dc2bd5357559258c26f33c498bf45e5a
   languageName: node
   linkType: hard
 
@@ -1890,6 +1946,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chalk@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "chalk@npm:3.0.0"
+  dependencies:
+    ansi-styles: ^4.1.0
+    supports-color: ^7.1.0
+  checksum: 8e3ddf3981c4da405ddbd7d9c8d91944ddf6e33d6837756979f7840a29272a69a5189ecae0ff84006750d6d1e92368d413335eab4db5476db6e6703a1d1e0505
+  languageName: node
+  linkType: hard
+
 "chalk@npm:^4.0.0":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
@@ -1961,6 +2027,17 @@ __metadata:
     slice-ansi: ^5.0.0
     string-width: ^5.0.0
   checksum: c3243e41974445691c63f8b405df1d5a24049dc33d324fe448dc572e561a7b772ae982692900b1a5960901cc4fc7def25a629b9c69a4208ee89d12ab3332617a
+  languageName: node
+  linkType: hard
+
+"clipanion@npm:^3.2.0-rc.10":
+  version: 3.2.0-rc.12
+  resolution: "clipanion@npm:3.2.0-rc.12"
+  dependencies:
+    typanion: ^3.8.0
+  peerDependencies:
+    typanion: "*"
+  checksum: a49acffb4ef843872dbbaf1d2c582021c03c51d08c556ff1e2909a1ebed27f32301f2e98a5ebe4cdf6ae30d360dac7a2a9aa6b0c5e34a6fc95c561091a734c87
   languageName: node
   linkType: hard
 
@@ -2104,7 +2181,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
+"cross-spawn@npm:7.0.3, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
   dependencies:
@@ -2877,16 +2954,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.0.3, fast-glob@npm:^3.2.9":
-  version: 3.2.11
-  resolution: "fast-glob@npm:3.2.11"
+"fast-glob@npm:^3.0.3, fast-glob@npm:^3.2.2, fast-glob@npm:^3.2.9":
+  version: 3.2.12
+  resolution: "fast-glob@npm:3.2.12"
   dependencies:
     "@nodelib/fs.stat": ^2.0.2
     "@nodelib/fs.walk": ^1.2.3
     glob-parent: ^5.1.2
     merge2: ^1.3.0
     micromatch: ^4.0.4
-  checksum: f473105324a7780a20c06de842e15ddbb41d3cb7e71d1e4fe6e8373204f22245d54f5ab9e2061e6a1c613047345954d29b022e0e76f5c28b1df9858179a0e6d7
+  checksum: 0b1990f6ce831c7e28c4d505edcdaad8e27e88ab9fa65eedadb730438cfc7cde4910d6c975d6b7b8dc8a73da4773702ebcfcd6e3518e73938bb1383badfe01c2
   languageName: node
   linkType: hard
 
@@ -4305,7 +4382,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^3.13.1":
+"js-yaml@npm:^3.10.0, js-yaml@npm:^3.13.1":
   version: 3.14.1
   resolution: "js-yaml@npm:3.14.1"
   dependencies:
@@ -4681,7 +4758,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"micromatch@npm:^4.0.4, micromatch@npm:^4.0.5":
+"micromatch@npm:^4.0.2, micromatch@npm:^4.0.4, micromatch@npm:^4.0.5":
   version: 4.0.5
   resolution: "micromatch@npm:4.0.5"
   dependencies:
@@ -6283,7 +6360,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.1.0":
+"tslib@npm:^2.1.0, tslib@npm:^2.4.0":
   version: 2.4.0
   resolution: "tslib@npm:2.4.0"
   checksum: 8c4aa6a3c5a754bf76aefc38026134180c053b7bd2f81338cb5e5ebf96fefa0f417bff221592bf801077f5bf990562f6264fecbc42cd3309b33872cb6fc3b113
@@ -6314,6 +6391,13 @@ __metadata:
   version: 0.14.5
   resolution: "tweetnacl@npm:0.14.5"
   checksum: 6061daba1724f59473d99a7bb82e13f211cdf6e31315510ae9656fefd4779851cb927adad90f3b488c8ed77c106adc0421ea8055f6f976ff21b27c5c4e918487
+  languageName: node
+  linkType: hard
+
+"typanion@npm:^3.8.0":
+  version: 3.12.0
+  resolution: "typanion@npm:3.12.0"
+  checksum: 3c61f33027f1612ef079574a538ea800aee93272d0080e5efd305b750065c344c66f8986a5fd1678f38694199ab0444e16afe1a03e7a01c1d204d1129d79e416
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -836,7 +836,6 @@ __metadata:
     "@types/jest": ^27.0.2
     "@typescript-eslint/eslint-plugin": ^5.0.0
     "@typescript-eslint/parser": ^5.0.0
-    "@yarnpkg/shell": ^4.0.0-rc.18
     eslint: ^7.23.0
     eslint-config-prettier: ^8.3.0
     eslint-plugin-import: ^2.22.1
@@ -1038,13 +1037,6 @@ __metadata:
   dependencies:
     "@babel/types": ^7.3.0
   checksum: a7158b13e5e4b844565217d04a0a09c1cf04e67de90972318960028effbd5e7400f2567b72c5f790acffdab9b4adce8d68f435a2f0c2b16e2c9c45994ace98f2
-  languageName: node
-  linkType: hard
-
-"@types/emscripten@npm:^1.39.6":
-  version: 1.39.6
-  resolution: "@types/emscripten@npm:1.39.6"
-  checksum: 437f2f9cdfd9057255662508fa9a415fe704ba484c6198f3549c5b05feebcdcd612b1ec7b10026d2566935d05d3c36f9366087cb42bc90bd25772a88fcfc9343
   languageName: node
   linkType: hard
 
@@ -1336,54 +1328,6 @@ __metadata:
     "@typescript-eslint/types": 5.36.2
     eslint-visitor-keys: ^3.3.0
   checksum: 87ccdcfa5cdedaa3a1aac30d656969f4f5910b62bcaacdf80a514dbf0cbbd8e79b55f8e987eab34cc79ece8ce4b8c19d5caf8b0afb74e0b0d7ab39fb29aa8eba
-  languageName: node
-  linkType: hard
-
-"@yarnpkg/fslib@npm:^3.0.0-rc.18":
-  version: 3.0.0-rc.18
-  resolution: "@yarnpkg/fslib@npm:3.0.0-rc.18"
-  dependencies:
-    "@yarnpkg/libzip": ^3.0.0-rc.18
-    tslib: ^2.4.0
-  checksum: 28409ffd3b885958bec924e9d2105e16778d9c69f1efc094d496480e14852a062158512039c93eb803cf90bd023112e68acc22d41bc0d5a01a41b68f9d59e7af
-  languageName: node
-  linkType: hard
-
-"@yarnpkg/libzip@npm:^3.0.0-rc.18":
-  version: 3.0.0-rc.18
-  resolution: "@yarnpkg/libzip@npm:3.0.0-rc.18"
-  dependencies:
-    "@types/emscripten": ^1.39.6
-    tslib: ^2.4.0
-  checksum: b732a2c9cc6766624b57cf1c9d1597af9456408bf361c0285a1995334c25a683a91239444b688ce5a3e4aa9e486e6cd276b0185cd0d5766b20f44d6963a19b50
-  languageName: node
-  linkType: hard
-
-"@yarnpkg/parsers@npm:^3.0.0-rc.18":
-  version: 3.0.0-rc.18
-  resolution: "@yarnpkg/parsers@npm:3.0.0-rc.18"
-  dependencies:
-    js-yaml: ^3.10.0
-    tslib: ^2.4.0
-  checksum: 73cc59cb2349ce78a376d6ad7953117360de9aff866f42329a3e957ebabbbd4cbd91bfe79e30aa3bf07f126af66b72c00a7fc733724ac93d7f46d420ba81beec
-  languageName: node
-  linkType: hard
-
-"@yarnpkg/shell@npm:^4.0.0-rc.18":
-  version: 4.0.0-rc.18
-  resolution: "@yarnpkg/shell@npm:4.0.0-rc.18"
-  dependencies:
-    "@yarnpkg/fslib": ^3.0.0-rc.18
-    "@yarnpkg/parsers": ^3.0.0-rc.18
-    chalk: ^3.0.0
-    clipanion: ^3.2.0-rc.10
-    cross-spawn: 7.0.3
-    fast-glob: ^3.2.2
-    micromatch: ^4.0.2
-    tslib: ^2.4.0
-  bin:
-    shell: ./lib/cli.js
-  checksum: eca01879e4004a96b5a666adbe211ed885b595d726fee028cd3791867b8b8783b481230e2164d4964452d9387077fb10dc2bd5357559258c26f33c498bf45e5a
   languageName: node
   linkType: hard
 
@@ -1946,16 +1890,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "chalk@npm:3.0.0"
-  dependencies:
-    ansi-styles: ^4.1.0
-    supports-color: ^7.1.0
-  checksum: 8e3ddf3981c4da405ddbd7d9c8d91944ddf6e33d6837756979f7840a29272a69a5189ecae0ff84006750d6d1e92368d413335eab4db5476db6e6703a1d1e0505
-  languageName: node
-  linkType: hard
-
 "chalk@npm:^4.0.0":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
@@ -2027,17 +1961,6 @@ __metadata:
     slice-ansi: ^5.0.0
     string-width: ^5.0.0
   checksum: c3243e41974445691c63f8b405df1d5a24049dc33d324fe448dc572e561a7b772ae982692900b1a5960901cc4fc7def25a629b9c69a4208ee89d12ab3332617a
-  languageName: node
-  linkType: hard
-
-"clipanion@npm:^3.2.0-rc.10":
-  version: 3.2.0-rc.12
-  resolution: "clipanion@npm:3.2.0-rc.12"
-  dependencies:
-    typanion: ^3.8.0
-  peerDependencies:
-    typanion: "*"
-  checksum: a49acffb4ef843872dbbaf1d2c582021c03c51d08c556ff1e2909a1ebed27f32301f2e98a5ebe4cdf6ae30d360dac7a2a9aa6b0c5e34a6fc95c561091a734c87
   languageName: node
   linkType: hard
 
@@ -2181,7 +2104,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:7.0.3, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
+"cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
   dependencies:
@@ -2954,16 +2877,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.0.3, fast-glob@npm:^3.2.2, fast-glob@npm:^3.2.9":
-  version: 3.2.12
-  resolution: "fast-glob@npm:3.2.12"
+"fast-glob@npm:^3.0.3, fast-glob@npm:^3.2.9":
+  version: 3.2.11
+  resolution: "fast-glob@npm:3.2.11"
   dependencies:
     "@nodelib/fs.stat": ^2.0.2
     "@nodelib/fs.walk": ^1.2.3
     glob-parent: ^5.1.2
     merge2: ^1.3.0
     micromatch: ^4.0.4
-  checksum: 0b1990f6ce831c7e28c4d505edcdaad8e27e88ab9fa65eedadb730438cfc7cde4910d6c975d6b7b8dc8a73da4773702ebcfcd6e3518e73938bb1383badfe01c2
+  checksum: f473105324a7780a20c06de842e15ddbb41d3cb7e71d1e4fe6e8373204f22245d54f5ab9e2061e6a1c613047345954d29b022e0e76f5c28b1df9858179a0e6d7
   languageName: node
   linkType: hard
 
@@ -4382,7 +4305,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^3.10.0, js-yaml@npm:^3.13.1":
+"js-yaml@npm:^3.13.1":
   version: 3.14.1
   resolution: "js-yaml@npm:3.14.1"
   dependencies:
@@ -4758,7 +4681,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"micromatch@npm:^4.0.2, micromatch@npm:^4.0.4, micromatch@npm:^4.0.5":
+"micromatch@npm:^4.0.4, micromatch@npm:^4.0.5":
   version: 4.0.5
   resolution: "micromatch@npm:4.0.5"
   dependencies:
@@ -6360,7 +6283,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.1.0, tslib@npm:^2.4.0":
+"tslib@npm:^2.1.0":
   version: 2.4.0
   resolution: "tslib@npm:2.4.0"
   checksum: 8c4aa6a3c5a754bf76aefc38026134180c053b7bd2f81338cb5e5ebf96fefa0f417bff221592bf801077f5bf990562f6264fecbc42cd3309b33872cb6fc3b113
@@ -6391,13 +6314,6 @@ __metadata:
   version: 0.14.5
   resolution: "tweetnacl@npm:0.14.5"
   checksum: 6061daba1724f59473d99a7bb82e13f211cdf6e31315510ae9656fefd4779851cb927adad90f3b488c8ed77c106adc0421ea8055f6f976ff21b27c5c4e918487
-  languageName: node
-  linkType: hard
-
-"typanion@npm:^3.8.0":
-  version: 3.12.0
-  resolution: "typanion@npm:3.12.0"
-  checksum: 3c61f33027f1612ef079574a538ea800aee93272d0080e5efd305b750065c344c66f8986a5fd1678f38694199ab0444e16afe1a03e7a01c1d204d1129d79e416
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #73.

This replaces the `postinstall` script with a Yarn plugin which calls `simple-git-hooks` after running `yarn`.