### PR TITLE
BREAKING: Remove specification field in favour of SLIP-10 path type

### DIFF
--- a/src/BIP44CoinTypeNode.ts
+++ b/src/BIP44CoinTypeNode.ts
@@ -335,7 +335,6 @@ export async function deriveBIP44AddressKey(
   const childNode = await deriveChildNode({
     path,
     node,
-    specification: 'bip32',
   });
 
   return new BIP44Node(childNode);
@@ -414,7 +413,6 @@ export async function getBIP44AddressKeyDeriver(
           : getUnhardenedBIP32NodeToken(address_index),
       ],
       node: actualNode,
-      specification: 'bip32',
     });
 
     return new BIP44Node(slip10Node);

--- a/src/BIP44Node.ts
+++ b/src/BIP44Node.ts
@@ -178,7 +178,6 @@ export class BIP44Node implements BIP44NodeInterface {
       parentFingerprint,
       index,
       curve: 'secp256k1',
-      specification: 'bip32',
     });
 
     return new BIP44Node(node);
@@ -214,7 +213,6 @@ export class BIP44Node implements BIP44NodeInterface {
     const node = await SLIP10Node.fromDerivationPath({
       derivationPath,
       curve: 'secp256k1',
-      specification: 'bip32',
     });
 
     return new BIP44Node(node);

--- a/src/SLIP10Node.test.ts
+++ b/src/SLIP10Node.test.ts
@@ -410,7 +410,6 @@ describe('SLIP10Node', () => {
         privateKey: node.privateKey,
         publicKey: node.publicKey,
         chainCode: node.chainCode,
-        specification: node.specification,
       });
     });
 
