### PR TITLE
BREAKING: Rename all occurrences of `Buffer` with `Bytes` or `Uint8Array`

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ const coinTypeNode = await getCoinTypeNode();
 // Alternatively you can use an extended key (`xprv`) as well.
 const addressKeyDeriver = getBIP44AddressKeyDeriver(coinTypeNode);
 
-// These are Node.js Buffer representations of the extended private keys for
+// These are Uint8Array representations of the extended private keys for
 // the respective addresses.
 
 // m / 44' / 60' / 0' / 0 / 0

--- a/src/BIP44CoinTypeNode.test.ts
+++ b/src/BIP44CoinTypeNode.test.ts
@@ -110,7 +110,9 @@ describe('BIP44CoinTypeNode', () => {
       for (const input of inputs) {
         await expect(
           BIP44CoinTypeNode.fromJSON(input as any, arbitraryCoinType),
-        ).rejects.toThrow('Invalid value: Must be a non-zero 32-byte buffer.');
+        ).rejects.toThrow(
+          'Invalid value: Must be a non-zero 32-byte byte array.',
+        );
       }
 
       await expect(
@@ -201,8 +203,8 @@ describe('BIP44CoinTypeNode', () => {
 
       expect(node.coin_type).toStrictEqual(coinType);
       expect(node.depth).toStrictEqual(2);
-      expect(node.privateKeyBuffer).toHaveLength(32);
-      expect(node.publicKeyBuffer).toHaveLength(65);
+      expect(node.privateKeyBytes).toHaveLength(32);
+      expect(node.publicKeyBytes).toHaveLength(65);
       expect(node.path).toStrictEqual(pathString);
 
       expect(node.toJSON()).toStrictEqual({
@@ -384,7 +386,7 @@ describe('BIP44CoinTypeNode', () => {
     });
   });
 
-  describe('compressedPublicKeyBuffer', () => {
+  describe('compressedPublicKeyBytes', () => {
     it('returns the compressed public key for a node', async () => {
       const coinType = 60;
       const node = await BIP44Node.fromDerivationPath({
@@ -397,8 +399,8 @@ describe('BIP44CoinTypeNode', () => {
 
       const parentNode = await BIP44CoinTypeNode.fromNode(node, coinType);
 
-      expect(parentNode.compressedPublicKeyBuffer).toStrictEqual(
-        node.compressedPublicKeyBuffer,
+      expect(parentNode.compressedPublicKeyBytes).toStrictEqual(
+        node.compressedPublicKeyBytes,
       );
     });
   });
@@ -431,8 +433,8 @@ describe('BIP44CoinTypeNode', () => {
 
       const extendedKey = encodeExtendedKey({
         version: PRIVATE_KEY_VERSION,
-        privateKey: node.privateKeyBuffer as Uint8Array,
-        chainCode: node.chainCodeBuffer,
+        privateKey: node.privateKeyBytes as Uint8Array,
+        chainCode: node.chainCodeBytes,
         depth: node.depth,
         parentFingerprint: node.parentFingerprint,
         index: node.index,

--- a/src/BIP44CoinTypeNode.ts
+++ b/src/BIP44CoinTypeNode.ts
@@ -15,8 +15,8 @@ import {
   getBIP44CoinTypeToAddressPathTuple,
   getHardenedBIP32NodeToken,
   getUnhardenedBIP32NodeToken,
-  hexStringToBuffer,
-  nullableHexStringToBuffer,
+  hexStringToBytes,
+  nullableHexStringToBytes,
 } from './utils';
 import { deriveChildNode } from './SLIP10Node';
 import { SupportedCurve } from './curves';
@@ -80,9 +80,9 @@ export class BIP44CoinTypeNode implements BIP44CoinTypeNodeInterface {
       depth: json.depth,
       index: json.index,
       parentFingerprint: json.parentFingerprint,
-      chainCode: hexStringToBuffer(json.chainCode),
-      privateKey: nullableHexStringToBuffer(json.privateKey),
-      publicKey: hexStringToBuffer(json.publicKey),
+      chainCode: hexStringToBytes(json.chainCode),
+      privateKey: nullableHexStringToBytes(json.privateKey),
+      publicKey: hexStringToBytes(json.publicKey),
     });
 
     return new BIP44CoinTypeNode(node, coin_type);
@@ -167,16 +167,16 @@ export class BIP44CoinTypeNode implements BIP44CoinTypeNodeInterface {
     return this.#node.depth;
   }
 
-  public get privateKeyBuffer(): Uint8Array | undefined {
-    return this.#node.privateKeyBuffer;
+  public get privateKeyBytes(): Uint8Array | undefined {
+    return this.#node.privateKeyBytes;
   }
 
-  public get publicKeyBuffer(): Uint8Array {
-    return this.#node.publicKeyBuffer;
+  public get publicKeyBytes(): Uint8Array {
+    return this.#node.publicKeyBytes;
   }
 
-  public get chainCodeBuffer(): Uint8Array {
-    return this.#node.chainCodeBuffer;
+  public get chainCodeBytes(): Uint8Array {
+    return this.#node.chainCodeBytes;
   }
 
   public get privateKey(): string | undefined {
@@ -191,8 +191,8 @@ export class BIP44CoinTypeNode implements BIP44CoinTypeNodeInterface {
     return this.#node.compressedPublicKey;
   }
 
-  public get compressedPublicKeyBuffer(): Uint8Array {
-    return this.#node.compressedPublicKeyBuffer;
+  public get compressedPublicKeyBytes(): Uint8Array {
+    return this.#node.compressedPublicKeyBytes;
   }
 
   public get chainCode(): string {

--- a/src/BIP44Node.test.ts
+++ b/src/BIP44Node.test.ts
@@ -1,7 +1,7 @@
 import { bytesToHex } from '@metamask/utils';
 import fixtures from '../test/fixtures';
 import { createBip39KeyFromSeed, deriveChildKey } from './derivers/bip39';
-import { hexStringToBuffer } from './utils';
+import { hexStringToBytes } from './utils';
 import { compressPublicKey } from './curves/secp256k1';
 import {
   encodeExtendedKey,
@@ -382,7 +382,7 @@ describe('BIP44Node', () => {
       'returns the public key for an secp256k1 node',
       async ({ index, publicKey }) => {
         const { privateKey, chainCode } = await createBip39KeyFromSeed(
-          hexStringToBuffer(hexSeed),
+          hexStringToBytes(hexSeed),
         );
 
         const node = await BIP44Node.fromExtendedKey({
@@ -411,7 +411,7 @@ describe('BIP44Node', () => {
       'returns the address for an secp256k1 node',
       async ({ index, address }) => {
         const { privateKey, chainCode } = await createBip39KeyFromSeed(
-          hexStringToBuffer(hexSeed),
+          hexStringToBytes(hexSeed),
         );
 
         const node = await BIP44Node.fromExtendedKey({
@@ -444,12 +444,12 @@ describe('BIP44Node', () => {
       });
 
       expect(node.compressedPublicKey).toStrictEqual(
-        bytesToHex(compressPublicKey(node.publicKeyBuffer)),
+        bytesToHex(compressPublicKey(node.publicKeyBytes)),
       );
     });
   });
 
-  describe('compressedPublicKeyBuffer', () => {
+  describe('compressedPublicKeyBytes', () => {
     it('returns the public key in compressed form', async () => {
       const node = await BIP44Node.fromDerivationPath({
         derivationPath: [
@@ -460,8 +460,8 @@ describe('BIP44Node', () => {
         ],
       });
 
-      expect(node.compressedPublicKeyBuffer).toStrictEqual(
-        compressPublicKey(node.publicKeyBuffer),
+      expect(node.compressedPublicKeyBytes).toStrictEqual(
+        compressPublicKey(node.publicKeyBytes),
       );
     });
   });
@@ -479,8 +479,8 @@ describe('BIP44Node', () => {
 
       const extendedKey = encodeExtendedKey({
         version: PRIVATE_KEY_VERSION,
-        privateKey: node.privateKeyBuffer as Uint8Array,
-        chainCode: node.chainCodeBuffer,
+        privateKey: node.privateKeyBytes as Uint8Array,
+        chainCode: node.chainCodeBytes,
         depth: node.depth,
         parentFingerprint: node.parentFingerprint,
         index: node.index,
@@ -503,8 +503,8 @@ describe('BIP44Node', () => {
 
       const extendedKey = encodeExtendedKey({
         version: PUBLIC_KEY_VERSION,
-        publicKey: neuteredNode.publicKeyBuffer,
-        chainCode: neuteredNode.chainCodeBuffer,
+        publicKey: neuteredNode.publicKeyBytes,
+        chainCode: neuteredNode.chainCodeBytes,
         depth: neuteredNode.depth,
         parentFingerprint: neuteredNode.parentFingerprint,
         index: neuteredNode.index,
@@ -529,7 +529,7 @@ describe('BIP44Node', () => {
 
       expect(neuterNode.publicKey).toBe(node.publicKey);
       expect(neuterNode.privateKey).toBeUndefined();
-      expect(neuterNode.privateKeyBuffer).toBeUndefined();
+      expect(neuterNode.privateKeyBytes).toBeUndefined();
     });
   });
 

--- a/src/BIP44Node.ts
+++ b/src/BIP44Node.ts
@@ -221,16 +221,16 @@ export class BIP44Node implements BIP44NodeInterface {
     return this.#node.depth as BIP44Depth;
   }
 
-  public get privateKeyBuffer(): Uint8Array | undefined {
-    return this.#node.privateKeyBuffer;
+  public get privateKeyBytes(): Uint8Array | undefined {
+    return this.#node.privateKeyBytes;
   }
 
-  public get publicKeyBuffer(): Uint8Array {
-    return this.#node.publicKeyBuffer;
+  public get publicKeyBytes(): Uint8Array {
+    return this.#node.publicKeyBytes;
   }
 
-  public get chainCodeBuffer(): Uint8Array {
-    return this.#node.chainCodeBuffer;
+  public get chainCodeBytes(): Uint8Array {
+    return this.#node.chainCodeBytes;
   }
 
   public get privateKey(): string | undefined {
@@ -245,8 +245,8 @@ export class BIP44Node implements BIP44NodeInterface {
     return this.#node.compressedPublicKey;
   }
 
-  public get compressedPublicKeyBuffer(): Uint8Array {
-    return this.#node.compressedPublicKeyBuffer;
+  public get compressedPublicKeyBytes(): Uint8Array {
+    return this.#node.compressedPublicKeyBytes;
   }
 
   public get chainCode(): string {
@@ -278,21 +278,21 @@ export class BIP44Node implements BIP44NodeInterface {
       depth: this.depth,
       parentFingerprint: this.parentFingerprint,
       index: this.index,
-      chainCode: this.chainCodeBuffer,
+      chainCode: this.chainCodeBytes,
     };
 
-    if (this.privateKeyBuffer) {
+    if (this.privateKeyBytes) {
       return encodeExtendedKey({
         ...data,
         version: PRIVATE_KEY_VERSION,
-        privateKey: this.privateKeyBuffer,
+        privateKey: this.privateKeyBytes,
       });
     }
 
     return encodeExtendedKey({
       ...data,
       version: PUBLIC_KEY_VERSION,
-      publicKey: this.publicKeyBuffer,
+      publicKey: this.publicKeyBytes,
     });
   }
 

--- a/src/SLIP10Node.ts
+++ b/src/SLIP10Node.ts
@@ -1,6 +1,6 @@
 import { bytesToHex } from '@metamask/utils';
 import {
-  BUFFER_KEY_LENGTH,
+  BYTES_KEY_LENGTH,
   RootedSLIP10PathTuple,
   SLIP10PathTuple,
 } from './constants';
@@ -8,7 +8,7 @@ import { curves, getCurveByName, SupportedCurve } from './curves';
 import { deriveKeyFromPath } from './derivation';
 import { publicKeyToEthAddress } from './derivers/bip32';
 import {
-  getBuffer,
+  getBytes,
   getFingerprint,
   isValidInteger,
   validateBIP32Index,
@@ -65,18 +65,18 @@ export type JsonSLIP10Node = {
 };
 
 export type SLIP10NodeInterface = JsonSLIP10Node & {
-  chainCodeBuffer: Uint8Array;
+  chainCodeBytes: Uint8Array;
 
   /**
-   * The private key for this node, as a Node.js Buffer or browser-equivalent.
+   * The private key for this node, as a {@link Uint8Array}.
    * May be undefined if this node is a public key only node.
    */
-  privateKeyBuffer?: Uint8Array;
+  privateKeyBytes?: Uint8Array;
 
   /**
-   * The public key for this node, as a Node.js Buffer or browser-equivalent.
+   * The public key for this node, as a {@link Uint8Array}.
    */
-  publicKeyBuffer: Uint8Array;
+  publicKeyBytes: Uint8Array;
 
   /**
    * @returns A JSON-compatible representation of this node's data fields.
@@ -153,7 +153,7 @@ export class SLIP10Node implements SLIP10NodeInterface {
     chainCode,
     curve,
   }: SLIP10ExtendedKeyOptions) {
-    const chainCodeBuffer = getBuffer(chainCode, BUFFER_KEY_LENGTH);
+    const chainCodeBytes = getBytes(chainCode, BYTES_KEY_LENGTH);
 
     validateCurve(curve);
     validateBIP32Depth(depth);
@@ -161,22 +161,22 @@ export class SLIP10Node implements SLIP10NodeInterface {
     validateParentFingerprint(parentFingerprint);
 
     if (privateKey) {
-      const privateKeyBuffer = getBuffer(privateKey, BUFFER_KEY_LENGTH);
+      const privateKeyBytes = getBytes(privateKey, BYTES_KEY_LENGTH);
 
       return new SLIP10Node({
         depth,
         masterFingerprint,
         parentFingerprint,
         index,
-        chainCode: chainCodeBuffer,
-        privateKey: privateKeyBuffer,
-        publicKey: await getCurveByName(curve).getPublicKey(privateKeyBuffer),
+        chainCode: chainCodeBytes,
+        privateKey: privateKeyBytes,
+        publicKey: await getCurveByName(curve).getPublicKey(privateKeyBytes),
         curve,
       });
     }
 
     if (publicKey) {
-      const publicKeyBuffer = getBuffer(
+      const publicKeyBytes = getBytes(
         publicKey,
         getCurveByName(curve).publicKeyLength,
       );
@@ -186,8 +186,8 @@ export class SLIP10Node implements SLIP10NodeInterface {
         masterFingerprint,
         parentFingerprint,
         index,
-        chainCode: chainCodeBuffer,
-        publicKey: publicKeyBuffer,
+        chainCode: chainCodeBytes,
+        publicKey: publicKeyBytes,
         curve,
       });
     }
@@ -251,11 +251,11 @@ export class SLIP10Node implements SLIP10NodeInterface {
 
   public readonly index: number;
 
-  public readonly chainCodeBuffer: Uint8Array;
+  public readonly chainCodeBytes: Uint8Array;
 
-  public readonly privateKeyBuffer?: Uint8Array;
+  public readonly privateKeyBytes?: Uint8Array;
 
-  public readonly publicKeyBuffer: Uint8Array;
+  public readonly publicKeyBytes: Uint8Array;
 
   constructor({
     depth,
@@ -271,36 +271,36 @@ export class SLIP10Node implements SLIP10NodeInterface {
     this.masterFingerprint = masterFingerprint;
     this.parentFingerprint = parentFingerprint;
     this.index = index;
-    this.chainCodeBuffer = chainCode;
-    this.privateKeyBuffer = privateKey;
-    this.publicKeyBuffer = publicKey;
+    this.chainCodeBytes = chainCode;
+    this.privateKeyBytes = privateKey;
+    this.publicKeyBytes = publicKey;
     this.curve = curve;
 
     Object.freeze(this);
   }
 
   public get chainCode() {
-    return bytesToHex(this.chainCodeBuffer);
+    return bytesToHex(this.chainCodeBytes);
   }
 
   public get privateKey(): string | undefined {
-    if (this.privateKeyBuffer) {
-      return bytesToHex(this.privateKeyBuffer);
+    if (this.privateKeyBytes) {
+      return bytesToHex(this.privateKeyBytes);
     }
 
     return undefined;
   }
 
   public get publicKey(): string {
-    return bytesToHex(this.publicKeyBuffer);
+    return bytesToHex(this.publicKeyBytes);
   }
 
-  public get compressedPublicKeyBuffer(): Uint8Array {
-    return getCurveByName(this.curve).compressPublicKey(this.publicKeyBuffer);
+  public get compressedPublicKeyBytes(): Uint8Array {
+    return getCurveByName(this.curve).compressPublicKey(this.publicKeyBytes);
   }
 
   public get compressedPublicKey(): string {
-    return bytesToHex(this.compressedPublicKeyBuffer);
+    return bytesToHex(this.compressedPublicKeyBytes);
   }
 
   public get address(): string {
@@ -310,11 +310,11 @@ export class SLIP10Node implements SLIP10NodeInterface {
       );
     }
 
-    return bytesToHex(publicKeyToEthAddress(this.publicKeyBuffer));
+    return bytesToHex(publicKeyToEthAddress(this.publicKeyBytes));
   }
 
   public get fingerprint(): number {
-    return getFingerprint(this.compressedPublicKeyBuffer);
+    return getFingerprint(this.compressedPublicKeyBytes);
   }
 
   /**
@@ -326,8 +326,8 @@ export class SLIP10Node implements SLIP10NodeInterface {
       masterFingerprint: this.masterFingerprint,
       parentFingerprint: this.parentFingerprint,
       index: this.index,
-      chainCode: this.chainCodeBuffer,
-      publicKey: this.publicKeyBuffer,
+      chainCode: this.chainCodeBytes,
+      publicKey: this.publicKeyBytes,
       curve: this.curve,
     });
   }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
-export const BUFFER_EXTENDED_KEY_LENGTH = 64;
+export const BYTES_EXTENDED_KEY_LENGTH = 64;
 
-export const BUFFER_KEY_LENGTH = 32;
+export const BYTES_KEY_LENGTH = 32;
 
 export const HEXADECIMAL_KEY_LENGTH = 64;
 

--- a/src/curves/ed25519.test.ts
+++ b/src/curves/ed25519.test.ts
@@ -62,10 +62,8 @@ describe('ed25519', () => {
 
     it.each(slip10)('returns the same public key', async ({ keys }) => {
       for (const { publicKey } of keys) {
-        const publicKeyBuffer = hexToBytes(publicKey);
-        expect(compressPublicKey(publicKeyBuffer)).toStrictEqual(
-          publicKeyBuffer,
-        );
+        const publicKeyBytes = hexToBytes(publicKey);
+        expect(compressPublicKey(publicKeyBytes)).toStrictEqual(publicKeyBytes);
       }
     });
   });
@@ -75,9 +73,9 @@ describe('ed25519', () => {
 
     it.each(slip10)('returns the same public key', async ({ keys }) => {
       for (const { publicKey } of keys) {
-        const publicKeyBuffer = hexToBytes(publicKey);
-        expect(decompressPublicKey(publicKeyBuffer)).toStrictEqual(
-          publicKeyBuffer,
+        const publicKeyBytes = hexToBytes(publicKey);
+        expect(decompressPublicKey(publicKeyBytes)).toStrictEqual(
+          publicKeyBytes,
         );
       }
     });

--- a/src/derivation.test.ts
+++ b/src/derivation.test.ts
@@ -48,8 +48,8 @@ describe('derivation', () => {
       );
 
       // validate addresses
-      keys.forEach(({ privateKeyBuffer }, index) => {
-        const address = privateKeyToEthAddress(privateKeyBuffer as Uint8Array);
+      keys.forEach(({ privateKeyBytes }, index) => {
+        const address = privateKeyToEthAddress(privateKeyBytes as Uint8Array);
         expect(bytesToHex(address)).toStrictEqual(expectedAddresses[index]);
       });
     });
@@ -73,8 +73,8 @@ describe('derivation', () => {
       );
 
       // validate addresses
-      keys.forEach(({ privateKeyBuffer }, index) => {
-        const address = privateKeyToEthAddress(privateKeyBuffer as Uint8Array);
+      keys.forEach(({ privateKeyBytes }, index) => {
+        const address = privateKeyToEthAddress(privateKeyBytes as Uint8Array);
         expect(bytesToHex(address)).toStrictEqual(expectedAddresses[index]);
       });
     });

--- a/src/derivers/bip32.test.ts
+++ b/src/derivers/bip32.test.ts
@@ -1,6 +1,6 @@
 import { CURVE } from '@noble/secp256k1';
 import { bytesToHex } from '@metamask/utils';
-import { hexStringToBuffer } from '../utils';
+import { hexStringToBytes } from '../utils';
 import fixtures from '../../test/fixtures';
 import { secp256k1 } from '../curves';
 import {
@@ -15,12 +15,12 @@ describe('privateAdd', () => {
   it.each(privateAddFixtures)(
     'adds a tweak to a private key',
     ({ privateKey, tweak, result }) => {
-      const expected = hexStringToBuffer(result);
+      const expected = hexStringToBytes(result);
 
       expect(
         privateAdd(
-          hexStringToBuffer(privateKey),
-          hexStringToBuffer(tweak),
+          hexStringToBytes(privateKey),
+          hexStringToBytes(tweak),
           secp256k1,
         ),
       ).toStrictEqual(expected);
@@ -28,10 +28,10 @@ describe('privateAdd', () => {
   );
 
   it('throws if the tweak is larger than the curve order', () => {
-    const privateKey = hexStringToBuffer(
+    const privateKey = hexStringToBytes(
       '51f34c9afc9d5b43e085688db58bb923c012bb07e42a8eaf18a8400aa9a167fb',
     );
-    const tweak = hexStringToBuffer(CURVE.n.toString(16));
+    const tweak = hexStringToBytes(CURVE.n.toString(16));
 
     expect(() => privateAdd(privateKey, tweak, secp256k1)).toThrow(
       'Invalid tweak: Tweak is larger than the curve order.',
@@ -40,12 +40,12 @@ describe('privateAdd', () => {
 
   it('throws if the result is invalid', () => {
     // n - 1
-    const privateKey = hexStringToBuffer(
+    const privateKey = hexStringToBytes(
       'fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140',
     );
 
     // 1
-    const tweak = hexStringToBuffer(
+    const tweak = hexStringToBytes(
       '0000000000000000000000000000000000000000000000000000000000000001',
     );
 
@@ -60,7 +60,7 @@ describe('privateKeyToEthAddress', () => {
     const { privateKey, address } = fixtures['ethereumjs-wallet'];
 
     expect(
-      bytesToHex(privateKeyToEthAddress(hexStringToBuffer(privateKey))),
+      bytesToHex(privateKeyToEthAddress(hexStringToBytes(privateKey))),
     ).toBe(address);
   });
 
@@ -80,9 +80,9 @@ describe('publicKeyToEthAddress', () => {
   it('returns the Ethereum address for a public key', () => {
     const { publicKey, address } = fixtures['ethereumjs-wallet'];
 
-    expect(
-      bytesToHex(publicKeyToEthAddress(hexStringToBuffer(publicKey))),
-    ).toBe(address);
+    expect(bytesToHex(publicKeyToEthAddress(hexStringToBytes(publicKey)))).toBe(
+      address,
+    );
   });
 
   it('throws for invalid public keys', () => {

--- a/src/derivers/bip32.ts
+++ b/src/derivers/bip32.ts
@@ -7,8 +7,8 @@ import {
   concatBytes,
   hexToBytes,
 } from '@metamask/utils';
-import { BIP_32_HARDENED_OFFSET, BUFFER_KEY_LENGTH } from '../constants';
-import { isValidBufferKey } from '../utils';
+import { BIP_32_HARDENED_OFFSET, BYTES_KEY_LENGTH } from '../constants';
+import { isValidBytesKey } from '../utils';
 import { Curve, mod, secp256k1 } from '../curves';
 import { SLIP10Node } from '../SLIP10Node';
 import { DeriveChildKeyArgs, DerivedKeys } from '.';
@@ -20,13 +20,13 @@ import { DeriveChildKeyArgs, DerivedKeys } from '.';
  * length. It is the consumer's responsibility to ensure that the specified
  * key is a valid BIP-44 Ethereum `address_index` key.
  *
- * @param key - The `address_index` private key buffer to convert to an Ethereum
+ * @param key - The `address_index` private key bytes to convert to an Ethereum
  * address.
  * @returns The Ethereum address corresponding to the given key.
  */
 export function privateKeyToEthAddress(key: Uint8Array) {
   assert(
-    key instanceof Uint8Array && isValidBufferKey(key, BUFFER_KEY_LENGTH),
+    key instanceof Uint8Array && isValidBytesKey(key, BYTES_KEY_LENGTH),
     'Invalid key: The key must be a 32-byte, non-zero Uint8Array.',
   );
 
@@ -41,14 +41,14 @@ export function privateKeyToEthAddress(key: Uint8Array) {
  * length. It is the consumer's responsibility to ensure that the specified
  * key is a valid BIP-44 Ethereum `address_index` key.
  *
- * @param key - The `address_index` public key buffer to convert to an Ethereum
+ * @param key - The `address_index` public key bytes to convert to an Ethereum
  * address.
  * @returns The Ethereum address corresponding to the given key.
  */
 export function publicKeyToEthAddress(key: Uint8Array) {
   assert(
     key instanceof Uint8Array &&
-      isValidBufferKey(key, secp256k1.publicKeyLength),
+      isValidBytesKey(key, secp256k1.publicKeyLength),
     'Invalid key: The key must be a 65-byte, non-zero Uint8Array.',
   );
 
@@ -100,17 +100,17 @@ export async function deriveChildKey({
     );
   }
 
-  if (node.privateKeyBuffer) {
+  if (node.privateKeyBytes) {
     const secretExtension = await deriveSecretExtension({
-      privateKey: node.privateKeyBuffer,
+      privateKey: node.privateKeyBytes,
       childIndex,
       isHardened,
       curve,
     });
 
     const { privateKey, chainCode } = await generateKey({
-      privateKey: node.privateKeyBuffer,
-      chainCode: node.chainCodeBuffer,
+      privateKey: node.privateKeyBytes,
+      chainCode: node.chainCodeBytes,
       secretExtension,
       curve,
     });
@@ -127,13 +127,13 @@ export async function deriveChildKey({
   }
 
   const publicExtension = await derivePublicExtension({
-    parentPublicKey: node.compressedPublicKeyBuffer,
+    parentPublicKey: node.compressedPublicKeyBytes,
     childIndex,
   });
 
   const { publicKey, chainCode } = generatePublicKey({
-    publicKey: node.compressedPublicKeyBuffer,
-    chainCode: node.chainCodeBuffer,
+    publicKey: node.compressedPublicKeyBytes,
+    chainCode: node.chainCodeBytes,
     publicExtension,
     curve,
   });
@@ -202,19 +202,19 @@ async function derivePublicExtension({
 /**
  * Add a tweak to the private key: `(privateKey + tweak) % n`.
  *
- * @param privateKeyBuffer - The private key as 32 byte Uint8Array.
- * @param tweakBuffer - The tweak as 32 byte Uint8Array.
+ * @param privateKeyBytes - The private key as 32 byte Uint8Array.
+ * @param tweakBytes - The tweak as 32 byte Uint8Array.
  * @param curve - The curve to use.
  * @throws If the private key or tweak is invalid.
  * @returns The private key with the tweak added to it.
  */
 export function privateAdd(
-  privateKeyBuffer: Uint8Array,
-  tweakBuffer: Uint8Array,
+  privateKeyBytes: Uint8Array,
+  tweakBytes: Uint8Array,
   curve: Curve,
 ): Uint8Array {
-  const privateKey = bytesToBigInt(privateKeyBuffer);
-  const tweak = bytesToBigInt(tweakBuffer);
+  const privateKey = bytesToBigInt(privateKeyBytes);
+  const tweak = bytesToBigInt(tweakBytes);
 
   if (tweak >= curve.curve.n) {
     throw new Error('Invalid tweak: Tweak is larger than the curve order.');

--- a/src/extended-keys.test.ts
+++ b/src/extended-keys.test.ts
@@ -6,7 +6,7 @@ import {
   PRIVATE_KEY_VERSION,
   PUBLIC_KEY_VERSION,
 } from './extended-keys';
-import { hexStringToBuffer } from './utils';
+import { hexStringToBytes } from './utils';
 
 describe('decodeExtendedKey', () => {
   it('decodes an extended public key', () => {
@@ -35,10 +35,10 @@ describe('decodeExtendedKey', () => {
       depth: 0,
       parentFingerprint: 0,
       index: 0,
-      chainCode: hexStringToBuffer(
+      chainCode: hexStringToBytes(
         '873dff81c02f525623fd1fe5167eac3a55a049de3d314bb42ee227ffed37d508',
       ),
-      privateKey: hexStringToBuffer(
+      privateKey: hexStringToBytes(
         'e8f32e723decf4051aefac8e2c93c9c5b214313817cdb01a1494b917c8436b35',
       ),
       version: PRIVATE_KEY_VERSION,
@@ -67,7 +67,7 @@ describe('decodeExtendedKey', () => {
       'xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzFAp8UkorEcJ4wSbGzEaLySRnFibyHm9Wvj72EK5vSiRn21B5B1e';
 
     expect(() => decodeExtendedKey(extendedKey)).toThrow(
-      'Invalid extended key: Chain code must be a 32-byte non-zero Buffer.',
+      'Invalid extended key: Chain code must be a 32-byte non-zero byte array.',
     );
   });
 
@@ -76,7 +76,7 @@ describe('decodeExtendedKey', () => {
       'xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChijLXZSun8bsGj49MuvWWsqL9fqS5fhiDUkRQvq8cj8L42RGwHP';
 
     expect(() => decodeExtendedKey(extendedKey)).toThrow(
-      'Invalid extended key: Key must be a 33-byte non-zero Buffer.',
+      'Invalid extended key: Key must be a 33-byte non-zero byte array.',
     );
   });
 
@@ -114,10 +114,10 @@ describe('encodeExtendedKey', () => {
       depth: 0,
       parentFingerprint: 0,
       index: 0,
-      chainCode: hexStringToBuffer(
+      chainCode: hexStringToBytes(
         '873dff81c02f525623fd1fe5167eac3a55a049de3d314bb42ee227ffed37d508',
       ),
-      publicKey: hexStringToBuffer(
+      publicKey: hexStringToBytes(
         '0439a36013301597daef41fbe593a02cc513d0b55527ec2df1050e2e8ff49c85c23cbe7ded0e7ce6a594896b8f62888fdbc5c8821305e2ea42bf01e37300116281',
       ),
       version: PUBLIC_KEY_VERSION,
@@ -133,10 +133,10 @@ describe('encodeExtendedKey', () => {
       depth: 0,
       parentFingerprint: 0,
       index: 0,
-      chainCode: hexStringToBuffer(
+      chainCode: hexStringToBytes(
         '873dff81c02f525623fd1fe5167eac3a55a049de3d314bb42ee227ffed37d508',
       ),
-      privateKey: hexStringToBuffer(
+      privateKey: hexStringToBytes(
         'e8f32e723decf4051aefac8e2c93c9c5b214313817cdb01a1494b917c8436b35',
       ),
       version: PRIVATE_KEY_VERSION,

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -6,11 +6,11 @@ import {
   getBIP44CoinTypeToAddressPathTuple,
   getHardenedBIP32NodeToken,
   getUnhardenedBIP32NodeToken,
-  isValidBufferKey,
-  nullableHexStringToBuffer,
-  getBuffer,
+  isValidBytesKey,
+  nullableHexStringToBytes,
+  getBytes,
   getFingerprint,
-  hexStringToBuffer,
+  hexStringToBytes,
   validateBIP32Index,
   isValidBIP32Index,
   isHardened,
@@ -206,66 +206,66 @@ describe('isHardened', () => {
   });
 });
 
-describe('hexStringToBuffer', () => {
-  it('returns the same buffer if a buffer is passed', () => {
-    const buffer = hexToBytes('123');
-    expect(hexStringToBuffer(buffer)).toBe(buffer);
+describe('hexStringToBytes', () => {
+  it('returns the same Uint8Array if a Uint8Array is passed', () => {
+    const bytes = hexToBytes('123');
+    expect(hexStringToBytes(bytes)).toBe(bytes);
   });
 
-  it('returns a buffer from a hex string', () => {
-    expect(hexStringToBuffer('1234')).toStrictEqual(hexToBytes('1234'));
-    expect(hexStringToBuffer('0x1234')).toStrictEqual(hexToBytes('1234'));
+  it('returns a Uint8Array from a hex string', () => {
+    expect(hexStringToBytes('1234')).toStrictEqual(hexToBytes('1234'));
+    expect(hexStringToBytes('0x1234')).toStrictEqual(hexToBytes('1234'));
   });
 
   it('throws if the string is not a valid hex string', () => {
-    expect(() => hexStringToBuffer('')).toThrow(
+    expect(() => hexStringToBytes('')).toThrow(
       'Value must be a hexadecimal string.',
     );
 
-    expect(() => hexStringToBuffer('0x0g')).toThrow(
+    expect(() => hexStringToBytes('0x0g')).toThrow(
       'Value must be a hexadecimal string.',
     );
   });
 });
 
-describe('nullableHexStringToBuffer', () => {
-  it('returns the same buffer if a buffer is passed', () => {
-    const buffer = hexToBytes('123');
-    expect(nullableHexStringToBuffer(buffer)).toBe(buffer);
+describe('nullableHexStringToBytes', () => {
+  it('returns the same Uint8Array if a Uint8Array is passed', () => {
+    const bytes = hexToBytes('123');
+    expect(nullableHexStringToBytes(bytes)).toBe(bytes);
   });
 
-  it('returns a buffer for a hexadecimal string', () => {
-    expect(nullableHexStringToBuffer('1234')).toStrictEqual(hexToBytes('1234'));
+  it('returns a Uint8Array for a hexadecimal string', () => {
+    expect(nullableHexStringToBytes('1234')).toStrictEqual(hexToBytes('1234'));
 
-    expect(nullableHexStringToBuffer('0x1234')).toStrictEqual(
+    expect(nullableHexStringToBytes('0x1234')).toStrictEqual(
       hexToBytes('1234'),
     );
   });
 
   it('returns undefined for falsy values', () => {
-    expect(nullableHexStringToBuffer(undefined)).toBeUndefined();
+    expect(nullableHexStringToBytes(undefined)).toBeUndefined();
   });
 
   it('throws if the string is not a valid hex string', () => {
-    expect(() => nullableHexStringToBuffer('')).toThrow(
+    expect(() => nullableHexStringToBytes('')).toThrow(
       'Value must be a hexadecimal string.',
     );
 
-    expect(() => nullableHexStringToBuffer('0x0g')).toThrow(
+    expect(() => nullableHexStringToBytes('0x0g')).toThrow(
       'Value must be a hexadecimal string.',
     );
   });
 });
 
-describe('isValidBufferKey', () => {
-  it('checks the buffer length', () => {
-    expect(isValidBufferKey(new Uint8Array(32).fill(1), 32)).toBe(true);
-    expect(isValidBufferKey(new Uint8Array(31).fill(1), 32)).toBe(false);
+describe('isValidBytesKey', () => {
+  it('checks the Uint8Array length', () => {
+    expect(isValidBytesKey(new Uint8Array(32).fill(1), 32)).toBe(true);
+    expect(isValidBytesKey(new Uint8Array(31).fill(1), 32)).toBe(false);
   });
 
-  it('checks if the buffer has at least one non-zero byte', () => {
-    expect(isValidBufferKey(new Uint8Array(32).fill(1), 32)).toBe(true);
-    expect(isValidBufferKey(new Uint8Array(32).fill(0), 32)).toBe(false);
+  it('checks if the Uint8Array has at least one non-zero byte', () => {
+    expect(isValidBytesKey(new Uint8Array(32).fill(1), 32)).toBe(true);
+    expect(isValidBytesKey(new Uint8Array(32).fill(0), 32)).toBe(false);
   });
 });
 
@@ -284,30 +284,30 @@ describe('isValidInteger', () => {
   );
 });
 
-describe('getBuffer', () => {
-  it('returns a buffer for a hexadecimal string', () => {
-    expect(getBuffer('0x1234', 2)).toStrictEqual(hexStringToBuffer('1234'));
-    expect(getBuffer('1234', 2)).toStrictEqual(hexStringToBuffer('1234'));
+describe('getBytes', () => {
+  it('returns a Uint8Array for a hexadecimal string', () => {
+    expect(getBytes('0x1234', 2)).toStrictEqual(hexStringToBytes('1234'));
+    expect(getBytes('1234', 2)).toStrictEqual(hexStringToBytes('1234'));
   });
 
-  it('returns the same buffer if a buffer is passed', () => {
-    const buffer = hexStringToBuffer('1234');
-    expect(getBuffer(buffer, 2)).toBe(buffer);
+  it('returns the same Uint8Array if a Uint8Array is passed', () => {
+    const bytes = hexStringToBytes('1234');
+    expect(getBytes(bytes, 2)).toBe(bytes);
   });
 
   it('throws if the length is invalid', () => {
-    expect(() => getBuffer('1234', 1)).toThrow(
-      'Invalid value: Must be a non-zero 1-byte buffer.',
+    expect(() => getBytes('1234', 1)).toThrow(
+      'Invalid value: Must be a non-zero 1-byte byte array.',
     );
 
-    expect(() => getBuffer(hexStringToBuffer('1234'), 1)).toThrow(
-      'Invalid value: Must be a non-zero 1-byte buffer.',
+    expect(() => getBytes(hexStringToBytes('1234'), 1)).toThrow(
+      'Invalid value: Must be a non-zero 1-byte byte array.',
     );
   });
 });
 
 describe('encodeBase58Check', () => {
-  it('encodes a buffer with Base58check', () => {
+  it('encodes a Uint8Array with Base58check', () => {
     expect(encodeBase58check(stringToBytes('foo bar'))).toBe('SQHFQMRT97ajZaP');
   });
 });
@@ -332,16 +332,16 @@ describe('getFingerprint', () => {
       'xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi',
     );
 
-    expect(getFingerprint(node.compressedPublicKeyBuffer)).toBe(876747070);
+    expect(getFingerprint(node.compressedPublicKeyBytes)).toBe(876747070);
   });
 
-  it('throws if the public key is not a valid buffer', async () => {
+  it('throws if the public key is not a valid Uint8Array', async () => {
     expect(() => getFingerprint(new Uint8Array(33).fill(0))).toThrow(
-      'Invalid public key: The key must be a 33-byte, non-zero Buffer.',
+      'Invalid public key: The key must be a 33-byte, non-zero byte array.',
     );
 
     expect(() => getFingerprint(new Uint8Array(65).fill(1))).toThrow(
-      'Invalid public key: The key must be a 33-byte, non-zero Buffer.',
+      'Invalid public key: The key must be a 33-byte, non-zero byte array.',
     );
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -176,7 +176,7 @@ export function isHardened(bip32Token: string): boolean {
  * @param hexString - The hexadecimal string to convert.
  * @returns The `Uint8Array` corresponding to the hexadecimal string.
  */
-export function hexStringToBuffer(hexString: string | Uint8Array): Uint8Array {
+export function hexStringToBytes(hexString: string | Uint8Array): Uint8Array {
   if (hexString instanceof Uint8Array) {
     return hexString;
   }
@@ -188,11 +188,11 @@ export function hexStringToBuffer(hexString: string | Uint8Array): Uint8Array {
  * @param hexString - The hexadecimal string to convert.
  * @returns The `Uint8Array` corresponding to the hexadecimal string.
  */
-export function nullableHexStringToBuffer(
+export function nullableHexStringToBytes(
   hexString?: string | Uint8Array,
 ): Uint8Array | undefined {
   if (hexString !== undefined) {
-    return hexStringToBuffer(hexString);
+    return hexStringToBytes(hexString);
   }
 
   return undefined;
@@ -200,21 +200,21 @@ export function nullableHexStringToBuffer(
 
 /**
  * Tests whether the specified `Uint8Array` is a valid BIP-32 key.
- * A valid buffer key is 64 bytes long and has at least one non-zero byte.
+ * A valid bytes key is 64 bytes long and has at least one non-zero byte.
  *
- * @param buffer - The `Uint8Array` to test.
- * @param expectedLength - The expected length of the buffer.
- * @returns Whether the buffer represents a valid BIP-32 key.
+ * @param bytes - The `Uint8Array` to test.
+ * @param expectedLength - The expected length of the Uint8Array.
+ * @returns Whether the Uint8Array represents a valid BIP-32 key.
  */
-export function isValidBufferKey(
-  buffer: Uint8Array,
+export function isValidBytesKey(
+  bytes: Uint8Array,
   expectedLength: number,
 ): boolean {
-  if (buffer.length !== expectedLength) {
+  if (bytes.length !== expectedLength) {
     return false;
   }
 
-  for (const byte of buffer) {
+  for (const byte of bytes) {
     if (byte !== 0) {
       return true;
     }
@@ -234,24 +234,24 @@ export function isValidInteger(value: unknown): value is number {
 
 /**
  * Get a `Uint8Array` from a hexadecimal string or `Uint8Array`. Validates that the
- * length of the buffer matches the specified length, and that the buffer
+ * length of the `Uint8Array` matches the specified length, and that the `Uint8Array`
  * is not empty.
  *
  * @param value - The value to convert to a `Uint8Array`.
  * @param length - The length to validate the `Uint8Array` against.
  */
-export function getBuffer(value: unknown, length: number): Uint8Array {
+export function getBytes(value: unknown, length: number): Uint8Array {
   if (value instanceof Uint8Array) {
-    validateBuffer(value, length);
+    validateBytes(value, length);
 
     return value;
   }
 
   if (typeof value === 'string') {
-    const buffer = hexToBytes(value);
-    validateBuffer(buffer, length);
+    const bytes = hexToBytes(value);
+    validateBytes(bytes, length);
 
-    return buffer;
+    return bytes;
   }
 
   throw new Error(
@@ -259,12 +259,14 @@ export function getBuffer(value: unknown, length: number): Uint8Array {
   );
 }
 
-function validateBuffer(
-  buffer: Uint8Array,
+function validateBytes(
+  bytes: Uint8Array,
   length: number,
-): asserts buffer is Uint8Array {
-  if (!isValidBufferKey(buffer, length)) {
-    throw new Error(`Invalid value: Must be a non-zero ${length}-byte buffer.`);
+): asserts bytes is Uint8Array {
+  if (!isValidBytesKey(bytes, length)) {
+    throw new Error(
+      `Invalid value: Must be a non-zero ${length}-byte byte array.`,
+    );
   }
 }
 
@@ -292,9 +294,9 @@ export const encodeBase58check = (value: Uint8Array): string => {
  * @param publicKey - The compressed public key to get the fingerprint for.
  */
 export const getFingerprint = (publicKey: Uint8Array): number => {
-  if (!isValidBufferKey(publicKey, 33)) {
+  if (!isValidBytesKey(publicKey, 33)) {
     throw new Error(
-      `Invalid public key: The key must be a 33-byte, non-zero Buffer.`,
+      `Invalid public key: The key must be a 33-byte, non-zero byte array.`,
     );
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -301,8 +301,9 @@ export const getFingerprint = (publicKey: Uint8Array): number => {
   }
 
   const bytes = ripemd160(sha256(publicKey));
+
+  // TODO: Replace with `@metamask/utils`' `createDataView` when it's available.
   const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
 
-  // The equivalent of `Buffer.readUInt32BE(0)`.
   return view.getUint32(0, false);
 };

--- a/test/reference-implementations.test.ts
+++ b/test/reference-implementations.test.ts
@@ -5,7 +5,7 @@ import { deriveKeyFromPath } from '../src/derivation';
 import { createBip39KeyFromSeed } from '../src/derivers/bip39';
 import {
   getBIP44CoinTypeToAddressPathTuple,
-  hexStringToBuffer,
+  hexStringToBytes,
 } from '../src/utils';
 
 import fixtures from './fixtures';
@@ -138,7 +138,7 @@ describe('reference implementation tests', () => {
   describe('ethereumjs-wallet', () => {
     const { sampleAddressIndices, hexSeed, privateKey, address, path } =
       fixtures['ethereumjs-wallet'];
-    const seed = hexStringToBuffer(hexSeed);
+    const seed = hexStringToBytes(hexSeed);
 
     describe('BIP44Node', () => {
       it('derives the same keys as the reference implementation', async () => {
@@ -206,7 +206,7 @@ describe('reference implementation tests', () => {
     describe('deriveKeyFromPath', () => {
       it('derives the test vector keys', async () => {
         for (const vector of vectors) {
-          const seed = hexStringToBuffer(vector.hexSeed);
+          const seed = hexStringToBytes(vector.hexSeed);
           const node = await createBip39KeyFromSeed(seed);
 
           for (const keyObj of vector.keys) {
@@ -239,7 +239,7 @@ describe('reference implementation tests', () => {
         it('derives the test vector keys', async () => {
           for (const { hexSeed, keys } of vectors) {
             const node = await createBip39KeyFromSeed(
-              hexStringToBuffer(hexSeed),
+              hexStringToBytes(hexSeed),
               ed25519,
             );
 
@@ -265,7 +265,7 @@ describe('reference implementation tests', () => {
     describe('ed25519-hd-key', () => {
       const { sampleKeyIndices, hexSeed, privateKey, path } =
         fixtures.ed25519['ed25519-hd-key'];
-      const seed = hexStringToBuffer(hexSeed);
+      const seed = hexStringToBytes(hexSeed);
 
       describe('SLIP10Node', () => {
         it('derives the same keys as the reference implementation', async () => {


### PR DESCRIPTION
To make it clear that we no longer use Node.js `Buffer`s, I renamed all usage of `Buffer` to `Bytes` or `Uint8Array` (depending on context).