### PR TITLE
Validate tweak passed to `publicAdd`

### DIFF
--- a/src/curves/secp256k1.test.ts
+++ b/src/curves/secp256k1.test.ts
@@ -1,7 +1,7 @@
 import { bytesToHex, hexToBytes } from '@metamask/utils';
 
 import fixtures from '../../test/fixtures';
-import { curve, getPublicKey, isValidPrivateKey } from './secp256k1';
+import { curve, getPublicKey, isValidPrivateKey, publicAdd } from './secp256k1';
 
 describe('secp256k1', () => {
   describe('curve', () => {
@@ -32,6 +32,29 @@ describe('secp256k1', () => {
           publicKey,
         );
       }
+    });
+  });
+
+  describe('publicAdd', () => {
+    const PUBLIC_KEY = getPublicKey(
+      hexToBytes(fixtures.bip32[0].keys[0].privateKey),
+    );
+
+    it.each([
+      '0x7ebc0a630524c2d5ac55a98b8527a8ab2e842cd7b4037baadc463e597183408200',
+      '0xa0a86d020f4c512b8639c38ecb9a3792f1575d3a4ad832e2523fd447c67170',
+      '0x0efd64c97a920e71d90cf54589fb8a93',
+      '0x1',
+    ])('throws if the tweak is not 32 bytes long', (tweak) => {
+      expect(() => publicAdd(PUBLIC_KEY, hexToBytes(tweak))).toThrow(
+        'Invalid tweak: Tweak must be a non-empty 32-byte array.',
+      );
+    });
+
+    it('throws if the tweak is zero', () => {
+      expect(() => publicAdd(PUBLIC_KEY, new Uint8Array(32).fill(0))).toThrow(
+        'Invalid tweak: Tweak must be a non-empty 32-byte array.',
+      );
     });
   });
 });

--- a/src/curves/secp256k1.test.ts
+++ b/src/curves/secp256k1.test.ts
@@ -47,13 +47,13 @@ describe('secp256k1', () => {
       '0x1',
     ])('throws if the tweak is not 32 bytes long', (tweak) => {
       expect(() => publicAdd(PUBLIC_KEY, hexToBytes(tweak))).toThrow(
-        'Invalid tweak: Tweak must be a non-empty 32-byte array.',
+        'Invalid tweak: Tweak must be a non-zero 32-byte Uint8Array.',
       );
     });
 
     it('throws if the tweak is zero', () => {
       expect(() => publicAdd(PUBLIC_KEY, new Uint8Array(32).fill(0))).toThrow(
-        'Invalid tweak: Tweak must be a non-empty 32-byte array.',
+        'Invalid tweak: Tweak must be a non-zero 32-byte Uint8Array.',
       );
     });
   });

--- a/src/curves/secp256k1.ts
+++ b/src/curves/secp256k1.ts
@@ -35,7 +35,7 @@ export const publicAdd = (
 ): Uint8Array => {
   assert(
     isValidBytesKey(tweak, 32),
-    'Invalid tweak: Tweak must be a non-empty 32-byte array.',
+    'Invalid tweak: Tweak must be a non-zero 32-byte Uint8Array.',
   );
 
   const point = Point.fromHex(publicKey);

--- a/src/curves/secp256k1.ts
+++ b/src/curves/secp256k1.ts
@@ -1,9 +1,11 @@
-import { stringToBytes } from '@metamask/utils';
+import { assert, stringToBytes } from '@metamask/utils';
 import {
   getPublicKey as getSecp256k1PublicKey,
   Point,
   utils,
 } from '@noble/secp256k1';
+
+import { isValidBytesKey } from '../utils';
 
 export { CURVE as curve } from '@noble/secp256k1';
 
@@ -31,13 +33,17 @@ export const publicAdd = (
   publicKey: Uint8Array,
   tweak: Uint8Array,
 ): Uint8Array => {
+  assert(
+    isValidBytesKey(tweak, 32),
+    'Invalid tweak: Tweak must be a non-empty 32-byte array.',
+  );
+
   const point = Point.fromHex(publicKey);
 
   // The returned child key Ki is point(parse256(IL)) + Kpar.
   // This multiplies the tweak with the base point of the curve (Gx, Gy).
   // https://github.com/bitcoin/bips/blob/274fa400d630ba757bec0c03b35ebe2345197108/bip-0032.mediawiki#public-parent-key--public-child-key
   const newPoint = point.add(Point.fromPrivateKey(tweak));
-
   newPoint.assertValidity();
 
   return newPoint.toRawBytes(false);


### PR DESCRIPTION
If the tweak equals zero, the generated child public key is the same as the parent public key. We have to validate that it has at least one non-zero byte.

Related to MM-02-001.