### PR TITLE
Export Buffer from `buffer` package explicitly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,4 +23,4 @@ export {
  * The {@link Buffer} accessible to `@metamask/key-tree`, re-exported in case
  * of module resolution issues.
  */
-export const PackageBuffer = Buffer;
+export { default as PackageBuffer } from 'buffer';

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,4 +23,4 @@ export {
  * The {@link Buffer} accessible to `@metamask/key-tree`, re-exported in case
  * of module resolution issues.
  */
-export { default as PackageBuffer } from 'buffer';
+export { Buffer as PackageBuffer } from 'buffer';


### PR DESCRIPTION
This fixes a type issue in packages using `key-tree`. Otherwise it would result in this:

```
../../node_modules/@metamask/key-tree/dist/index.d.ts:11:37 - error TS2552: Cannot find name 'BufferConstructor'. Did you mean 'NumberConstructor'?

11 export declare const PackageBuffer: BufferConstructor;
                                       ~~~~~~~~~~~~~~~~~
```

A possibly better solution is to remove this export entirely, as I don't think we're using it anywhere? @rekmarks 