### PR TITLE
Allow zero private key for `ed25519`

### DIFF
--- a/src/BIP44CoinTypeNode.test.ts
+++ b/src/BIP44CoinTypeNode.test.ts
@@ -113,9 +113,7 @@ describe('BIP44CoinTypeNode', () => {
       for (const input of inputs) {
         await expect(
           BIP44CoinTypeNode.fromJSON(input as any, arbitraryCoinType),
-        ).rejects.toThrow(
-          'Invalid value: Must be a non-zero 32-byte byte array.',
-        );
+        ).rejects.toThrow('Invalid value: Must be a 32-byte byte array.');
       }
 
       await expect(

--- a/src/SLIP10Node.test.ts
+++ b/src/SLIP10Node.test.ts
@@ -70,6 +70,21 @@ describe('SLIP10Node', () => {
       expect(node.publicKeyBytes).toHaveLength(33);
     });
 
+    it('initializes a new ed25519 node from a zero private key', async () => {
+      const node = await SLIP10Node.fromExtendedKey({
+        privateKey: new Uint8Array(32).fill(0),
+        chainCode: new Uint8Array(32).fill(1),
+        depth: 0,
+        parentFingerprint: 0,
+        index: 0,
+        curve: 'ed25519',
+      });
+
+      expect(node.depth).toBe(0);
+      expect(node.privateKeyBytes).toStrictEqual(new Uint8Array(32).fill(0));
+      expect(node.publicKeyBytes).toHaveLength(33);
+    });
+
     it('initializes a new node from a public key', async () => {
       const { publicKeyBytes, chainCodeBytes } = await deriveChildKey({
         path: fixtures.local.mnemonic,
@@ -261,6 +276,21 @@ describe('SLIP10Node', () => {
         }),
       ).rejects.toThrow(
         'Invalid value: Expected an instance of Uint8Array or hexadecimal string.',
+      );
+    });
+
+    it('throws if the private key is zero for secp256k1', async () => {
+      await expect(
+        SLIP10Node.fromExtendedKey({
+          privateKey: new Uint8Array(32).fill(0),
+          chainCode: new Uint8Array(32).fill(1),
+          depth: 0,
+          parentFingerprint: 0,
+          index: 0,
+          curve: 'secp256k1',
+        }),
+      ).rejects.toThrow(
+        'Invalid private key: Value is not a valid secp256k1 private key.',
       );
     });
   });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -22,6 +22,7 @@ import {
   encodeBase58check,
   decodeBase58check,
   mnemonicPhraseToBytes,
+  getBytesUnsafe,
 } from './utils';
 
 // Inputs used for testing non-negative integers
@@ -306,6 +307,38 @@ describe('getBytes', () => {
 
     expect(() => getBytes(hexStringToBytes('1234'), 1)).toThrow(
       'Invalid value: Must be a non-zero 1-byte byte array.',
+    );
+  });
+
+  it('throws if the value is zero', () => {
+    expect(() => getBytes('0x00', 1)).toThrow(
+      'Invalid value: Must be a non-zero 1-byte byte array.',
+    );
+
+    expect(() => getBytes(new Uint8Array(1).fill(0), 1)).toThrow(
+      'Invalid value: Must be a non-zero 1-byte byte array.',
+    );
+  });
+});
+
+describe('getBytesUnsafe', () => {
+  it('returns a Uint8Array for a hexadecimal string', () => {
+    expect(getBytesUnsafe('0x1234', 2)).toStrictEqual(hexStringToBytes('1234'));
+    expect(getBytesUnsafe('1234', 2)).toStrictEqual(hexStringToBytes('1234'));
+  });
+
+  it('returns the same Uint8Array if a Uint8Array is passed', () => {
+    const bytes = hexStringToBytes('1234');
+    expect(getBytesUnsafe(bytes, 2)).toBe(bytes);
+  });
+
+  it('throws if the length is invalid', () => {
+    expect(() => getBytesUnsafe('1234', 1)).toThrow(
+      'Invalid value: Must be a 1-byte byte array.',
+    );
+
+    expect(() => getBytesUnsafe(hexStringToBytes('1234'), 1)).toThrow(
+      'Invalid value: Must be a 1-byte byte array.',
     );
   });
 });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -331,11 +331,15 @@ describe('getBytesUnsafe', () => {
   it('returns a Uint8Array for a hexadecimal string', () => {
     expect(getBytesUnsafe('0x1234', 2)).toStrictEqual(hexStringToBytes('1234'));
     expect(getBytesUnsafe('1234', 2)).toStrictEqual(hexStringToBytes('1234'));
+    expect(getBytesUnsafe('0000', 2)).toStrictEqual(hexStringToBytes('0000'));
   });
 
   it('returns the same Uint8Array if a Uint8Array is passed', () => {
     const bytes = hexStringToBytes('1234');
     expect(getBytesUnsafe(bytes, 2)).toBe(bytes);
+
+    const zeroBytes = hexStringToBytes('0000');
+    expect(getBytesUnsafe(zeroBytes, 2)).toBe(zeroBytes);
   });
 
   it('throws if the length is invalid', () => {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -319,6 +319,12 @@ describe('getBytes', () => {
       'Invalid value: Must be a non-zero 1-byte byte array.',
     );
   });
+
+  it('throws if the value is not a Uint8Array or a hexadecimal string', () => {
+    expect(() => getBytes(1, 1)).toThrow(
+      'Invalid value: Expected an instance of Uint8Array or hexadecimal string.',
+    );
+  });
 });
 
 describe('getBytesUnsafe', () => {
@@ -339,6 +345,12 @@ describe('getBytesUnsafe', () => {
 
     expect(() => getBytesUnsafe(hexStringToBytes('1234'), 1)).toThrow(
       'Invalid value: Must be a 1-byte byte array.',
+    );
+  });
+
+  it('throws if the value is not a Uint8Array or a hexadecimal string', () => {
+    expect(() => getBytesUnsafe(1, 1)).toThrow(
+      'Invalid value: Expected an instance of Uint8Array or hexadecimal string.',
     );
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -276,6 +276,35 @@ export function getBytes(value: unknown, length: number): Uint8Array {
 }
 
 /**
+ * Get a `Uint8Array` from a hexadecimal string or `Uint8Array`. Validates that
+ * the length of the `Uint8Array` matches the specified length.
+ *
+ * This function is "unsafe," in the sense that it does not validate that the
+ * `Uint8Array` is not empty (i.e., all bytes are zero).
+ *
+ * @param value - The value to convert to a `Uint8Array`.
+ * @param length - The length to validate the `Uint8Array` against.
+ * @returns The `Uint8Array` corresponding to the hexadecimal string.
+ */
+export function getBytesUnsafe(value: unknown, length: number): Uint8Array {
+  if (value instanceof Uint8Array) {
+    assert(
+      value.length === length,
+      `Invalid value: Must be a ${length}-byte byte array.`,
+    );
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    return getBytesUnsafe(hexToBytes(value), length);
+  }
+
+  throw new Error(
+    `Invalid value: Expected an instance of Uint8Array or hexadecimal string.`,
+  );
+}
+
+/**
  * Validate that the specified `Uint8Array` is not empty and has the specified
  * length.
  *


### PR DESCRIPTION
`0x000...000` is a valid private key for `ed25519` (since all private keys are valid). Previously we would always reject this private key, due to the function used to validate bytes. I've updated it to use the curve function to check if a private key is valid.

Related to MM-02-007.