### PR TITLE
Accept BIP-39 mnemonic phrase as Uint8Array

### DIFF
--- a/src/BIP44CoinTypeNode.test.ts
+++ b/src/BIP44CoinTypeNode.test.ts
@@ -229,26 +229,14 @@ describe('BIP44CoinTypeNode', () => {
         BIP44PurposeNodeToken,
         `bip32:60'`,
       ]);
-      const coinType = 60;
-      const pathString = `m / bip32:44' / bip32:${coinType}'`;
 
-      expect(node.coin_type).toStrictEqual(coinType);
-      expect(node.depth).toBe(2);
-      expect(node.privateKeyBytes).toHaveLength(32);
-      expect(node.publicKeyBytes).toHaveLength(65);
-      expect(node.path).toStrictEqual(pathString);
+      const stringNode = await BIP44CoinTypeNode.fromDerivationPath([
+        defaultBip39NodeToken,
+        BIP44PurposeNodeToken,
+        `bip32:60'`,
+      ]);
 
-      expect(node.toJSON()).toStrictEqual({
-        coin_type: coinType,
-        depth: node.depth,
-        masterFingerprint: node.masterFingerprint,
-        parentFingerprint: node.parentFingerprint,
-        index: node.index,
-        path: pathString,
-        privateKey: node.privateKey,
-        publicKey: node.publicKey,
-        chainCode: node.chainCode,
-      });
+      expect(node.toJSON()).toStrictEqual(stringNode.toJSON());
     });
 
     it('throws if derivation path has invalid depth', async () => {

--- a/src/BIP44CoinTypeNode.test.ts
+++ b/src/BIP44CoinTypeNode.test.ts
@@ -10,12 +10,10 @@ import {
 } from '.';
 import fixtures from '../test/fixtures';
 import { encodeExtendedKey, PRIVATE_KEY_VERSION } from './extended-keys';
-import { mnemonicPhraseToUint8Array } from './utils';
+import { mnemonicPhraseToBytes } from './utils';
 
 const defaultBip39NodeToken = `bip39:${fixtures.local.mnemonic}` as const;
-const defaultBip39BytesToken = mnemonicPhraseToUint8Array(
-  fixtures.local.mnemonic,
-);
+const defaultBip39BytesToken = mnemonicPhraseToBytes(fixtures.local.mnemonic);
 
 describe('BIP44CoinTypeNode', () => {
   describe('fromJSON', () => {

--- a/src/BIP44CoinTypeNode.test.ts
+++ b/src/BIP44CoinTypeNode.test.ts
@@ -10,8 +10,12 @@ import {
 } from '.';
 import fixtures from '../test/fixtures';
 import { encodeExtendedKey, PRIVATE_KEY_VERSION } from './extended-keys';
+import { mnemonicPhraseToUint8Array } from './utils';
 
 const defaultBip39NodeToken = `bip39:${fixtures.local.mnemonic}` as const;
+const defaultBip39BytesToken = mnemonicPhraseToUint8Array(
+  fixtures.local.mnemonic,
+);
 
 describe('BIP44CoinTypeNode', () => {
   describe('fromJSON', () => {
@@ -196,6 +200,34 @@ describe('BIP44CoinTypeNode', () => {
     it('initializes a BIP44CoinTypeNode (derivation path)', async () => {
       const node = await BIP44CoinTypeNode.fromDerivationPath([
         defaultBip39NodeToken,
+        BIP44PurposeNodeToken,
+        `bip32:60'`,
+      ]);
+      const coinType = 60;
+      const pathString = `m / bip32:44' / bip32:${coinType}'`;
+
+      expect(node.coin_type).toStrictEqual(coinType);
+      expect(node.depth).toBe(2);
+      expect(node.privateKeyBytes).toHaveLength(32);
+      expect(node.publicKeyBytes).toHaveLength(65);
+      expect(node.path).toStrictEqual(pathString);
+
+      expect(node.toJSON()).toStrictEqual({
+        coin_type: coinType,
+        depth: node.depth,
+        masterFingerprint: node.masterFingerprint,
+        parentFingerprint: node.parentFingerprint,
+        index: node.index,
+        path: pathString,
+        privateKey: node.privateKey,
+        publicKey: node.publicKey,
+        chainCode: node.chainCode,
+      });
+    });
+
+    it('initializes a BIP44CoinTypeNode with a Uint8Array', async () => {
+      const node = await BIP44CoinTypeNode.fromDerivationPath([
+        defaultBip39BytesToken,
         BIP44PurposeNodeToken,
         `bip32:60'`,
       ]);

--- a/src/BIP44Node.test.ts
+++ b/src/BIP44Node.test.ts
@@ -9,9 +9,12 @@ import {
   PRIVATE_KEY_VERSION,
   PUBLIC_KEY_VERSION,
 } from './extended-keys';
-import { hexStringToBytes } from './utils';
+import { hexStringToBytes, mnemonicPhraseToUint8Array } from './utils';
 
 const defaultBip39NodeToken = `bip39:${fixtures.local.mnemonic}` as const;
+const defaultBip39BytesToken = mnemonicPhraseToUint8Array(
+  fixtures.local.mnemonic,
+);
 
 describe('BIP44Node', () => {
   describe('fromExtendedKey', () => {
@@ -105,6 +108,27 @@ describe('BIP44Node', () => {
       const node = await BIP44Node.fromDerivationPath({
         derivationPath: [
           defaultBip39NodeToken,
+          BIP44PurposeNodeToken,
+          `bip32:60'`,
+        ],
+      });
+
+      expect(node.depth).toBe(2);
+      expect(node.toJSON()).toStrictEqual({
+        depth: node.depth,
+        masterFingerprint: node.masterFingerprint,
+        parentFingerprint: node.parentFingerprint,
+        index: node.index,
+        privateKey: node.privateKey,
+        publicKey: node.publicKey,
+        chainCode: node.chainCode,
+      });
+    });
+
+    it('initializes a new node from a derivation path with a Uint8Array', async () => {
+      const node = await BIP44Node.fromDerivationPath({
+        derivationPath: [
+          defaultBip39BytesToken,
           BIP44PurposeNodeToken,
           `bip32:60'`,
         ],

--- a/src/BIP44Node.test.ts
+++ b/src/BIP44Node.test.ts
@@ -9,12 +9,10 @@ import {
   PRIVATE_KEY_VERSION,
   PUBLIC_KEY_VERSION,
 } from './extended-keys';
-import { hexStringToBytes, mnemonicPhraseToUint8Array } from './utils';
+import { hexStringToBytes, mnemonicPhraseToBytes } from './utils';
 
 const defaultBip39NodeToken = `bip39:${fixtures.local.mnemonic}` as const;
-const defaultBip39BytesToken = mnemonicPhraseToUint8Array(
-  fixtures.local.mnemonic,
-);
+const defaultBip39BytesToken = mnemonicPhraseToBytes(fixtures.local.mnemonic);
 
 describe('BIP44Node', () => {
   describe('fromExtendedKey', () => {

--- a/src/BIP44Node.test.ts
+++ b/src/BIP44Node.test.ts
@@ -132,16 +132,15 @@ describe('BIP44Node', () => {
         ],
       });
 
-      expect(node.depth).toBe(2);
-      expect(node.toJSON()).toStrictEqual({
-        depth: node.depth,
-        masterFingerprint: node.masterFingerprint,
-        parentFingerprint: node.parentFingerprint,
-        index: node.index,
-        privateKey: node.privateKey,
-        publicKey: node.publicKey,
-        chainCode: node.chainCode,
+      const stringNode = await BIP44Node.fromDerivationPath({
+        derivationPath: [
+          defaultBip39NodeToken,
+          BIP44PurposeNodeToken,
+          `bip32:60'`,
+        ],
       });
+
+      expect(node.toJSON()).toStrictEqual(stringNode.toJSON());
     });
 
     it('throws an error if attempting to modify the fields of a node', async () => {

--- a/src/BIP44Node.ts
+++ b/src/BIP44Node.ts
@@ -1,3 +1,5 @@
+import { assert } from '@metamask/utils';
+
 import {
   BIP44Depth,
   BIP44PurposeNodeToken,
@@ -407,16 +409,23 @@ function validateBIP44DerivationPath(
   path.forEach((nodeToken, index) => {
     const currentDepth = startingDepth + index;
 
+    if (currentDepth === MIN_BIP_44_DEPTH) {
+      if (
+        !(nodeToken instanceof Uint8Array) &&
+        !BIP_39_PATH_REGEX.test(nodeToken)
+      ) {
+        throw new Error(
+          'Invalid derivation path: The "m" / seed node (depth 0) must be a BIP-39 node.',
+        );
+      }
+
+      return;
+    }
+
+    assert(typeof nodeToken === 'string');
+
     // eslint-disable-next-line default-case
     switch (currentDepth) {
-      case MIN_BIP_44_DEPTH:
-        if (!BIP_39_PATH_REGEX.test(nodeToken)) {
-          throw new Error(
-            'Invalid derivation path: The "m" / seed node (depth 0) must be a BIP-39 node.',
-          );
-        }
-        break;
-
       case 1:
         if (nodeToken !== BIP44PurposeNodeToken) {
           throw new Error(

--- a/src/SLIP10Node.test.ts
+++ b/src/SLIP10Node.test.ts
@@ -6,12 +6,10 @@ import { ed25519, secp256k1 } from './curves';
 import { compressPublicKey } from './curves/secp256k1';
 import { createBip39KeyFromSeed, deriveChildKey } from './derivers/bip39';
 import { SLIP10Node } from './SLIP10Node';
-import { hexStringToBytes, mnemonicPhraseToUint8Array } from './utils';
+import { hexStringToBytes, mnemonicPhraseToBytes } from './utils';
 
 const defaultBip39NodeToken = `bip39:${fixtures.local.mnemonic}` as const;
-const defaultBip39BytesToken = mnemonicPhraseToUint8Array(
-  fixtures.local.mnemonic,
-);
+const defaultBip39BytesToken = mnemonicPhraseToBytes(fixtures.local.mnemonic);
 
 describe('SLIP10Node', () => {
   describe('fromExtendedKey', () => {

--- a/src/SLIP10Node.test.ts
+++ b/src/SLIP10Node.test.ts
@@ -300,17 +300,16 @@ describe('SLIP10Node', () => {
         curve: 'secp256k1',
       });
 
-      expect(node.depth).toBe(2);
-      expect(node.toJSON()).toStrictEqual({
-        depth: node.depth,
-        masterFingerprint: node.masterFingerprint,
-        parentFingerprint: node.parentFingerprint,
-        index: node.index,
+      const stringNode = await SLIP10Node.fromDerivationPath({
+        derivationPath: [
+          defaultBip39NodeToken,
+          BIP44PurposeNodeToken,
+          `bip32:60'`,
+        ],
         curve: 'secp256k1',
-        privateKey: node.privateKey,
-        publicKey: node.publicKey,
-        chainCode: node.chainCode,
       });
+
+      expect(node.toJSON()).toStrictEqual(stringNode.toJSON());
     });
 
     it('throws if the derivation path is empty', async () => {

--- a/src/SLIP10Node.test.ts
+++ b/src/SLIP10Node.test.ts
@@ -6,9 +6,12 @@ import { ed25519, secp256k1 } from './curves';
 import { compressPublicKey } from './curves/secp256k1';
 import { createBip39KeyFromSeed, deriveChildKey } from './derivers/bip39';
 import { SLIP10Node } from './SLIP10Node';
-import { hexStringToBytes } from './utils';
+import { hexStringToBytes, mnemonicPhraseToUint8Array } from './utils';
 
 const defaultBip39NodeToken = `bip39:${fixtures.local.mnemonic}` as const;
+const defaultBip39BytesToken = mnemonicPhraseToUint8Array(
+  fixtures.local.mnemonic,
+);
 
 describe('SLIP10Node', () => {
   describe('fromExtendedKey', () => {
@@ -270,6 +273,29 @@ describe('SLIP10Node', () => {
       const node = await SLIP10Node.fromDerivationPath({
         derivationPath: [
           defaultBip39NodeToken,
+          BIP44PurposeNodeToken,
+          `bip32:60'`,
+        ],
+        curve: 'secp256k1',
+      });
+
+      expect(node.depth).toBe(2);
+      expect(node.toJSON()).toStrictEqual({
+        depth: node.depth,
+        masterFingerprint: node.masterFingerprint,
+        parentFingerprint: node.parentFingerprint,
+        index: node.index,
+        curve: 'secp256k1',
+        privateKey: node.privateKey,
+        publicKey: node.publicKey,
+        chainCode: node.chainCode,
+      });
+    });
+
+    it('initializes a new node from a derivation path with a Uint8Array', async () => {
+      const node = await SLIP10Node.fromDerivationPath({
+        derivationPath: [
+          defaultBip39BytesToken,
           BIP44PurposeNodeToken,
           `bip32:60'`,
         ],

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,7 +18,8 @@ export type BIP44Depth = MinBIP44Depth | 1 | 2 | 3 | 4 | MaxBIP44Depth;
 // m  / 44' / 60' / 0' / 0 / 0
 
 export type AnonymizedBIP39Node = 'm';
-export type BIP39Node = `bip39:${string}`;
+export type BIP39StringNode = `bip39:${string}`;
+export type BIP39Node = BIP39StringNode | Uint8Array;
 export type HardenedBIP32Node = `bip32:${number}'`;
 export type UnhardenedBIP32Node = `bip32:${number}`;
 export type BIP32Node = HardenedBIP32Node | UnhardenedBIP32Node;

--- a/src/derivation.test.ts
+++ b/src/derivation.test.ts
@@ -6,10 +6,7 @@ import { deriveKeyFromPath } from './derivation';
 import { derivers } from './derivers';
 import { privateKeyToEthAddress } from './derivers/bip32';
 import { SLIP10Node } from './SLIP10Node';
-import {
-  getUnhardenedBIP32NodeToken,
-  mnemonicPhraseToUint8Array,
-} from './utils';
+import { getUnhardenedBIP32NodeToken, mnemonicPhraseToBytes } from './utils';
 
 const {
   bip32: { deriveChildKey: bip32Derive },
@@ -67,7 +64,7 @@ describe('derivation', () => {
           ] as const;
 
           const multipath = [
-            mnemonicPhraseToUint8Array(mnemonic),
+            mnemonicPhraseToBytes(mnemonic),
             ...bip32Part,
           ] as HDPathTuple;
 

--- a/src/derivation.test.ts
+++ b/src/derivation.test.ts
@@ -2,7 +2,7 @@ import { bytesToHex } from '@metamask/utils';
 
 import fixtures from '../test/fixtures';
 import { HDPathTuple } from './constants';
-import { deriveKeyFromPath } from './derivation';
+import { deriveKeyFromPath, validatePathSegment } from './derivation';
 import { derivers } from './derivers';
 import { privateKeyToEthAddress } from './derivers/bip32';
 import { SLIP10Node } from './SLIP10Node';
@@ -322,5 +322,38 @@ describe('derivation', () => {
         );
       });
     });
+  });
+});
+
+describe('validatePathSegment', () => {
+  it('accepts a Uint8Array or string path for the first segment', () => {
+    expect(() =>
+      validatePathSegment(
+        [mnemonicPhraseToBytes(fixtures.local.mnemonic)],
+        false,
+      ),
+    ).not.toThrow();
+
+    expect(() =>
+      validatePathSegment([`bip39:${fixtures.local.mnemonic}`], false),
+    ).not.toThrow();
+  });
+
+  it('does not accept a Uint8Array for BIP-32 segments', () => {
+    expect(() =>
+      validatePathSegment(
+        // @ts-expect-error Invalid type.
+        [`bip39:${fixtures.local.mnemonic}`, new Uint8Array(32)],
+        false,
+      ),
+    ).toThrow('Invalid HD path segment: The path segment is malformed.');
+
+    expect(() =>
+      validatePathSegment(
+        // @ts-expect-error Invalid type.
+        [`bip39:${fixtures.local.mnemonic}`, `bip32:0`, new Uint8Array(32)],
+        false,
+      ),
+    ).toThrow('Invalid HD path segment: The path segment is malformed.');
   });
 });

--- a/src/derivation.ts
+++ b/src/derivation.ts
@@ -164,7 +164,7 @@ export function validatePathSegment(
       ) {
         throw getMalformedError();
       }
-    } else if (!(node instanceof Uint8Array) && !BIP_32_PATH_REGEX.test(node)) {
+    } else if (node instanceof Uint8Array || !BIP_32_PATH_REGEX.test(node)) {
       throw getMalformedError();
     }
   });

--- a/src/derivation.ts
+++ b/src/derivation.ts
@@ -158,6 +158,8 @@ export function validatePathSegment(
         node instanceof Uint8Array || BIP_39_PATH_REGEX.test(node);
 
       if (
+        // TypeScript is unable to infer that `node` is a string here, so we
+        // need to explicitly check it again.
         !(node instanceof Uint8Array) &&
         !startsWithBip39 &&
         !BIP_32_PATH_REGEX.test(node)

--- a/src/derivers/bip32.ts
+++ b/src/derivers/bip32.ts
@@ -71,6 +71,8 @@ export async function deriveChildKey({
   node,
   curve = secp256k1,
 }: DeriveChildKeyArgs): Promise<SLIP10Node> {
+  assert(typeof path === 'string', 'Invalid path: Must be a string.');
+
   const isHardened = path.includes(`'`);
   if (!isHardened && !curve.deriveUnhardenedKeys) {
     throw new Error(

--- a/src/derivers/bip39.ts
+++ b/src/derivers/bip39.ts
@@ -4,7 +4,7 @@ import { hmac } from '@noble/hashes/hmac';
 import { sha512 } from '@noble/hashes/sha512';
 
 import { DeriveChildKeyArgs } from '.';
-import { BIP39Node } from '../constants';
+import { BIP39StringNode } from '../constants';
 import { Curve, secp256k1 } from '../curves';
 import { SLIP10Node } from '../SLIP10Node';
 import { getFingerprint } from '../utils';
@@ -15,7 +15,7 @@ import { getFingerprint } from '../utils';
  * @param mnemonic - The BIP-39 mnemonic phrase to convert.
  * @returns The multi path.
  */
-export function bip39MnemonicToMultipath(mnemonic: string): BIP39Node {
+export function bip39MnemonicToMultipath(mnemonic: string): BIP39StringNode {
   return `bip39:${mnemonic.toLowerCase().trim()}`;
 }
 

--- a/src/derivers/index.ts
+++ b/src/derivers/index.ts
@@ -13,7 +13,7 @@ export type DerivedKeys = {
 };
 
 export type DeriveChildKeyArgs = {
-  path: string;
+  path: Uint8Array | string;
   curve?: Curve;
   node?: SLIP10Node;
 };

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -21,7 +21,7 @@ import {
   isHardened,
   encodeBase58check,
   decodeBase58check,
-  mnemonicPhraseToUint8Array,
+  mnemonicPhraseToBytes,
 } from './utils';
 
 // Inputs used for testing non-negative integers
@@ -350,11 +350,11 @@ describe('getFingerprint', () => {
   });
 });
 
-describe('mnemonicPhraseToUint8Array', () => {
+describe('mnemonicPhraseToBytes', () => {
   it.each([fixtures.local.mnemonic, fixtures['eth-hd-keyring'].mnemonic])(
     'converts a mnemonic phrase to a Uint8Array',
     async (mnemonicPhrase) => {
-      const array = mnemonicPhraseToUint8Array(mnemonicPhrase);
+      const array = mnemonicPhraseToBytes(mnemonicPhrase);
       expect(await mnemonicToSeed(array, wordlist)).toStrictEqual(
         await mnemonicToSeed(mnemonicPhrase, wordlist),
       );

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,5 +1,8 @@
+import { mnemonicToSeed } from '@metamask/scure-bip39';
+import { wordlist } from '@metamask/scure-bip39/dist/wordlists/english';
 import { hexToBytes, stringToBytes } from '@metamask/utils';
 
+import fixtures from '../test/fixtures';
 import { BIP44Node } from './BIP44Node';
 import {
   getBIP32NodeToken,
@@ -18,6 +21,7 @@ import {
   isHardened,
   encodeBase58check,
   decodeBase58check,
+  mnemonicPhraseToUint8Array,
 } from './utils';
 
 // Inputs used for testing non-negative integers
@@ -344,4 +348,16 @@ describe('getFingerprint', () => {
       'Invalid public key: The key must be a 33-byte, non-zero byte array.',
     );
   });
+});
+
+describe('mnemonicPhraseToUint8Array', () => {
+  it.each([fixtures.local.mnemonic, fixtures['eth-hd-keyring'].mnemonic])(
+    'converts a mnemonic phrase to a Uint8Array',
+    async (mnemonicPhrase) => {
+      const array = mnemonicPhraseToUint8Array(mnemonicPhrase);
+      expect(await mnemonicToSeed(array, wordlist)).toStrictEqual(
+        await mnemonicToSeed(mnemonicPhrase, wordlist),
+      );
+    },
+  );
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
-import { createDataView, hexToBytes } from '@metamask/utils';
+import { wordlist as englishWordlist } from '@metamask/scure-bip39/dist/wordlists/english';
+import { assert, createDataView, hexToBytes } from '@metamask/utils';
 import { ripemd160 } from '@noble/hashes/ripemd160';
 import { sha256 } from '@noble/hashes/sha256';
 import { base58check as scureBase58check } from '@scure/base';
@@ -329,3 +330,25 @@ export const getFingerprint = (publicKey: Uint8Array): number => {
 
   return view.getUint32(0, false);
 };
+
+/**
+ * Get a secret recovery phrase (or mnemonic phrase) in string form as a
+ * `Uint8Array`. The secret recovery phrase is split into words, and each word
+ * is converted to a number using the BIP-39 word list. The numbers are then
+ * converted to bytes, and the bytes are concatenated into a single
+ * `Uint8Array`.
+ *
+ * @param mnemonicPhrase - The secret recovery phrase to convert.
+ * @returns The `Uint8Array` corresponding to the secret recovery phrase.
+ */
+export function mnemonicPhraseToUint8Array(mnemonicPhrase: string): Uint8Array {
+  const words = mnemonicPhrase.split(' ');
+  const indices = words.map((word) => {
+    const index = englishWordlist.indexOf(word);
+    assert(index !== -1, `Invalid mnemonic phrase: Unknown word "${word}".`);
+
+    return index;
+  });
+
+  return new Uint8Array(new Uint16Array(indices).buffer);
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -341,7 +341,7 @@ export const getFingerprint = (publicKey: Uint8Array): number => {
  * @param mnemonicPhrase - The secret recovery phrase to convert.
  * @returns The `Uint8Array` corresponding to the secret recovery phrase.
  */
-export function mnemonicPhraseToUint8Array(mnemonicPhrase: string): Uint8Array {
+export function mnemonicPhraseToBytes(mnemonicPhrase: string): Uint8Array {
   const words = mnemonicPhrase.split(' ');
   const indices = words.map((word) => {
     const index = englishWordlist.indexOf(word);


### PR DESCRIPTION
This adds support for passing mnemonic phrases as `Uint8Array`, in all places where we accept them. The expected format is the same as the format we use in `@metamask/scure-bip39`.

The derivation path can now look like `[new Uint8Array(), 'bip32:...', ...]`. Only the first BIP-39 segment can be a `Uint8Array`, it's not supported for BIP-32 segments.

Closes #106.