@@ -438,20 +437,12 @@ describe('SLIP10Node', () => {
 
     it('initializes a new node from a derivation path with a Uint8Array using ed25519', async () => {
       const node = await SLIP10Node.fromDerivationPath({
-        derivationPath: [
-          defaultBip39BytesToken,
-          BIP44PurposeNodeToken,
-          `bip32:60'`,
-        ],
+        derivationPath: [defaultBip39BytesToken, `slip10:44'`, `slip10:60'`],
         curve: 'ed25519',
       });
 
       const stringNode = await SLIP10Node.fromDerivationPath({
-        derivationPath: [
-          defaultBip39NodeToken,
-          BIP44PurposeNodeToken,
-          `bip32:60'`,
-        ],
+        derivationPath: [defaultBip39NodeToken, `slip10:44'`, `slip10:60'`],
         curve: 'ed25519',
       });
 
@@ -522,9 +513,7 @@ describe('SLIP10Node', () => {
     it('throws an error if no curve is specified', async () => {
       await expect(
         // @ts-expect-error No curve specified, but required in type
-        SLIP10Node.fromDerivationPath({
-          specification: 'bip32',
-        }),
+        SLIP10Node.fromDerivationPath({}),
       ).rejects.toThrow('Invalid curve: Must specify a curve.');
     });
 
@@ -537,18 +526,6 @@ describe('SLIP10Node', () => {
         }),
       ).rejects.toThrow(
         'Invalid curve: Only the following curves are supported: secp256k1, ed25519.',
-      );
-    });
-
-    it('throws an error for unsupported specifications', async () => {
-      await expect(
-        SLIP10Node.fromDerivationPath({
-          curve: 'secp256k1',
-          // @ts-expect-error Invalid specification name for type
-          specification: 'foo bar',
-        }),
-      ).rejects.toThrow(
-        'Invalid specification: Must be one of bip32, slip10. Received "foo bar".',
       );
     });
   });
@@ -630,14 +607,14 @@ describe('SLIP10Node', () => {
       const node = await SLIP10Node.fromDerivationPath({
         derivationPath: [
           defaultBip39NodeToken,
-          BIP44PurposeNodeToken,
-          `bip32:3'`,
-          `bip32:0'`,
+          `slip10:44'`,
+          `slip10:3'`,
+          `slip10:0'`,
         ],
         curve: 'ed25519',
       });
 
-      await expect(node.derive(['bip32:0'])).rejects.toThrow(
+      await expect(node.derive(['slip10:0'])).rejects.toThrow(
         'Invalid path: Cannot derive unhardened child keys with ed25519.',
       );
     });
@@ -774,11 +751,7 @@ describe('SLIP10Node', () => {
 
     it('throws an error when trying to get an address for an ed25519 node', async () => {
       const node = await SLIP10Node.fromDerivationPath({
-        derivationPath: [
-          defaultBip39NodeToken,
-          BIP44PurposeNodeToken,
-          `bip32:60'`,
-        ],
+        derivationPath: [defaultBip39NodeToken, `slip10:44'`, `slip10:60'`],
         curve: 'ed25519',
       });
 
@@ -863,7 +836,6 @@ describe('SLIP10Node', () => {
         privateKey: node.privateKey,
         publicKey: node.publicKey,
         chainCode: node.chainCode,
-        specification: node.specification,
       });
 
       expect(JSON.parse(JSON.stringify(nodeJson))).toStrictEqual({
@@ -875,7 +847,6 @@ describe('SLIP10Node', () => {
         privateKey: node.privateKey,
         publicKey: node.publicKey,
         chainCode: node.chainCode,
-        specification: node.specification,
       });
     });
   });

--- a/src/SLIP10Node.ts
+++ b/src/SLIP10Node.ts
@@ -9,17 +9,14 @@ import {
 } from './constants';
 import { getCurveByName, SupportedCurve } from './curves';
 import { deriveKeyFromPath } from './derivation';
-import { Specification } from './derivers';
 import { publicKeyToEthAddress } from './derivers/bip32';
 import {
   getBytes,
   getBytesUnsafe,
   getFingerprint,
-  getSpecification,
   isValidInteger,
   validateBIP32Index,
   validateCurve,
-  validateSpecification,
 } from './utils';
 
 /**
@@ -68,21 +65,6 @@ export type JsonSLIP10Node = {
    * The name of the curve used by the node.
    */
   readonly curve: SupportedCurve;
-
-  /**
-   * The specification used to derive this node. Defaults to `bip32` when the
-   * `secp256k1` curve is used, and `slip10` when the `ed25519` curve is used.
-   *
-   * While SLIP-10 and BIP-32 are largely compatible when the `secp256k1` curve
-   * is used, they differ in the way they handle key derivation errors. The
-   * probability of this happening is extremely low, but it is possible. When
-   * full compatibility with one of these specifications is required, this field
-   * should be set to the appropriate value.
-   *
-   * Note that `ed25519` is not supported by BIP-32, so the `bip32`
-   * specification is not available for this curve.
-   */
-  readonly specification: Specification;
 };
 
 export type SLIP10NodeInterface = JsonSLIP10Node & {
@@ -114,7 +96,6 @@ export type SLIP10NodeConstructorOptions = {
   readonly privateKey?: Uint8Array;
   readonly publicKey: Uint8Array;
   readonly curve: SupportedCurve;
-  readonly specification?: Specification;
 };
 
 export type SLIP10ExtendedKeyOptions = {
@@ -126,13 +107,11 @@ export type SLIP10ExtendedKeyOptions = {
   readonly privateKey?: string | Uint8Array;
   readonly publicKey?: string | Uint8Array;
   readonly curve: SupportedCurve;
-  readonly specification?: Specification;
 };
 
 export type SLIP10DerivationPathOptions = {
   readonly derivationPath: RootedSLIP10PathTuple;
   readonly curve: SupportedCurve;
-  readonly specification?: Specification;
 };
 
 export class SLIP10Node implements SLIP10NodeInterface {
@@ -167,7 +146,6 @@ export class SLIP10Node implements SLIP10NodeInterface {
    * specified, this parameter is ignored.
    * @param options.chainCode - The chain code for the node.
    * @param options.curve - The curve used by the node.
-   * @param options.specification - The specification used to derive this node.
    */
   static async fromExtendedKey({
     depth,
@@ -178,12 +156,10 @@ export class SLIP10Node implements SLIP10NodeInterface {
     publicKey,
     chainCode,
     curve,
-    specification = getSpecification(curve),
   }: SLIP10ExtendedKeyOptions) {
     const chainCodeBytes = getBytes(chainCode, BYTES_KEY_LENGTH);
 
     validateCurve(curve);
-    validateSpecification(specification);
     validateBIP32Depth(depth);
     validateBIP32Index(index);
     validateRootIndex(index, depth);
@@ -213,7 +189,6 @@ export class SLIP10Node implements SLIP10NodeInterface {
           privateKey: privateKeyBytes,
           publicKey: await curveObject.getPublicKey(privateKeyBytes),
           curve,
-          specification,
         },
         this.#constructorGuard,
       );
@@ -231,7 +206,6 @@ export class SLIP10Node implements SLIP10NodeInterface {
           chainCode: chainCodeBytes,
           publicKey: publicKeyBytes,
           curve,
-          specification,
         },
         this.#constructorGuard,
       );
@@ -263,17 +237,13 @@ export class SLIP10Node implements SLIP10NodeInterface {
    * @param options.derivationPath - The rooted HD tree path that will be used
    * to derive the key of this node.
    * @param options.curve - The curve used by the node.
-   * @param options.specification - The specification used to derive the key.
-   * Defaults to `slip10`.
    * @returns A new SLIP-10 node.
    */
   static async fromDerivationPath({
     derivationPath,
     curve,
-    specification = getSpecification(curve),
   }: SLIP10DerivationPathOptions) {
     validateCurve(curve);
-    validateSpecification(specification);
 
     if (!derivationPath) {
       throw new Error('Invalid options: Must provide a derivation path.');
@@ -289,15 +259,12 @@ export class SLIP10Node implements SLIP10NodeInterface {
       path: derivationPath,
       depth: derivationPath.length - 1,
       curve,
-      specification,
     });
   }
 
   static #constructorGuard = Symbol('SLIP10Node.constructor');
 
   public readonly curve: SupportedCurve;
-
-  public readonly specification: Specification;
 
   public readonly depth: number;
 
@@ -324,7 +291,6 @@ export class SLIP10Node implements SLIP10NodeInterface {
       privateKey,
       publicKey,
       curve,
-      specification = getSpecification(curve),
     }: SLIP10NodeConstructorOptions,
     constructorGuard?: symbol,
   ) {
@@ -341,7 +307,6 @@ export class SLIP10Node implements SLIP10NodeInterface {
     this.privateKeyBytes = privateKey;
     this.publicKeyBytes = publicKey;
     this.curve = curve;
-    this.specification = specification;
 
     Object.freeze(this);
   }
@@ -418,7 +383,6 @@ export class SLIP10Node implements SLIP10NodeInterface {
     return await deriveChildNode({
       path,
       node: this,
-      specification: this.specification,
     });
   }
 
@@ -433,7 +397,6 @@ export class SLIP10Node implements SLIP10NodeInterface {
       privateKey: this.privateKey,
       publicKey: this.publicKey,
       chainCode: this.chainCode,
-      specification: this.specification,
     };
   }
 }
@@ -541,7 +504,6 @@ export function validateRootIndex(index: number, depth: number) {
 type DeriveChildNodeArgs = {
   path: SLIP10PathTuple;
   node: SLIP10Node | BIP44Node | BIP44CoinTypeNode;
-  specification: Specification;
 };
 
 /**
@@ -550,14 +512,11 @@ type DeriveChildNodeArgs = {
  * @param options - The options to use when deriving the child key.
  * @param options.node - The node to derive from.
  * @param options.path - The path to the child node / key.
- * @param options.specification - The specification to use when deriving the
- * child key.
  * @returns The derived key and depth.
  */
 export async function deriveChildNode({
   path,
   node,
-  specification,
 }: DeriveChildNodeArgs): Promise<SLIP10Node> {
   if (path.length === 0) {
     throw new Error(
@@ -574,6 +533,5 @@ export async function deriveChildNode({
     path,
     node,
     depth: newDepth,
-    specification,
   });
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,9 +22,14 @@ export type BIP44Depth = MinBIP44Depth | 1 | 2 | 3 | 4 | MaxBIP44Depth;
 export type AnonymizedBIP39Node = 'm';
 export type BIP39StringNode = `bip39:${string}`;
 export type BIP39Node = BIP39StringNode | Uint8Array;
+
 export type HardenedBIP32Node = `bip32:${number}'`;
 export type UnhardenedBIP32Node = `bip32:${number}`;
 export type BIP32Node = HardenedBIP32Node | UnhardenedBIP32Node;
+
+export type HardenedSLIP10Node = `slip10:${number}'`;
+export type UnhardenedSLIP10Node = `slip10:${number}`;
+export type SLIP10Node = HardenedSLIP10Node | UnhardenedSLIP10Node;
 
 export const BIP44PurposeNodeToken = `bip32:44'`;
 
@@ -34,6 +39,13 @@ export const BIP44PurposeNodeToken = `bip32:44'`;
  * -  bip32:0'
  */
 export const BIP_32_PATH_REGEX = /^bip32:\d+'?$/u;
+
+/**
+ * e.g.
+ * -  slip10:0
+ * -  slip10:0'
+ */
+export const SLIP_10_PATH_REGEX = /^slip10:\d+'?$/u;
 
 /**
  * bip39:<SPACE_DELMITED_SEED_PHRASE>
@@ -138,8 +150,12 @@ export type PartialHDPathTuple =
  */
 export type HDPathTuple = RootedHDPathTuple | PartialHDPathTuple;
 
-export type RootedSLIP10PathTuple = readonly [BIP39Node, ...BIP32Node[]];
-export type SLIP10PathTuple = readonly BIP32Node[];
+export type RootedSLIP10PathTuple = readonly [
+  BIP39Node,
+  ...(BIP32Node[] | SLIP10Node[]),
+];
+
+export type SLIP10PathTuple = readonly BIP32Node[] | readonly SLIP10Node[];
 export type SLIP10Path = RootedSLIP10PathTuple | SLIP10PathTuple;
 
 export type FullHDPathTuple = RootedHDPathTuple5;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -33,6 +33,8 @@ export type SLIP10Node = HardenedSLIP10Node | UnhardenedSLIP10Node;
 
 export const BIP44PurposeNodeToken = `bip32:44'`;
 
+export const UNPREFIXED_PATH_REGEX = /^\d+$/u;
+
 /**
  * e.g.
  * -  bip32:0

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,7 +29,7 @@ export type BIP32Node = HardenedBIP32Node | UnhardenedBIP32Node;
 
 export type HardenedSLIP10Node = `slip10:${number}'`;
 export type UnhardenedSLIP10Node = `slip10:${number}`;
-export type SLIP10Node = HardenedSLIP10Node | UnhardenedSLIP10Node;
+export type SLIP10PathNode = HardenedSLIP10Node | UnhardenedSLIP10Node;
 
 export const BIP44PurposeNodeToken = `bip32:44'`;
 
@@ -154,10 +154,10 @@ export type HDPathTuple = RootedHDPathTuple | PartialHDPathTuple;
 
 export type RootedSLIP10PathTuple = readonly [
   BIP39Node,
-  ...(BIP32Node[] | SLIP10Node[]),
+  ...(BIP32Node[] | SLIP10PathNode[]),
 ];
 
-export type SLIP10PathTuple = readonly BIP32Node[] | readonly SLIP10Node[];
+export type SLIP10PathTuple = readonly BIP32Node[] | readonly SLIP10PathNode[];
 export type SLIP10Path = RootedSLIP10PathTuple | SLIP10PathTuple;
 
 export type FullHDPathTuple = RootedHDPathTuple5;

--- a/src/derivation.test.ts
+++ b/src/derivation.test.ts
@@ -48,7 +48,6 @@ describe('derivation', () => {
           return deriveKeyFromPath({
             path: multipath,
             curve: 'secp256k1',
-            specification: 'bip32',
           });
         }),
       );
@@ -76,7 +75,6 @@ describe('derivation', () => {
           return deriveKeyFromPath({
             path: multipath,
             curve: 'secp256k1',
-            specification: 'bip32',
           });
         }),
       );
@@ -95,7 +93,6 @@ describe('derivation', () => {
       const node = await deriveKeyFromPath({
         path: multipath,
         curve: 'secp256k1',
-        specification: 'bip32',
       });
 
       const keys = await Promise.all(
@@ -103,7 +100,6 @@ describe('derivation', () => {
           return deriveKeyFromPath({
             path: [`bip32:${index}`],
             node,
-            specification: 'bip32',
           });
         }),
       );
@@ -122,7 +118,6 @@ describe('derivation', () => {
       const node = await deriveKeyFromPath({
         path: multipath,
         curve: 'secp256k1',
-        specification: 'bip32',
       });
 
       // Empty segments are forbidden
@@ -158,7 +153,6 @@ describe('derivation', () => {
         return deriveKeyFromPath({
           path: [bip39Part, bip32Part1.replace(`44'`, 'xyz') as any, ...rest],
           curve: 'secp256k1',
-          specification: 'bip32',
         });
       }).rejects.toThrow(
         /Invalid HD path segment: The path segment is malformed\./u,
@@ -169,7 +163,6 @@ describe('derivation', () => {
         return deriveKeyFromPath({
           path: [bip39Part, bip32Part1.replace(`'`, '"') as any, ...rest],
           curve: 'secp256k1',
-          specification: 'bip32',
         });
       }).rejects.toThrow(
         /Invalid HD path segment: The path segment is malformed\./u,
@@ -180,7 +173,6 @@ describe('derivation', () => {
           path: [bip39Part, ethereumBip32PathParts[0]],
           curve: 'secp256k1',
           depth: 0,
-          specification: 'bip32',
         }),
       ).rejects.toThrow(
         /Invalid HD path segment: The segment must consist of a single BIP-39 node for depths of 0\. Received:/u,
@@ -191,7 +183,6 @@ describe('derivation', () => {
         deriveKeyFromPath({
           path: [bip39Part.replace('r', 'R') as any],
           curve: 'secp256k1',
-          specification: 'bip32',
         }),
       ).rejects.toThrow(
         /Invalid HD path segment: The path segment is malformed\./u,
@@ -199,7 +190,7 @@ describe('derivation', () => {
 
       // Multipaths that start with bip39 segment require _no_ parentKey
       await expect(
-        deriveKeyFromPath({ path: [bip39Part], node, specification: 'bip32' }),
+        deriveKeyFromPath({ path: [bip39Part], node }),
       ).rejects.toThrow(
         /Invalid derivation parameters: May not specify parent key if the path segment starts with a BIP-39 node\./u,
       );
@@ -209,7 +200,6 @@ describe('derivation', () => {
         deriveKeyFromPath({
           path: [`bip32:1'`],
           curve: 'secp256k1',
-          specification: 'bip32',
         }),
       ).rejects.toThrow(
         /Invalid derivation parameters: Must specify parent key if the first node of the path segment is not a BIP-39 node\./u,
@@ -220,7 +210,6 @@ describe('derivation', () => {
       await expect(
         deriveKeyFromPath({
           path: [bip39MnemonicToMultipath(mnemonic)],
-          specification: 'bip32',
         }),
       ).rejects.toThrow(
         'Invalid arguments: Must specify either a parent node or curve.',
@@ -252,28 +241,24 @@ describe('derivation', () => {
         path: `44'`,
         node,
         curve: secp256k1,
-        specification: 'bip32',
       });
 
       node = await bip32Derive({
         path: `60'`,
         node,
         curve: secp256k1,
-        specification: 'bip32',
       });
 
       node = await bip32Derive({
         path: `0'`,
         node,
         curve: secp256k1,
-        specification: 'bip32',
       });
 
       node = await bip32Derive({
         path: `0`,
         node,
         curve: secp256k1,
-        specification: 'bip32',
       });
       /* eslint-enable require-atomic-updates */
 
@@ -283,7 +268,6 @@ describe('derivation', () => {
             path: `${index}`,
             node,
             curve: secp256k1,
-            specification: 'bip32',
           });
         }),
       );
@@ -312,7 +296,6 @@ describe('derivation', () => {
             path: input,
             node,
             curve: secp256k1,
-            specification: 'bip32',
           }),
         ).rejects.toThrow(
           'Invalid BIP-32 index: The index must be a non-negative decimal integer less than 2147483648.',
@@ -325,7 +308,6 @@ describe('derivation', () => {
         bip32Derive({
           path: '0',
           curve: secp256k1,
-          specification: 'bip32',
         }),
       ).rejects.toThrow(
         'Invalid parameters: Must specify a node to derive from.',
@@ -341,7 +323,6 @@ describe('derivation', () => {
           path: `0'`,
           node: publicNode,
           curve: secp256k1,
-          specification: 'bip32',
         }),
       ).rejects.toThrow(
         'Invalid parameters: Cannot derive hardened child keys without a private key.',

--- a/src/derivation.test.ts
+++ b/src/derivation.test.ts
@@ -380,4 +380,24 @@ describe('validatePathSegment', () => {
       ),
     ).toThrow('Invalid HD path segment: The path segment is malformed.');
   });
+
+  it('checks if each segment starts with the same type', () => {
+    expect(() =>
+      validatePathSegment(['slip10:0', 'slip10:1'], true),
+    ).not.toThrow();
+
+    expect(() =>
+      // @ts-expect-error Invalid type.
+      validatePathSegment(['bip32:0', 'slip10:1'], true),
+    ).toThrow(
+      "Invalid HD path segment: Cannot mix 'bip32' and 'slip10' path segments.",
+    );
+
+    expect(() =>
+      // @ts-expect-error Invalid type.
+      validatePathSegment(['slip10:0', 'bip32:1'], true),
+    ).toThrow(
+      "Invalid HD path segment: Cannot mix 'bip32' and 'slip10' path segments.",
+    );
+  });
 });

--- a/src/derivation.test.ts
+++ b/src/derivation.test.ts
@@ -298,7 +298,7 @@ describe('derivation', () => {
             curve: secp256k1,
           }),
         ).rejects.toThrow(
-          'Invalid BIP-32 index: The index must be a non-negative decimal integer less than 2147483648.',
+          'Invalid path: The index must be a non-negative decimal integer less than 2147483648.',
         );
       }
     });

--- a/src/derivation.ts
+++ b/src/derivation.ts
@@ -7,9 +7,10 @@ import {
   BIP_39_PATH_REGEX,
   MIN_BIP_44_DEPTH,
   SLIP10Path,
+  SLIP_10_PATH_REGEX,
 } from './constants';
 import { getCurveByName, SupportedCurve } from './curves';
-import { Deriver, derivers, Specification } from './derivers';
+import { Deriver, derivers } from './derivers';
 import { SLIP10Node } from './SLIP10Node';
 
 /**
@@ -27,7 +28,6 @@ import { SLIP10Node } from './SLIP10Node';
 type BaseDeriveKeyFromPathArgs = {
   path: SLIP10Path;
   depth?: number;
-  specification?: Specification;
 };
 
 type DeriveKeyFromPathNodeArgs = BaseDeriveKeyFromPathArgs & {
@@ -110,7 +110,6 @@ export async function deriveKeyFromPath(
         path: pathPart,
         node: derivedNode,
         curve: getCurveByName(curve),
-        specification: args.specification,
       });
     }
 
@@ -121,7 +120,6 @@ export async function deriveKeyFromPath(
       path: pathNode,
       node: derivedNode,
       curve: getCurveByName(curve),
-      specification: args.specification,
     });
   }, Promise.resolve(node as SLIP10Node));
 }
@@ -166,11 +164,15 @@ export function validatePathSegment(
         // need to explicitly check it again.
         !(node instanceof Uint8Array) &&
         !startsWithBip39 &&
-        !BIP_32_PATH_REGEX.test(node)
+        !BIP_32_PATH_REGEX.test(node) &&
+        !SLIP_10_PATH_REGEX.test(node)
       ) {
         throw getMalformedError();
       }
-    } else if (node instanceof Uint8Array || !BIP_32_PATH_REGEX.test(node)) {
+    } else if (
+      node instanceof Uint8Array ||
+      (!BIP_32_PATH_REGEX.test(node) && !SLIP_10_PATH_REGEX.test(node))
+    ) {
       throw getMalformedError();
     }
   });

--- a/src/derivation.ts
+++ b/src/derivation.ts
@@ -196,6 +196,17 @@ export function validatePathSegment(
       'Invalid derivation parameters: May not specify parent key if the path segment starts with a BIP-39 node.',
     );
   }
+
+  const pathWithoutKey = (startsWithBip39 ? path.slice(1) : path) as string[];
+  if (pathWithoutKey.length > 0) {
+    const firstSegmentType = pathWithoutKey[0].split(':')[0];
+    assert(
+      pathWithoutKey.every((segment) =>
+        segment.startsWith(`${firstSegmentType}:`),
+      ),
+      `Invalid HD path segment: Cannot mix 'bip32' and 'slip10' path segments.`,
+    );
+  }
 }
 
 /**

--- a/src/derivers/bip32.test.ts
+++ b/src/derivers/bip32.test.ts
@@ -1,5 +1,4 @@
 import { bytesToHex, hexToBytes } from '@metamask/utils';
-import { CURVE } from '@noble/secp256k1';
 
 import fixtures from '../../test/fixtures';
 import { BIP_32_HARDENED_OFFSET } from '../constants';
@@ -8,35 +7,29 @@ import { SLIP10Node } from '../SLIP10Node';
 import { hexStringToBytes } from '../utils';
 import {
   deriveChildKey,
-  privateAdd,
   privateKeyToEthAddress,
   publicKeyToEthAddress,
 } from './bip32';
 import { bip39MnemonicToMultipath, createBip39KeyFromSeed } from './bip39';
 
-const privateAddFixtures = fixtures['secp256k1-node'].privateAdd;
-
 describe('deriveChildKey', () => {
-  describe('private key derivation', () => {
-    it('handles invalid keys using BIP-32', async () => {
-      const node = await SLIP10Node.fromDerivationPath({
-        derivationPath: [bip39MnemonicToMultipath(fixtures.local.mnemonic)],
-        curve: 'secp256k1',
-        specification: 'bip32',
-      });
+  it('handles deriving invalid private keys', async () => {
+    const node = await SLIP10Node.fromDerivationPath({
+      derivationPath: [bip39MnemonicToMultipath(fixtures.local.mnemonic)],
+      curve: 'secp256k1',
+    });
 
-      // Simulate an invalid key once.
-      jest.spyOn(secp256k1, 'isValidPrivateKey').mockReturnValueOnce(false);
+    // Simulate an invalid key once.
+    jest.spyOn(secp256k1, 'isValidPrivateKey').mockReturnValueOnce(false);
 
-      const childNode = await deriveChildKey({
-        node,
-        path: `0'`,
-        curve: secp256k1,
-        specification: 'bip32',
-      });
+    const childNode = await deriveChildKey({
+      node,
+      path: `0'`,
+      curve: secp256k1,
+    });
 
-      expect(childNode.index).toBe(BIP_32_HARDENED_OFFSET + 1);
-      expect(childNode).toMatchInlineSnapshot(`
+    expect(childNode.index).toBe(BIP_32_HARDENED_OFFSET + 1);
+    expect(childNode).toMatchInlineSnapshot(`
         Object {
           "chainCode": "0xe7862c5448c2e347dbdd0ee287e69888beec88e958388c927d2eff0e04df88f8",
           "curve": "secp256k1",
@@ -46,125 +39,48 @@ describe('deriveChildKey', () => {
           "parentFingerprint": 3293725253,
           "privateKey": "0xdcc114faa58e3feccf10e6658494c0c48b9d146dec313f0dedbd263547da23dc",
           "publicKey": "0x044948f8f48422b7608754bf228d93aff08c8e27fa46397afd80632be39f1213f8ca7aa33fd2b3630bdbbfa259841ca66f18de39f1de89a603c34f15378c817c24",
-          "specification": "bip32",
         }
       `);
-    });
+  });
 
-    it.each(fixtures.errorHandling.bip32.keys)(
-      'handles invalid keys using BIP-32 (test vectors)',
-      async ({ path, privateKey, chainCode, index, depth }) => {
-        const node = await createBip39KeyFromSeed(
-          hexToBytes(fixtures.errorHandling.bip32.hexSeed),
-          secp256k1,
-        );
-
-        // Simulate an invalid key once.
-        jest.spyOn(secp256k1, 'isValidPrivateKey').mockReturnValueOnce(false);
-
-        const childNode = await node.derive(path.ours.tuple);
-        expect(childNode.privateKey).toBe(privateKey);
-        expect(childNode.chainCode).toBe(chainCode);
-        expect(childNode.index).toBe(index);
-        expect(childNode.depth).toBe(depth);
-      },
-    );
-
-    it('handles invalid keys using SLIP-10', async () => {
-      const node = await SLIP10Node.fromDerivationPath({
-        derivationPath: [bip39MnemonicToMultipath(fixtures.local.mnemonic)],
-        curve: 'secp256k1',
-        specification: 'slip10',
-      });
+  it.each(fixtures.errorHandling.bip32.keys)(
+    'handles deriving invalid private keys (test vectors)',
+    async ({ path, privateKey, chainCode, index, depth }) => {
+      const node = await createBip39KeyFromSeed(
+        hexToBytes(fixtures.errorHandling.bip32.hexSeed),
+        secp256k1,
+      );
 
       // Simulate an invalid key once.
       jest.spyOn(secp256k1, 'isValidPrivateKey').mockReturnValueOnce(false);
 
-      const childNode = await deriveChildKey({
-        node,
-        path: `0'`,
-        curve: secp256k1,
-        specification: 'slip10',
-      });
+      const childNode = await node.derive(path.ours.tuple);
+      expect(childNode.privateKey).toBe(privateKey);
+      expect(childNode.chainCode).toBe(chainCode);
+      expect(childNode.index).toBe(index);
+      expect(childNode.depth).toBe(depth);
+    },
+  );
 
-      expect(childNode.index).toBe(BIP_32_HARDENED_OFFSET);
-      expect(childNode).toMatchInlineSnapshot(`
-        Object {
-          "chainCode": "0x69c58a9e53bb674d1bbeb871975f01adce5e058cdcba89f8930225341a75b439",
-          "curve": "secp256k1",
-          "depth": 1,
-          "index": 2147483648,
-          "masterFingerprint": 3293725253,
-          "parentFingerprint": 3293725253,
-          "privateKey": "0xb9dbe9cda5d858df377ab6c6a9b3efef99269142e390d24aaceb49c547b9fcad",
-          "publicKey": "0x0422a2beb2a0c800ef19200db9161a3a7ee5645ccf67c05e18e7055a73cb1e1451f2c85f9aaac274bd16ea9a77f102feef3aba3f37ed6ac6e0961fb569011e42cf",
-          "specification": "slip10",
-        }
-      `);
+  it('handles deriving invalid public keys', async () => {
+    const node = await SLIP10Node.fromDerivationPath({
+      derivationPath: [bip39MnemonicToMultipath(fixtures.local.mnemonic)],
+      curve: 'secp256k1',
+    }).then((privateNode) => privateNode.neuter());
+
+    // Simulate an invalid key once.
+    jest.spyOn(secp256k1, 'publicAdd').mockImplementationOnce(() => {
+      throw new Error('Invalid key.');
     });
 
-    it.each(fixtures.errorHandling.slip10.keys)(
-      'handles invalid keys using SLIP-10 (test vectors)',
-      async ({ path, privateKey, chainCode }) => {
-        const node = await createBip39KeyFromSeed(
-          hexToBytes(fixtures.errorHandling.slip10.hexSeed),
-          secp256k1,
-          'slip10',
-        );
-
-        // Simulate an invalid key once.
-        jest.spyOn(secp256k1, 'isValidPrivateKey').mockReturnValueOnce(false);
-
-        const childNode = await node.derive(path.ours.tuple);
-        expect(childNode.privateKey).toBe(privateKey);
-        expect(childNode.chainCode).toBe(chainCode);
-      },
-    );
-
-    it('throws the original error if the curve is ed25519', async () => {
-      const node = await SLIP10Node.fromDerivationPath({
-        derivationPath: [bip39MnemonicToMultipath(fixtures.local.mnemonic)],
-        curve: 'ed25519',
-        specification: 'slip10',
-      });
-
-      // This should never be the case.
-      const error = new Error('Unable to derive child key.');
-      jest.spyOn(ed25519, 'getPublicKey').mockRejectedValueOnce(error);
-
-      await expect(
-        deriveChildKey({
-          node,
-          path: `0'`,
-          curve: ed25519,
-          specification: 'slip10',
-        }),
-      ).rejects.toThrow(error);
+    const childNode = await deriveChildKey({
+      node,
+      path: `0`,
+      curve: secp256k1,
     });
-  });
 
-  describe('public key derivation', () => {
-    it('handles invalid keys using BIP-32', async () => {
-      const node = await SLIP10Node.fromDerivationPath({
-        derivationPath: [bip39MnemonicToMultipath(fixtures.local.mnemonic)],
-        curve: 'secp256k1',
-        specification: 'bip32',
-      }).then((privateNode) => privateNode.neuter());
-
-      // Simulate an invalid key once.
-      jest.spyOn(secp256k1, 'publicAdd').mockImplementationOnce(() => {
-        throw new Error('Invalid key.');
-      });
-
-      const childNode = await deriveChildKey({
-        node,
-        path: `0`,
-        curve: secp256k1,
-        specification: 'bip32',
-      });
-
-      expect(childNode.index).toBe(1);
-      expect(childNode).toMatchInlineSnapshot(`
+    expect(childNode.index).toBe(1);
+    expect(childNode).toMatchInlineSnapshot(`
         Object {
           "chainCode": "0x4304d9e48a694baabefba498c2ef85f9e88307f4f621f79f19cbf5f704483130",
           "curve": "secp256k1",
@@ -174,87 +90,11 @@ describe('deriveChildKey', () => {
           "parentFingerprint": 3293725253,
           "privateKey": undefined,
           "publicKey": "0x048aa5d3fe38c7e81685f9efa72d8b4e9f2cb61647c954e9cdf324a6eefe8a4a00c2b7fa2b2d3e598c87d244fb4eb8708e402aa5ccd945533f4a6ddbc026f77c7b",
-          "specification": "bip32",
         }
       `);
-    });
-
-    it('handles invalid keys using SLIP-10', async () => {
-      const node = await SLIP10Node.fromDerivationPath({
-        derivationPath: [bip39MnemonicToMultipath(fixtures.local.mnemonic)],
-        curve: 'secp256k1',
-        specification: 'slip10',
-      }).then((privateNode) => privateNode.neuter());
-
-      // Simulate an invalid key once.
-      jest.spyOn(secp256k1, 'publicAdd').mockImplementationOnce(() => {
-        throw new Error('Invalid key.');
-      });
-
-      const childNode = await deriveChildKey({
-        node,
-        path: `0`,
-        curve: secp256k1,
-        specification: 'slip10',
-      });
-
-      expect(childNode.index).toBe(0);
-      expect(childNode).toMatchInlineSnapshot(`
-        Object {
-          "chainCode": "0x03eebbe4707329e7da4aef868adb65f21bdc8712a86567b17a15ee4c3f01a57a",
-          "curve": "secp256k1",
-          "depth": 1,
-          "index": 0,
-          "masterFingerprint": 3293725253,
-          "parentFingerprint": 3293725253,
-          "privateKey": undefined,
-          "publicKey": "0x04bc28203026c9fda2030f00ca592bdbe25392a106afae5205fa07dc4d77ecc61d21fa7a4bf21920abb52f56ae87f2d7b10d5db8d51229dea9c98c6b7982d514f9",
-          "specification": "slip10",
-        }
-      `);
-    });
   });
 
-  it('throws an error if the specification is undefined', async () => {
-    const node = await SLIP10Node.fromDerivationPath({
-      derivationPath: [bip39MnemonicToMultipath(fixtures.local.mnemonic)],
-      curve: 'secp256k1',
-    });
-
-    await expect(
-      deriveChildKey({
-        node,
-        path: `'bip32:0'`,
-        curve: secp256k1,
-        specification: undefined,
-      }),
-    ).rejects.toThrow(`Invalid specification: Must be specified.`);
-  });
-
-  it.each(['foo', 'bip-32', 'slip-10', 'BIP32', 'SLIP10'])(
-    'throws an error if the specification is invalid',
-    async (specification) => {
-      const node = await SLIP10Node.fromDerivationPath({
-        derivationPath: [bip39MnemonicToMultipath(fixtures.local.mnemonic)],
-        curve: 'secp256k1',
-      });
-
-      await expect(
-        deriveChildKey({
-          node,
-          path: `'bip32:0'`,
-          curve: secp256k1,
-          // @ts-expect-error Invalid specification type.
-          specification,
-        }),
-      ).rejects.toThrow(
-        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-        `Invalid specification: Must be one of bip32, slip10. Received "${specification}".`,
-      );
-    },
-  );
-
-  it('throws an error if the curve is ed25519 and the specification is bip32', async () => {
+  it('throws an error if the curve is ed25519', async () => {
     const node = await SLIP10Node.fromDerivationPath({
       derivationPath: [bip39MnemonicToMultipath(fixtures.local.mnemonic)],
       curve: 'secp256k1',
@@ -265,74 +105,8 @@ describe('deriveChildKey', () => {
         node,
         path: `'bip32:0'`,
         curve: ed25519,
-        specification: 'bip32',
       }),
-    ).rejects.toThrow(
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      `Invalid specification: The ed25519 curve only supports "slip10".`,
-    );
-  });
-});
-
-describe('privateAdd', () => {
-  const PRIVATE_KEY = hexStringToBytes(
-    '51f34c9afc9d5b43e085688db58bb923c012bb07e42a8eaf18a8400aa9a167fb',
-  );
-
-  it.each(privateAddFixtures)(
-    'adds a tweak to a private key',
-    ({ privateKey, tweak, result }) => {
-      const expected = hexStringToBytes(result);
-
-      expect(
-        privateAdd(
-          hexStringToBytes(privateKey),
-          hexStringToBytes(tweak),
-          secp256k1,
-        ),
-      ).toStrictEqual(expected);
-    },
-  );
-
-  it('throws if the tweak is larger than the curve order', () => {
-    const tweak = hexStringToBytes(CURVE.n.toString(16));
-
-    expect(() => privateAdd(PRIVATE_KEY, tweak, secp256k1)).toThrow(
-      'Invalid tweak: Tweak is larger than the curve order.',
-    );
-  });
-
-  it('throws if the result is invalid', () => {
-    // n - 1
-    const privateKey = hexStringToBytes(
-      'fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140',
-    );
-
-    // 1
-    const tweak = hexStringToBytes(
-      '0000000000000000000000000000000000000000000000000000000000000001',
-    );
-
-    expect(() => privateAdd(privateKey, tweak, secp256k1)).toThrow(
-      'Invalid private key or tweak: The resulting private key is invalid.',
-    );
-  });
-
-  it.each([
-    '0x7ebc0a630524c2d5ac55a98b8527a8ab2e842cd7b4037baadc463e597183408200',
-    '0xa0a86d020f4c512b8639c38ecb9a3792f1575d3a4ad832e2523fd447c67170',
-    '0x0efd64c97a920e71d90cf54589fb8a93',
-    '0x1',
-  ])('throws if the tweak is not 32 bytes long', (tweak) => {
-    expect(() => privateAdd(PRIVATE_KEY, hexToBytes(tweak), secp256k1)).toThrow(
-      'Invalid tweak: Tweak must be a non-zero 32-byte Uint8Array.',
-    );
-  });
-
-  it('throws if the tweak is zero', () => {
-    expect(() =>
-      privateAdd(PRIVATE_KEY, new Uint8Array(32).fill(0), secp256k1),
-    ).toThrow('Invalid tweak: Tweak must be a non-zero 32-byte Uint8Array.');
+    ).rejects.toThrow(`Invalid curve: Only secp256k1 is supported by BIP-32.`);
   });
 });
 

--- a/src/derivers/bip39.ts
+++ b/src/derivers/bip39.ts
@@ -4,11 +4,11 @@ import { assert } from '@metamask/utils';
 import { hmac } from '@noble/hashes/hmac';
 import { sha512 } from '@noble/hashes/sha512';
 
-import { DeriveChildKeyArgs, Specification } from '.';
+import { DeriveChildKeyArgs } from '.';
 import { BIP39StringNode, BYTES_KEY_LENGTH } from '../constants';
 import { Curve } from '../curves';
 import { SLIP10Node } from '../SLIP10Node';
-import { getFingerprint, getSpecification } from '../utils';
+import { getFingerprint } from '../utils';
 
 /**
  * Convert a BIP-39 mnemonic phrase to a multi path.
@@ -43,14 +43,12 @@ export async function deriveChildKey({
  *
  * @param seed - The cryptographic seed bytes.
  * @param curve - The curve to use.
- * @param specification - The specification to use.
  * @returns An object containing the corresponding BIP-39 master key and chain
  * code.
  */
 export async function createBip39KeyFromSeed(
   seed: Uint8Array,
   curve: Curve,
-  specification: Specification = getSpecification(curve.name),
 ): Promise<SLIP10Node> {
   assert(
     seed.length >= 16 && seed.length <= 64,
@@ -78,6 +76,5 @@ export async function createBip39KeyFromSeed(
     parentFingerprint: 0,
     index: 0,
     curve: curve.name,
-    specification,
   });
 }

--- a/src/derivers/index.ts
+++ b/src/derivers/index.ts
@@ -2,9 +2,7 @@ import { Curve } from '../curves';
 import { SLIP10Node } from '../SLIP10Node';
 import * as bip32 from './bip32';
 import * as bip39 from './bip39';
-
-export const VALID_SPECIFICATIONS = ['bip32', 'slip10'] as const;
-export type Specification = typeof VALID_SPECIFICATIONS[number];
+import * as slip10 from './slip10';
 
 export type DerivedKeys = {
   /**
@@ -19,7 +17,6 @@ export type DeriveChildKeyArgs = {
   path: Uint8Array | string;
   curve: Curve;
   node?: SLIP10Node;
-  specification?: Specification;
 };
 
 export type Deriver = {
@@ -29,4 +26,5 @@ export type Deriver = {
 export const derivers = {
   bip32,
   bip39,
+  slip10,
 };

--- a/src/derivers/shared.test.ts
+++ b/src/derivers/shared.test.ts
@@ -1,0 +1,69 @@
+import { hexToBytes } from '@metamask/utils';
+import { CURVE } from '@noble/secp256k1';
+
+import fixtures from '../../test/fixtures';
+import { secp256k1 } from '../curves';
+import { hexStringToBytes } from '../utils';
+import { privateAdd } from './shared';
+
+describe('privateAdd', () => {
+  const PRIVATE_KEY = hexStringToBytes(
+    '51f34c9afc9d5b43e085688db58bb923c012bb07e42a8eaf18a8400aa9a167fb',
+  );
+
+  it.each(fixtures['secp256k1-node'].privateAdd)(
+    'adds a tweak to a private key',
+    ({ privateKey, tweak, result }) => {
+      const expected = hexStringToBytes(result);
+
+      expect(
+        privateAdd(
+          hexStringToBytes(privateKey),
+          hexStringToBytes(tweak),
+          secp256k1,
+        ),
+      ).toStrictEqual(expected);
+    },
+  );
+
+  it('throws if the tweak is larger than the curve order', () => {
+    const tweak = hexStringToBytes(CURVE.n.toString(16));
+
+    expect(() => privateAdd(PRIVATE_KEY, tweak, secp256k1)).toThrow(
+      'Invalid tweak: Tweak is larger than the curve order.',
+    );
+  });
+
+  it('throws if the result is invalid', () => {
+    // n - 1
+    const privateKey = hexStringToBytes(
+      'fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140',
+    );
+
+    // 1
+    const tweak = hexStringToBytes(
+      '0000000000000000000000000000000000000000000000000000000000000001',
+    );
+
+    expect(() => privateAdd(privateKey, tweak, secp256k1)).toThrow(
+      'Invalid private key or tweak: The resulting private key is invalid.',
+    );
+  });
+
+  it.each([
+    '0x7ebc0a630524c2d5ac55a98b8527a8ab2e842cd7b4037baadc463e597183408200',
+    '0xa0a86d020f4c512b8639c38ecb9a3792f1575d3a4ad832e2523fd447c67170',
+    '0x0efd64c97a920e71d90cf54589fb8a93',
+    '0x1',
+  ])('throws if the tweak is not 32 bytes long', (tweak) => {
+    expect(() => privateAdd(PRIVATE_KEY, hexToBytes(tweak), secp256k1)).toThrow(
+      'Invalid tweak: Tweak must be a non-zero 32-byte Uint8Array.',
+    );
+  });
+
+  it('throws if the tweak is zero', () => {
+    expect(() =>
+      privateAdd(PRIVATE_KEY, new Uint8Array(32).fill(0), secp256k1),
+    ).toThrow('Invalid tweak: Tweak must be a non-zero 32-byte Uint8Array.');
+  });
+});

--- a/src/derivers/shared.ts
+++ b/src/derivers/shared.ts
@@ -1,0 +1,305 @@
+import {
+  assert,
+  bytesToBigInt,
+  concatBytes,
+  hexToBytes,
+} from '@metamask/utils';
+import { hmac } from '@noble/hashes/hmac';
+import { sha512 } from '@noble/hashes/sha512';
+
+import { DerivedKeys } from '.';
+import { BIP_32_HARDENED_OFFSET } from '../constants';
+import { Curve, mod } from '../curves';
+import { SLIP10Node } from '../SLIP10Node';
+import { isValidBytesKey, numberToUint32 } from '../utils';
+
+type DeriveSecretExtensionArgs = {
+  privateKey: Uint8Array;
+  childIndex: number;
+  isHardened: boolean;
+  curve: Curve;
+};
+
+/**
+ * Derive a BIP-32 secret extension from a parent key and child index.
+ *
+ * @param options - The options for deriving a secret extension.
+ * @param options.privateKey - The parent private key bytes.
+ * @param options.childIndex - The child index to derive.
+ * @param options.isHardened - Whether the child index is hardened.
+ * @param options.curve - The curve to use for derivation.
+ * @returns The secret extension bytes.
+ */
+export async function deriveSecretExtension({
+  privateKey,
+  childIndex,
+  isHardened,
+  curve,
+}: DeriveSecretExtensionArgs) {
+  if (isHardened) {
+    // Hardened child
+    return concatBytes([
+      new Uint8Array([0]),
+      privateKey,
+      numberToUint32(childIndex + BIP_32_HARDENED_OFFSET),
+    ]);
+  }
+
+  // Normal child
+  const parentPublicKey = await curve.getPublicKey(privateKey, true);
+  return derivePublicExtension({ parentPublicKey, childIndex });
+}
+
+type DerivePublicExtensionArgs = {
+  parentPublicKey: Uint8Array;
+  childIndex: number;
+};
+
+/**
+ * Derive a BIP-32 public extension from a parent key and child index.
+ *
+ * @param options - The options for deriving a public extension.
+ * @param options.parentPublicKey - The parent public key bytes.
+ * @param options.childIndex - The child index to derive.
+ * @returns The public extension bytes.
+ */
+export function derivePublicExtension({
+  parentPublicKey,
+  childIndex,
+}: DerivePublicExtensionArgs) {
+  const indexBytes = new Uint8Array(4);
+  const view = new DataView(indexBytes.buffer);
+
+  view.setUint32(0, childIndex, false);
+  return concatBytes([parentPublicKey, indexBytes]);
+}
+
+type GenerateKeyArgs = {
+  privateKey: Uint8Array;
+  entropy: Uint8Array;
+  curve: Curve;
+};
+
+/**
+ * Derive a BIP-32 key from a parent key and secret extension.
+ *
+ * @param options - The options for deriving a key.
+ * @param options.privateKey - The parent private key bytes.
+ * @param options.entropy - The entropy bytes.
+ * @param options.curve - The curve to use for derivation.
+ * @returns The derived key.
+ */
+async function generateKey({
+  privateKey,
+  entropy,
+  curve,
+}: GenerateKeyArgs): Promise<DerivedKeys & { privateKey: Uint8Array }> {
+  const keyMaterial = entropy.slice(0, 32);
+  const childChainCode = entropy.slice(32);
+
+  // If curve is ed25519: The returned child key ki is parse256(IL).
+  // https://github.com/satoshilabs/slips/blob/133ea52a8e43d338b98be208907e144277e44c0e/slip-0010.md#private-parent-key--private-child-key
+  if (curve.name === 'ed25519') {
+    const publicKey = await curve.getPublicKey(keyMaterial);
+    return { privateKey: keyMaterial, publicKey, chainCode: childChainCode };
+  }
+
+  const childPrivateKey = privateAdd(privateKey, keyMaterial, curve);
+  const publicKey = await curve.getPublicKey(childPrivateKey);
+
+  return { privateKey: childPrivateKey, publicKey, chainCode: childChainCode };
+}
+
+type DerivePrivateChildKeyArgs = {
+  entropy: Uint8Array;
+  privateKey: Uint8Array;
+  depth: number;
+  masterFingerprint?: number;
+  parentFingerprint: number;
+  childIndex: number;
+  isHardened: boolean;
+  curve: Curve;
+};
+
+/**
+ * Derive a BIP-32 private child key with a given path from a parent key.
+ *
+ * @param args - The arguments for deriving a private child key.
+ * @param args.entropy - The entropy to use for derivation.
+ * @param args.privateKey - The parent private key to use for derivation.
+ * @param args.depth - The depth of the parent node.
+ * @param args.masterFingerprint - The fingerprint of the master node.
+ * @param args.parentFingerprint - The fingerprint of the parent node.
+ * @param args.childIndex - The child index to derive.
+ * @param args.isHardened - Whether the child index is hardened.
+ * @param args.curve - The curve to use for derivation.
+ * @returns The derived {@link SLIP10Node}.
+ */
+export async function derivePrivateChildKey({
+  entropy,
+  privateKey,
+  depth,
+  masterFingerprint,
+  parentFingerprint,
+  childIndex,
+  isHardened,
+  curve,
+}: DerivePrivateChildKeyArgs): Promise<SLIP10Node> {
+  const actualChildIndex =
+    childIndex + (isHardened ? BIP_32_HARDENED_OFFSET : 0);
+
+  const { privateKey: childPrivateKey, chainCode: childChainCode } =
+    await generateKey({
+      privateKey,
+      entropy,
+      curve,
+    });
+
+  return await SLIP10Node.fromExtendedKey({
+    privateKey: childPrivateKey,
+    chainCode: childChainCode,
+    depth: depth + 1,
+    masterFingerprint,
+    parentFingerprint,
+    index: actualChildIndex,
+    curve: curve.name,
+  });
+}
+
+type GeneratePublicKeyArgs = {
+  publicKey: Uint8Array;
+  entropy: Uint8Array;
+  curve: Curve;
+};
+
+/**
+ * Derive a BIP-32 public key from a parent key and public extension.
+ *
+ * @param options - The options for deriving a public key.
+ * @param options.publicKey - The parent public key bytes.
+ * @param options.entropy - The entropy bytes.
+ * @param options.curve - The curve to use for derivation.
+ * @returns The derived public key.
+ */
+function generatePublicKey({
+  publicKey,
+  entropy,
+  curve,
+}: GeneratePublicKeyArgs): DerivedKeys {
+  const keyMaterial = entropy.slice(0, 32);
+  const childChainCode = entropy.slice(32);
+
+  // This function may fail if the resulting key is invalid.
+  const childPublicKey = curve.publicAdd(publicKey, keyMaterial);
+
+  return {
+    publicKey: childPublicKey,
+    chainCode: childChainCode,
+  };
+}
+
+type DerivePublicChildKeyArgs = {
+  entropy: Uint8Array;
+  publicKey: Uint8Array;
+  depth: number;
+  masterFingerprint?: number;
+  parentFingerprint: number;
+  childIndex: number;
+  curve: Curve;
+};
+
+/**
+ * Derive a BIP-32 public child key with a given path from a parent key.
+ *
+ * @param args - The arguments for deriving a public child key.
+ * @param args.entropy - The entropy to use for derivation.
+ * @param args.publicKey - The parent public key to use for derivation.
+ * @param args.depth - The depth of the parent node.
+ * @param args.masterFingerprint - The fingerprint of the master node.
+ * @param args.parentFingerprint - The fingerprint of the parent node.
+ * @param args.childIndex - The child index to derive.
+ * @param args.curve - The curve to use for derivation.
+ * @returns The derived {@link SLIP10Node}.
+ */
+export async function derivePublicChildKey({
+  entropy,
+  publicKey,
+  depth,
+  masterFingerprint,
+  parentFingerprint,
+  childIndex,
+  curve,
+}: DerivePublicChildKeyArgs): Promise<SLIP10Node> {
+  const { publicKey: childPublicKey, chainCode: childChainCode } =
+    generatePublicKey({
+      publicKey,
+      entropy,
+      curve,
+    });
+
+  return await SLIP10Node.fromExtendedKey({
+    publicKey: childPublicKey,
+    chainCode: childChainCode,
+    depth: depth + 1,
+    masterFingerprint,
+    parentFingerprint,
+    index: childIndex,
+    curve: curve.name,
+  });
+}
+
+/**
+ * Add a tweak to the private key: `(privateKey + tweak) % n`.
+ *
+ * @param privateKeyBytes - The private key as 32 byte Uint8Array.
+ * @param tweakBytes - The tweak as 32 byte Uint8Array.
+ * @param curve - The curve to use.
+ * @throws If the private key or tweak is invalid.
+ * @returns The private key with the tweak added to it.
+ */
+export function privateAdd(
+  privateKeyBytes: Uint8Array,
+  tweakBytes: Uint8Array,
+  curve: Curve,
+): Uint8Array {
+  assert(
+    isValidBytesKey(tweakBytes, 32),
+    'Invalid tweak: Tweak must be a non-zero 32-byte Uint8Array.',
+  );
+
+  const privateKey = bytesToBigInt(privateKeyBytes);
+  const tweak = bytesToBigInt(tweakBytes);
+
+  if (tweak >= curve.curve.n) {
+    throw new Error('Invalid tweak: Tweak is larger than the curve order.');
+  }
+
+  const added = mod(privateKey + tweak, curve.curve.n);
+  const bytes = hexToBytes(added.toString(16).padStart(64, '0'));
+
+  if (!curve.isValidPrivateKey(bytes)) {
+    throw new Error(
+      'Invalid private key or tweak: The resulting private key is invalid.',
+    );
+  }
+
+  return bytes;
+}
+
+type GenerateEntropyArgs = {
+  chainCode: Uint8Array;
+  extension: Uint8Array;
+};
+
+/**
+ * Generate 64 bytes of (deterministic) entropy from a chain code and secret
+ * extension.
+ *
+ * @param args - The arguments for generating entropy.
+ * @param args.chainCode - The parent chain code bytes.
+ * @param args.extension - The extension bytes.
+ * @returns The generated entropy bytes.
+ */
+export function generateEntropy({ chainCode, extension }: GenerateEntropyArgs) {
+  return hmac(sha512, chainCode, extension);
+}

--- a/src/derivers/shared.ts
+++ b/src/derivers/shared.ts
@@ -234,11 +234,7 @@ export function derivePublicExtension({
   parentPublicKey,
   childIndex,
 }: DerivePublicExtensionArgs) {
-  const indexBytes = new Uint8Array(4);
-  const view = new DataView(indexBytes.buffer);
-
-  view.setUint32(0, childIndex, false);
-  return concatBytes([parentPublicKey, indexBytes]);
+  return concatBytes([parentPublicKey, numberToUint32(childIndex)]);
 }
 
 type GenerateKeyArgs = {

--- a/src/derivers/slip10.test.ts
+++ b/src/derivers/slip10.test.ts
@@ -1,0 +1,108 @@
+import { hexToBytes } from '@metamask/utils';
+
+import fixtures from '../../test/fixtures';
+import { BIP_32_HARDENED_OFFSET } from '../constants';
+import { ed25519, secp256k1 } from '../curves';
+import { SLIP10Node } from '../SLIP10Node';
+import { bip39MnemonicToMultipath, createBip39KeyFromSeed } from './bip39';
+import { deriveChildKey } from './slip10';
+
+describe('deriveChildKey', () => {
+  it('handles deriving invalid private keys', async () => {
+    const node = await SLIP10Node.fromDerivationPath({
+      derivationPath: [bip39MnemonicToMultipath(fixtures.local.mnemonic)],
+      curve: 'secp256k1',
+    });
+
+    // Simulate an invalid key once.
+    jest.spyOn(secp256k1, 'isValidPrivateKey').mockReturnValueOnce(false);
+
+    const childNode = await deriveChildKey({
+      node,
+      path: `0'`,
+      curve: secp256k1,
+    });
+
+    expect(childNode.index).toBe(BIP_32_HARDENED_OFFSET);
+    expect(childNode).toMatchInlineSnapshot(`
+        Object {
+          "chainCode": "0x69c58a9e53bb674d1bbeb871975f01adce5e058cdcba89f8930225341a75b439",
+          "curve": "secp256k1",
+          "depth": 1,
+          "index": 2147483648,
+          "masterFingerprint": 3293725253,
+          "parentFingerprint": 3293725253,
+          "privateKey": "0xb9dbe9cda5d858df377ab6c6a9b3efef99269142e390d24aaceb49c547b9fcad",
+          "publicKey": "0x0422a2beb2a0c800ef19200db9161a3a7ee5645ccf67c05e18e7055a73cb1e1451f2c85f9aaac274bd16ea9a77f102feef3aba3f37ed6ac6e0961fb569011e42cf",
+        }
+      `);
+  });
+
+  it.each(fixtures.errorHandling.slip10.keys)(
+    'handles deriving invalid private keys (test vectors)',
+    async ({ path, privateKey, chainCode }) => {
+      const node = await createBip39KeyFromSeed(
+        hexToBytes(fixtures.errorHandling.slip10.hexSeed),
+        secp256k1,
+      );
+
+      // Simulate an invalid key once.
+      jest.spyOn(secp256k1, 'isValidPrivateKey').mockReturnValueOnce(false);
+
+      const childNode = await node.derive(path.ours.tuple);
+      expect(childNode.privateKey).toBe(privateKey);
+      expect(childNode.chainCode).toBe(chainCode);
+    },
+  );
+
+  it('throws the original error if the curve is ed25519', async () => {
+    const node = await SLIP10Node.fromDerivationPath({
+      derivationPath: [bip39MnemonicToMultipath(fixtures.local.mnemonic)],
+      curve: 'ed25519',
+    });
+
+    // This should never be the case.
+    const error = new Error('Unable to derive child key.');
+    jest.spyOn(ed25519, 'getPublicKey').mockRejectedValueOnce(error);
+
+    await expect(
+      deriveChildKey({
+        node,
+        path: `0'`,
+        curve: ed25519,
+      }),
+    ).rejects.toThrow(error);
+  });
+
+  it('handles deriving invalid public keys', async () => {
+    const node = await SLIP10Node.fromDerivationPath({
+      derivationPath: [bip39MnemonicToMultipath(fixtures.local.mnemonic)],
+      curve: 'secp256k1',
+    }).then((privateNode) => privateNode.neuter());
+
+    // Simulate an invalid key once.
+    jest.spyOn(secp256k1, 'publicAdd').mockImplementationOnce(() => {
+      throw new Error('Invalid key.');
+    });
+
+    const childNode = await deriveChildKey({
+      node,
+      path: `0`,
+      curve: secp256k1,
+    });
+
+    expect(childNode.index).toBe(0);
+    expect(childNode).toMatchInlineSnapshot(`
+        Object {
+          "chainCode": "0x03eebbe4707329e7da4aef868adb65f21bdc8712a86567b17a15ee4c3f01a57a",
+          "curve": "secp256k1",
+          "depth": 1,
+          "index": 0,
+          "masterFingerprint": 3293725253,
+          "parentFingerprint": 3293725253,
+          "privateKey": undefined,
+          "publicKey": "0x04bc28203026c9fda2030f00ca592bdbe25392a106afae5205fa07dc4d77ecc61d21fa7a4bf21920abb52f56ae87f2d7b10d5db8d51229dea9c98c6b7982d514f9",
+        }
+      `);
+  });
+});

--- a/src/derivers/slip10.ts
+++ b/src/derivers/slip10.ts
@@ -6,175 +6,59 @@ import { SLIP10Node } from '../SLIP10Node';
 import { numberToUint32 } from '../utils';
 import {
   DeriveNodeArgs,
-  derivePrivateChildKey,
-  derivePublicChildKey,
-  derivePublicExtension,
-  deriveSecretExtension,
   generateEntropy,
-  getValidatedPath,
-  validateNode,
+  deriveChildKey as sharedDeriveChildKey,
 } from './shared';
 
 /**
  * Derive a SLIP-10 child key with a given path from a parent key.
  *
  * @param options - The options for deriving a child key.
- * @param options.path - The derivation path part to derive.
- * @param options.node - The node to derive from.
- * @param options.curve - The curve to use for derivation.
  * @returns A tuple containing the derived private key, public key and chain
  * code.
  */
-export async function deriveChildKey({
-  path,
-  node,
-  curve,
-}: DeriveChildKeyArgs): Promise<SLIP10Node> {
-  validateNode(node);
-
-  const { childIndex, isHardened } = getValidatedPath(path, node, curve);
-
-  const args = {
-    chainCode: node.chainCodeBytes,
-    childIndex,
-    isHardened,
-    depth: node.depth,
-    parentFingerprint: node.fingerprint,
-    masterFingerprint: node.masterFingerprint,
-    curve,
-  };
-
-  if (node.privateKeyBytes) {
-    const secretExtension = await deriveSecretExtension({
-      privateKey: node.privateKeyBytes,
-      childIndex,
-      isHardened,
-      curve,
-    });
-
-    const entropy = generateEntropy({
-      chainCode: node.chainCodeBytes,
-      extension: secretExtension,
-    });
-
-    return deriveNode({
-      privateKey: node.privateKeyBytes,
-      entropy,
-      ...args,
-    });
-  }
-
-  const publicExtension = derivePublicExtension({
-    parentPublicKey: node.compressedPublicKeyBytes,
-    childIndex,
-  });
-
-  const entropy = generateEntropy({
-    chainCode: node.chainCodeBytes,
-    extension: publicExtension,
-  });
-
-  return deriveNode({
-    publicKey: node.compressedPublicKeyBytes,
-    entropy,
-    ...args,
-  });
+export async function deriveChildKey(
+  options: DeriveChildKeyArgs,
+): Promise<SLIP10Node> {
+  return await sharedDeriveChildKey(options, handleError);
 }
 
 /**
- * Derive a SLIP-10 child key from a parent key.
+ * Handle an error that occurs during SLIP-10 derivation.
  *
- * @param options - The options for deriving a child key.
- * @param options.privateKey - The private key to derive from.
- * @param options.publicKey - The public key to derive from.
- * @param options.entropy - The entropy to use for deriving the child key.
- * @param options.chainCode - The chain code to use for deriving the child key.
- * @param options.childIndex - The child index to use for deriving the child key.
- * @param options.isHardened - Whether the child key is hardened.
- * @param options.depth - The depth of the child key.
- * @param options.parentFingerprint - The fingerprint of the parent key.
- * @param options.masterFingerprint - The fingerprint of the master key.
- * @param options.curve - The curve to use for deriving the child key.
- * @returns The derived child key as {@link SLIP10Node}.
+ * @param error - The error that occurred.
+ * @param options - The options that were used for derivation.
+ * @returns The new options to use for derivation.
  */
-async function deriveNode({
-  privateKey,
-  publicKey,
-  entropy,
-  chainCode,
-  childIndex,
-  isHardened,
-  depth,
-  parentFingerprint,
-  masterFingerprint,
-  curve,
-}: DeriveNodeArgs): Promise<SLIP10Node> {
-  try {
-    if (privateKey) {
-      return await derivePrivateChildKey({
-        entropy,
-        privateKey,
-        depth,
-        masterFingerprint,
-        parentFingerprint,
-        childIndex,
-        isHardened,
-        curve,
-      });
-    }
+async function handleError(
+  error: unknown,
+  options: DeriveNodeArgs,
+): Promise<DeriveNodeArgs> {
+  const { curve, isHardened, childIndex, entropy, chainCode } = options;
 
-    return await derivePublicChildKey({
-      entropy,
-      publicKey,
-      depth,
-      masterFingerprint,
-      parentFingerprint,
-      childIndex,
-      curve,
-    });
-  } catch (error) {
-    if (curve.name === 'ed25519') {
-      throw error;
-    }
-
-    const actualChildIndex = isHardened
-      ? childIndex + BIP_32_HARDENED_OFFSET
-      : childIndex;
-
-    // As per SLIP-10, if the resulting key is invalid, the new entropy is
-    // generated as follows:
-    // Key material (32 bytes), child chain code (32 bytes) =
-    //   HMAC-SHA512(parent chain code, 0x01 || chain code from invalid key || index).
-    const newEntropy = generateEntropy({
-      chainCode,
-      extension: concatBytes([
-        0x01,
-        entropy.slice(32, 64),
-        numberToUint32(actualChildIndex),
-      ]),
-    });
-
-    const args = {
-      entropy: newEntropy,
-      chainCode,
-      childIndex,
-      isHardened,
-      depth,
-      parentFingerprint,
-      masterFingerprint,
-      curve,
-    };
-
-    if (privateKey) {
-      return deriveNode({
-        ...args,
-        privateKey,
-      });
-    }
-
-    return deriveNode({
-      ...args,
-      publicKey,
-    });
+  if (curve.name === 'ed25519') {
+    throw error;
   }
+
+  const actualChildIndex = isHardened
+    ? childIndex + BIP_32_HARDENED_OFFSET
+    : childIndex;
+
+  // As per SLIP-10, if the resulting key is invalid, the new entropy is
+  // generated as follows:
+  // Key material (32 bytes), child chain code (32 bytes) =
+  //   HMAC-SHA512(parent chain code, 0x01 || chain code from invalid key || index).
+  const newEntropy = generateEntropy({
+    chainCode,
+    extension: concatBytes([
+      0x01,
+      entropy.slice(32, 64),
+      numberToUint32(actualChildIndex),
+    ]),
+  });
+
+  return {
+    ...options,
+    entropy: newEntropy,
+  };
 }

--- a/src/derivers/slip10.ts
+++ b/src/derivers/slip10.ts
@@ -36,6 +36,8 @@ async function handleError(
 ): Promise<DeriveNodeArgs> {
   const { curve, isHardened, childIndex, entropy, chainCode } = options;
 
+  // `ed25519` keys are always valid, so this error should never be thrown. If
+  // it is, we re-throw it.
   if (curve.name === 'ed25519') {
     throw error;
   }

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -23,7 +23,6 @@ import {
   decodeBase58check,
   mnemonicPhraseToBytes,
   getBytesUnsafe,
-  getSpecification,
 } from './utils';
 
 // Inputs used for testing non-negative integers
@@ -410,14 +409,4 @@ describe('mnemonicPhraseToBytes', () => {
       );
     },
   );
-});
-
-describe('getSpecification', () => {
-  it('returns BIP-32 for secp256k1', () => {
-    expect(getSpecification('secp256k1')).toBe('bip32');
-  });
-
-  it('returns SLIP-10 for ed25519', () => {
-    expect(getSpecification('ed25519')).toBe('slip10');
-  });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,5 @@
 import { wordlist as englishWordlist } from '@metamask/scure-bip39/dist/wordlists/english';
-import {
-  assert,
-  assertExhaustive,
-  createDataView,
-  hexToBytes,
-} from '@metamask/utils';
+import { assert, createDataView, hexToBytes } from '@metamask/utils';
 import { ripemd160 } from '@noble/hashes/ripemd160';
 import { sha256 } from '@noble/hashes/sha256';
 import { base58check as scureBase58check } from '@scure/base';
@@ -20,7 +15,6 @@ import {
   UnhardenedBIP32Node,
 } from './constants';
 import { curves, SupportedCurve } from './curves';
-import { Specification, VALID_SPECIFICATIONS } from './derivers';
 
 /**
  * Gets a string representation of a BIP-44 path of depth 2, i.e.:
@@ -409,45 +403,6 @@ export function validateCurve(
       ).join(', ')}.`,
     );
   }
-}
-
-/**
- * Get the default specification (BIP-32 or SLIP-10) for a given curve.
- *
- * @param curve - The curve to get the specification for.
- * @returns The specification for the curve.
- */
-export function getSpecification(curve: SupportedCurve): Specification {
-  validateCurve(curve);
-
-  switch (curve) {
-    case 'secp256k1':
-      return 'bip32';
-    case 'ed25519':
-      return 'slip10';
-
-    /* c8 ignore next 2 */
-    default:
-      return assertExhaustive(curve);
-  }
-}
-
-/**
- * Validate that the specified specification is valid.
- *
- * @param specification - The specification to validate.
- * @throws An error if the specification is invalid.
- */
-export function validateSpecification(
-  specification?: unknown,
-): asserts specification is Specification {
-  assert(specification, 'Invalid specification: Must be specified.');
-  assert(
-    VALID_SPECIFICATIONS.includes(specification as Specification),
-    `Invalid specification: Must be one of ${VALID_SPECIFICATIONS.join(
-      ', ',
-    )}. Received "${specification.toString()}".`,
-  );
 }
 
 /**

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -548,8 +548,8 @@ export default {
           {
             path: {
               ours: {
-                tuple: [`bip32:0'`],
-                string: `bip32:0'`,
+                tuple: [`slip10:0'`],
+                string: `slip10:0'`,
               },
               theirs: `m/0'`,
             },
@@ -561,8 +561,8 @@ export default {
           {
             path: {
               ours: {
-                tuple: [`bip32:0'`, `bip32:1'`],
-                string: `bip32:0'/bip32:1'`,
+                tuple: [`slip10:0'`, `slip10:1'`],
+                string: `slip10:0'/slip10:1'`,
               },
               theirs: `m/0'/1'`,
             },
@@ -574,8 +574,8 @@ export default {
           {
             path: {
               ours: {
-                tuple: [`bip32:0'`, `bip32:1'`, `bip32:2'`],
-                string: `bip32:0'/bip32:1'/bip32:2'`,
+                tuple: [`slip10:0'`, `slip10:1'`, `slip10:2'`],
+                string: `slip10:0'/slip10:1'/slip10:2'`,
               },
               theirs: `m/0'/1'/2'`,
             },
@@ -587,8 +587,8 @@ export default {
           {
             path: {
               ours: {
-                tuple: [`bip32:0'`, `bip32:1'`, `bip32:2'`, `bip32:2'`],
-                string: `bip32:0'/bip32:1'/bip32:2'/bip32:2'`,
+                tuple: [`slip10:0'`, `slip10:1'`, `slip10:2'`, `slip10:2'`],
+                string: `slip10:0'/slip10:1'/slip10:2'/slip10:2'`,
               },
               theirs: `m/0'/1'/2'/2'`,
             },
@@ -601,13 +601,13 @@ export default {
             path: {
               ours: {
                 tuple: [
-                  `bip32:0'`,
-                  `bip32:1'`,
-                  `bip32:2'`,
-                  `bip32:2'`,
-                  `bip32:1000000000'`,
+                  `slip10:0'`,
+                  `slip10:1'`,
+                  `slip10:2'`,
+                  `slip10:2'`,
+                  `slip10:1000000000'`,
                 ],
-                string: `bip32:0'/bip32:1'/bip32:2'/bip32:2'/bip32:1000000000'`,
+                string: `slip10:0'/slip10:1'/slip10:2'/slip10:2'/slip10:1000000000'`,
               },
               theirs: `m/0'/1'/2'/2'/1000000000'`,
             },
@@ -638,8 +638,8 @@ export default {
           {
             path: {
               ours: {
-                tuple: [`bip32:0'`],
-                string: `bip32:0'`,
+                tuple: [`slip10:0'`],
+                string: `slip10:0'`,
               },
               theirs: `m/0'`,
             },
@@ -651,8 +651,8 @@ export default {
           {
             path: {
               ours: {
-                tuple: [`bip32:0'`, `bip32:2147483647'`],
-                string: `bip32:0'/bip32:2147483647'`,
+                tuple: [`slip10:0'`, `slip10:2147483647'`],
+                string: `slip10:0'/slip10:2147483647'`,
               },
               theirs: `m/0'/2147483647'`,
             },
@@ -664,8 +664,8 @@ export default {
           {
             path: {
               ours: {
-                tuple: [`bip32:0'`, `bip32:2147483647'`, `bip32:1'`],
-                string: `bip32:0'/bip32:2147483647'/bip32:1'`,
+                tuple: [`slip10:0'`, `slip10:2147483647'`, `slip10:1'`],
+                string: `slip10:0'/slip10:2147483647'/slip10:1'`,
               },
               theirs: `m/0'/2147483647'/1'`,
             },
@@ -678,12 +678,12 @@ export default {
             path: {
               ours: {
                 tuple: [
-                  `bip32:0'`,
-                  `bip32:2147483647'`,
-                  `bip32:1'`,
-                  `bip32:2147483646'`,
+                  `slip10:0'`,
+                  `slip10:2147483647'`,
+                  `slip10:1'`,
+                  `slip10:2147483646'`,
                 ],
-                string: `bip32:0'/bip32:2147483647'/bip32:1'/bip32:2147483646'`,
+                string: `slip10:0'/slip10:2147483647'/slip10:1'/slip10:2147483646'`,
               },
               theirs: `m/0'/2147483647'/1'/2147483646'`,
             },
@@ -696,13 +696,13 @@ export default {
             path: {
               ours: {
                 tuple: [
-                  `bip32:0'`,
-                  `bip32:2147483647'`,
-                  `bip32:1'`,
-                  `bip32:2147483646'`,
-                  `bip32:2'`,
+                  `slip10:0'`,
+                  `slip10:2147483647'`,
+                  `slip10:1'`,
+                  `slip10:2147483646'`,
+                  `slip10:2'`,
                 ],
-                string: `bip32:0'/bip32:2147483647'/bip32:1'/bip32:2147483646'/bip32:2'`,
+                string: `slip10:0'/slip10:2147483647'/slip10:1'/slip10:2147483646'/slip10:2'`,
               },
               theirs: `m/0'/2147483647'/1'/2147483646'/2'`,
             },
@@ -728,8 +728,8 @@ export default {
       // implementation, not any reference values, this is fine.
       path: {
         ours: {
-          tuple: [`bip32:44'`, `bip32:0'`, `bip32:0'`, `bip32:1'`],
-          string: [`bip32:44'/bip32:0'/bip32:0'/bip32:1'`],
+          tuple: [`slip10:44'`, `slip10:0'`, `slip10:0'`, `slip10:1'`],
+          string: [`slip10:44'/slip10:0'/slip10:0'/slip10:1'`],
         },
         theirs: `m/44'/0'/0'/1'`,
       },
@@ -875,8 +875,8 @@ export default {
         {
           path: {
             ours: {
-              tuple: [`bip32:3`],
-              string: `bip32:3`,
+              tuple: [`slip10:3`],
+              string: `slip10:3`,
             },
             theirs: `m/3`,
           },
@@ -888,8 +888,8 @@ export default {
         {
           path: {
             ours: {
-              tuple: [`bip32:3`, `bip32:0`],
-              string: `bip32:3/bip32:0`,
+              tuple: [`slip10:3`, `slip10:0`],
+              string: `slip10:3/slip10:0`,
             },
             theirs: `m/3/0`,
           },
@@ -901,8 +901,8 @@ export default {
         {
           path: {
             ours: {
-              tuple: [`bip32:123'`],
-              string: `bip32:123'`,
+              tuple: [`slip10:123'`],
+              string: `slip10:123'`,
             },
             theirs: `m/123'`,
           },
@@ -914,8 +914,8 @@ export default {
         {
           path: {
             ours: {
-              tuple: [`bip32:123'`, `bip32:456'`],
-              string: `bip32:123'/bip32:456'`,
+              tuple: [`slip10:123'`, `slip10:456'`],
+              string: `slip10:123'/slip10:456'`,
             },
             theirs: `m/123'/456'`,
           },

--- a/test/reference-implementations.test.ts
+++ b/test/reference-implementations.test.ts
@@ -1,6 +1,6 @@
 import {
   BIP44Node,
-  SLIP10Node,
+  SLIP10PathNode,
   BIP44PurposeNodeToken,
   HDPathTuple,
 } from '../src';
@@ -215,7 +215,7 @@ describe('reference implementation tests', () => {
           for (const keyObj of vector.keys) {
             const { path, privateKey } = keyObj;
 
-            let targetNode: SLIP10Node;
+            let targetNode: SLIP10PathNode;
 
             // If the path is empty, use the master node
             if (path.ours.string === '') {
@@ -247,7 +247,7 @@ describe('reference implementation tests', () => {
             );
 
             for (const { path, privateKey, publicKey } of keys) {
-              let targetNode: SLIP10Node;
+              let targetNode: SLIP10PathNode;
               if (path.ours.string === '') {
                 targetNode = node;
               } else {

--- a/test/reference-implementations.test.ts
+++ b/test/reference-implementations.test.ts
@@ -46,7 +46,6 @@ describe('reference implementation tests', () => {
         const node = await deriveKeyFromPath({
           path: [mnemonicBip39Node, BIP44PurposeNodeToken, `bip32:60'`],
           curve: 'secp256k1',
-          specification: 'bip32',
         });
 
         for (let index = 0; index < addresses.length; index++) {
@@ -54,7 +53,6 @@ describe('reference implementation tests', () => {
           const { address } = await deriveKeyFromPath({
             path: getBIP44CoinTypeToAddressPathTuple({ address_index: index }),
             node,
-            specification: 'bip32',
           });
 
           expect(address).toStrictEqual(expectedAddress);
@@ -122,7 +120,6 @@ describe('reference implementation tests', () => {
         const node = await deriveKeyFromPath({
           path: [mnemonicBip39Node, BIP44PurposeNodeToken, `bip32:60'`],
           curve: 'secp256k1',
-          specification: 'bip32',
         });
 
         const numberOfAccounts = 5;
@@ -132,7 +129,6 @@ describe('reference implementation tests', () => {
             await deriveKeyFromPath({
               path: getBIP44CoinTypeToAddressPathTuple({ address_index: i }),
               node,
-              specification: 'bip32',
             }).then(({ address }) => address),
           );
         }
@@ -188,7 +184,6 @@ describe('reference implementation tests', () => {
         const childNode = await deriveKeyFromPath({
           path: path.ours.tuple,
           node,
-          specification: 'bip32',
         });
 
         expect(childNode.privateKey).toStrictEqual(privateKey);
@@ -198,7 +193,6 @@ describe('reference implementation tests', () => {
           const childChildNode = await deriveKeyFromPath({
             path: [`bip32:${index}`],
             node: childNode,
-            specification: 'bip32',
           });
 
           expect(childChildNode.address).toStrictEqual(theirAddress);
@@ -230,7 +224,6 @@ describe('reference implementation tests', () => {
               targetNode = await deriveKeyFromPath({
                 path: path.ours.tuple as HDPathTuple,
                 node,
-                specification: 'bip32',
               });
             }
 
@@ -259,9 +252,8 @@ describe('reference implementation tests', () => {
                 targetNode = node;
               } else {
                 targetNode = await deriveKeyFromPath({
-                  path: path.ours.tuple as HDPathTuple,
+                  path: path.ours.tuple,
                   node,
-                  specification: 'slip10',
                 });
               }
 
@@ -291,7 +283,7 @@ describe('reference implementation tests', () => {
             privateKey: theirPrivateKey,
             publicKey: theirPublicKey,
           } of sampleKeyIndices) {
-            const childNode = await node.derive([`bip32:${index}'`]);
+            const childNode = await node.derive([`slip10:${index}'`]);
 
             expect(childNode.privateKey).toStrictEqual(theirPrivateKey);
             expect(childNode.publicKey).toStrictEqual(theirPublicKey);
@@ -304,9 +296,8 @@ describe('reference implementation tests', () => {
           // Ethereum coin type key
           const node = await createBip39KeyFromSeed(seed, ed25519);
           const childNode = await deriveKeyFromPath({
-            path: [BIP44PurposeNodeToken, `bip32:0'`, `bip32:0'`, `bip32:1'`],
+            path: [`slip10:44'`, `slip10:0'`, `slip10:0'`, `slip10:1'`],
             node,
-            specification: 'slip10',
           });
 
           for (const {
@@ -314,9 +305,8 @@ describe('reference implementation tests', () => {
             privateKey: theirPrivateKey,
           } of sampleKeyIndices) {
             const { privateKey: ourPrivateKey } = await deriveKeyFromPath({
-              path: [`bip32:${index}'`],
+              path: [`slip10:${index}'`],
               node: childNode,
-              specification: 'slip10',
             });
 
             expect(ourPrivateKey).toStrictEqual(theirPrivateKey);

--- a/test/reference-implementations.test.ts
+++ b/test/reference-implementations.test.ts
@@ -1,6 +1,6 @@
 import {
   BIP44Node,
-  SLIP10PathNode,
+  SLIP10Node,
   BIP44PurposeNodeToken,
   HDPathTuple,
 } from '../src';
@@ -215,7 +215,7 @@ describe('reference implementation tests', () => {
           for (const keyObj of vector.keys) {
             const { path, privateKey } = keyObj;
 
-            let targetNode: SLIP10PathNode;
+            let targetNode: SLIP10Node;
 
             // If the path is empty, use the master node
             if (path.ours.string === '') {
@@ -247,7 +247,7 @@ describe('reference implementation tests', () => {
             );
 
             for (const { path, privateKey, publicKey } of keys) {
-              let targetNode: SLIP10PathNode;
+              let targetNode: SLIP10Node;
               if (path.ours.string === '') {
                 targetNode = node;
               } else {


### PR DESCRIPTION
This replaces the specification field added in #120, with a new path type `slip10:`. This means that you can now use something like `["slip10:44'", "slip10:60'", /* ... */]` as derivation path, as well as the current `bip32:` derivation paths. This simplifies the BIP-32 derivation logic, and separates SLIP-10 and BIP-32 specific logic to a separate file.

While BIP-32 and SLIP-10 are mostly the same, there are some subtle differences. Projects that require full compatibility with one or the other spec can now choose based on the path type.

## Example

This works:

```ts
const node = SLIP10Node.fromExtendedKey({
  /* ... */,
  curve: 'secp256k1',
});

node.derive([`slip10:0'`, `slip10:1`]);
```

This also works:

```ts
const node = SLIP10Node.fromExtendedKey({
  /* ... */,
  curve: 'secp256k1',
});

node.derive([`bip32:0'`, `bip32:1`]);
```

This does **not** work anymore:

```ts
const node = SLIP10Node.fromExtendedKey({
  /* ... */,
  curve: 'ed25519', // <-- Note the curve
});

node.derive([`bip32:0'`, `bip32:1`]);
```

## Breaking changes

- `ed25519` can no longer be used with `bip32:` derivation paths, as it's only defined in SLIP-10.