### PR TITLE
Add missing curve parameter

### DIFF
--- a/src/SLIP10Node.test.ts
+++ b/src/SLIP10Node.test.ts
@@ -312,6 +312,28 @@ describe('SLIP10Node', () => {
       expect(node.toJSON()).toStrictEqual(stringNode.toJSON());
     });
 
+    it('initializes a new node from a derivation path with a Uint8Array using ed25519', async () => {
+      const node = await SLIP10Node.fromDerivationPath({
+        derivationPath: [
+          defaultBip39BytesToken,
+          BIP44PurposeNodeToken,
+          `bip32:60'`,
+        ],
+        curve: 'ed25519',
+      });
+
+      const stringNode = await SLIP10Node.fromDerivationPath({
+        derivationPath: [
+          defaultBip39NodeToken,
+          BIP44PurposeNodeToken,
+          `bip32:60'`,
+        ],
+        curve: 'ed25519',
+      });
+
+      expect(node.toJSON()).toStrictEqual(stringNode.toJSON());
+    });
+
     it('throws if the derivation path is empty', async () => {
       await expect(
         SLIP10Node.fromDerivationPath({

--- a/src/derivation.ts
+++ b/src/derivation.ts
@@ -118,6 +118,7 @@ export async function deriveKeyFromPath(
     return await derivers.bip39.deriveChildKey({
       path: pathNode,
       node: derivedNode,
+      curve: getCurveByName(curve),
     });
   }, Promise.resolve(node as SLIP10Node));
 }


### PR DESCRIPTION
This fixes a regression introduced in #107. The bytes-based derivation wasn't tested for `ed25519`, and was broken due to a missing curve parameter.