### PR TITLE
Fix fingerprint derivation

### DIFF
--- a/src/SLIP10Node.test.ts
+++ b/src/SLIP10Node.test.ts
@@ -612,7 +612,24 @@ describe('SLIP10Node', () => {
         curve: 'secp256k1',
       });
 
-      expect(node.fingerprint).toBe(1498926763);
+      expect(node.fingerprint).toBe(3263250961);
+    });
+  });
+
+  describe('masterFingerprint', () => {
+    it('returns the master fingerprint for a node', async () => {
+      const masterNode = await SLIP10Node.fromDerivationPath({
+        derivationPath: [defaultBip39NodeToken],
+        curve: 'secp256k1',
+      });
+
+      const node = await masterNode.derive([
+        BIP44PurposeNodeToken,
+        `bip32:60'`,
+      ]);
+
+      expect(node.masterFingerprint).toBe(3293725253);
+      expect(node.masterFingerprint).toBe(masterNode.fingerprint);
     });
   });
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -372,7 +372,7 @@ describe('getFingerprint', () => {
       'xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi',
     );
 
-    expect(getFingerprint(node.compressedPublicKeyBuffer)).toBe(2391500305);
+    expect(getFingerprint(node.compressedPublicKeyBuffer)).toBe(876747070);
   });
 
   it('throws if the public key is not a valid buffer', async () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -336,5 +336,5 @@ export const getFingerprint = (publicKey: Buffer): number => {
     );
   }
 
-  return Buffer.from(ripemd160(publicKey)).readUInt32BE(0);
+  return Buffer.from(ripemd160(sha256(publicKey))).readUInt32BE(0);
 };


### PR DESCRIPTION
From the BIP-32 specification:

> Extended keys can be identified by the Hash160 (RIPEMD160 after SHA256) of the serialized ECDSA public key K, ignoring the chain code.

We were only taking the `RIPEMD160` hash, rather than `RIPEMD160` after `SHA256`.