### PR TITLE
Update `bip39` implementation to `@metamask/scure-bip39`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     ]
   },
   "dependencies": {
-    "@metamask/scure-bip39": "^2.0.4",
+    "@metamask/scure-bip39": "^2.1.0",
     "@metamask/utils": "^3.3.0",
     "@noble/ed25519": "^1.6.0",
     "@noble/hashes": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
     "@noble/ed25519": "^1.6.0",
     "@noble/hashes": "^1.0.0",
     "@noble/secp256k1": "^1.5.5",
-    "@scure/base": "^1.0.0",
-    "@scure/bip39": "^1.0.0"
+    "@scure/base": "^1.0.0"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     ]
   },
   "dependencies": {
+    "@metamask/scure-bip39": "^2.0.4",
     "@metamask/utils": "^3.3.0",
     "@noble/ed25519": "^1.6.0",
     "@noble/hashes": "^1.0.0",

--- a/src/derivers/bip39.ts
+++ b/src/derivers/bip39.ts
@@ -1,4 +1,4 @@
-import { mnemonicToSeedSync } from '@metamask/scure-bip39';
+import { mnemonicToSeed } from '@metamask/scure-bip39';
 import { wordlist as englishWordlist } from '@metamask/scure-bip39/dist/wordlists/english';
 import { hmac } from '@noble/hashes/hmac';
 import { sha512 } from '@noble/hashes/sha512';
@@ -32,7 +32,7 @@ export async function deriveChildKey({
   curve,
 }: DeriveChildKeyArgs): Promise<SLIP10Node> {
   return createBip39KeyFromSeed(
-    mnemonicToSeedSync(path, englishWordlist),
+    await mnemonicToSeed(path, englishWordlist),
     curve,
   );
 }

--- a/src/derivers/bip39.ts
+++ b/src/derivers/bip39.ts
@@ -1,6 +1,6 @@
+import { mnemonicToSeed } from '@metamask/scure-bip39';
 import { hmac } from '@noble/hashes/hmac';
 import { sha512 } from '@noble/hashes/sha512';
-import { mnemonicToSeed } from '@scure/bip39';
 
 import { DeriveChildKeyArgs } from '.';
 import { BIP39Node } from '../constants';

--- a/src/derivers/bip39.ts
+++ b/src/derivers/bip39.ts
@@ -1,4 +1,5 @@
-import { mnemonicToSeed } from '@metamask/scure-bip39';
+import { mnemonicToSeedSync } from '@metamask/scure-bip39';
+import { wordlist as englishWordlist } from '@metamask/scure-bip39/dist/wordlists/english';
 import { hmac } from '@noble/hashes/hmac';
 import { sha512 } from '@noble/hashes/sha512';
 
@@ -30,7 +31,10 @@ export async function deriveChildKey({
   path,
   curve,
 }: DeriveChildKeyArgs): Promise<SLIP10Node> {
-  return createBip39KeyFromSeed(await mnemonicToSeed(path), curve);
+  return createBip39KeyFromSeed(
+    mnemonicToSeedSync(path, englishWordlist),
+    curve,
+  );
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -871,7 +871,6 @@ __metadata:
     "@noble/hashes": ^1.0.0
     "@noble/secp256k1": ^1.5.5
     "@scure/base": ^1.0.0
-    "@scure/bip39": ^1.0.0
     "@types/jest": ^27.0.2
     "@typescript-eslint/eslint-plugin": ^5.42.1
     "@typescript-eslint/parser": ^5.42.1
@@ -1017,16 +1016,6 @@ __metadata:
   version: 1.1.1
   resolution: "@scure/base@npm:1.1.1"
   checksum: b4fc810b492693e7e8d0107313ac74c3646970c198bbe26d7332820886fa4f09441991023ec9aa3a2a51246b74409ab5ebae2e8ef148bbc253da79ac49130309
-  languageName: node
-  linkType: hard
-
-"@scure/bip39@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "@scure/bip39@npm:1.1.0"
-  dependencies:
-    "@noble/hashes": ~1.1.1
-    "@scure/base": ~1.1.0
-  checksum: c4361406f092a45e511dc572c89f497af6665ad81cb3fd7bf78e6772f357f7ae885e129ef0b985cb3496a460b4811318f77bc61634d9b0a8446079a801b6003c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -865,6 +865,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^11.0.0
     "@metamask/eslint-config-nodejs": ^11.0.1
     "@metamask/eslint-config-typescript": ^11.0.0
+    "@metamask/scure-bip39": ^2.0.4
     "@metamask/utils": ^3.3.0
     "@noble/ed25519": ^1.6.0
     "@noble/hashes": ^1.0.0
@@ -893,6 +894,16 @@ __metadata:
     typescript: ~4.8.4
   languageName: unknown
   linkType: soft
+
+"@metamask/scure-bip39@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "@metamask/scure-bip39@npm:2.0.4"
+  dependencies:
+    "@noble/hashes": ~1.1.1
+    "@scure/base": ~1.1.0
+  checksum: 9ab83ddad70a39dc46a869801d33e639006f7f8dc0b050f1e4711af3fae9bfe5f82ab90d890753935413491adb7064860aa40b3dc7ad1d31a8d70b5c1548d359
+  languageName: node
+  linkType: hard
 
 "@metamask/utils@npm:^3.3.0":
   version: 3.4.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -865,7 +865,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^11.0.0
     "@metamask/eslint-config-nodejs": ^11.0.1
     "@metamask/eslint-config-typescript": ^11.0.0
-    "@metamask/scure-bip39": ^2.0.4
+    "@metamask/scure-bip39": ^2.1.0
     "@metamask/utils": ^3.3.0
     "@noble/ed25519": ^1.6.0
     "@noble/hashes": ^1.0.0
@@ -894,13 +894,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/scure-bip39@npm:^2.0.4":
-  version: 2.0.4
-  resolution: "@metamask/scure-bip39@npm:2.0.4"
+"@metamask/scure-bip39@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@metamask/scure-bip39@npm:2.1.0"
   dependencies:
     "@noble/hashes": ~1.1.1
     "@scure/base": ~1.1.0
-  checksum: 9ab83ddad70a39dc46a869801d33e639006f7f8dc0b050f1e4711af3fae9bfe5f82ab90d890753935413491adb7064860aa40b3dc7ad1d31a8d70b5c1548d359
+  checksum: 13e07f03077472e9b230f702cbba7848ecac752028396647ccdeedd7bc280ceb50ee15203e25603f05c4c6ca5d4dc7277825f7004beb113e1a415adc91f059f9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
We are updating all instances of `bip39` across our packages to use the `@metamask/scure-bip39` (our fork of `@scure/bip39`) - which allows us to pass around SRP's as `Uint8Array`s rather than plain strings for security purposes.

Currently this change may also be blocking: https://github.com/MetaMask/metamask-extension/pull/17056