### PR TITLE
Add `isValidBIP32PathSegment` function

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,6 +19,8 @@ export type BIP44Depth = MinBIP44Depth | 1 | 2 | 3 | 4 | MaxBIP44Depth;
 // always "0". Here's an example Ethereum HD path for account "0":
 // m  / 44' / 60' / 0' / 0 / 0
 
+export type UnprefixedNode = `${number}'`;
+
 export type AnonymizedBIP39Node = 'm';
 export type BIP39StringNode = `bip39:${string}`;
 export type BIP39Node = BIP39StringNode | Uint8Array;
@@ -34,6 +36,13 @@ export type SLIP10PathNode = HardenedSLIP10Node | UnhardenedSLIP10Node;
 export const BIP44PurposeNodeToken = `bip32:44'`;
 
 export const UNPREFIXED_PATH_REGEX = /^\d+$/u;
+
+/**
+ * e.g.
+ * -  0
+ * -  0'
+ */
+export const UNPREFIXED_BIP_32_PATH_REGEX = /^(?<index>\d+)'?$/u;
 
 /**
  * e.g.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -4,6 +4,7 @@ import {
   SLIP10Node,
   secp256k1,
   ed25519,
+  isValidBIP32PathSegment,
 } from '.';
 
 // This is purely for coverage shenanigans
@@ -15,5 +16,6 @@ describe('index', () => {
     expect(SLIP10Node).toBeDefined();
     expect(secp256k1).toBeDefined();
     expect(ed25519).toBeDefined();
+    expect(isValidBIP32PathSegment).toBeDefined();
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,5 @@ export {
   getBIP44AddressKeyDeriver,
 } from './BIP44CoinTypeNode';
 export * from './constants';
-export type {
-  CoinTypeToAddressIndices,
-  isValidBIP32PathSegment,
-} from './utils';
+export type { CoinTypeToAddressIndices } from './utils';
+export { isValidBIP32PathSegment } from './utils';

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,4 +28,7 @@ export {
   getBIP44AddressKeyDeriver,
 } from './BIP44CoinTypeNode';
 export * from './constants';
-export type { CoinTypeToAddressIndices, isValidBIP32Path } from './utils';
+export type {
+  CoinTypeToAddressIndices,
+  isValidBIP32PathSegment,
+} from './utils';

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,4 +28,4 @@ export {
   getBIP44AddressKeyDeriver,
 } from './BIP44CoinTypeNode';
 export * from './constants';
-export type { CoinTypeToAddressIndices } from './utils';
+export type { CoinTypeToAddressIndices, isValidBIP32Path } from './utils';

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -208,9 +208,10 @@ describe('isValidBIP32Path', () => {
     expect(isValidBIP32Path(`1000'`)).toBe(true);
   });
 
-  it.each(['foo', `123''`, `'123'`, `123'/456'`])(
+  it.each(['foo', `123''`, `'123'`, `123'/456'`, ...inputs])(
     'returns false if the index is invalid',
     (input) => {
+      // @ts-expect-error Invalid type.
       expect(isValidBIP32Path(input)).toBe(false);
     },
   );

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -23,7 +23,7 @@ import {
   decodeBase58check,
   mnemonicPhraseToBytes,
   getBytesUnsafe,
-  isValidBIP32Path,
+  isValidBIP32PathSegment,
 } from './utils';
 
 // Inputs used for testing non-negative integers
@@ -198,21 +198,21 @@ describe('isValidBIP32Index', () => {
   });
 });
 
-describe('isValidBIP32Path', () => {
+describe('isValidBIP32PathSegment', () => {
   it('returns true if the path is valid', () => {
-    expect(isValidBIP32Path(`0`)).toBe(true);
-    expect(isValidBIP32Path(`0'`)).toBe(true);
-    expect(isValidBIP32Path(`1`)).toBe(true);
-    expect(isValidBIP32Path(`1'`)).toBe(true);
-    expect(isValidBIP32Path(`1000`)).toBe(true);
-    expect(isValidBIP32Path(`1000'`)).toBe(true);
+    expect(isValidBIP32PathSegment(`0`)).toBe(true);
+    expect(isValidBIP32PathSegment(`0'`)).toBe(true);
+    expect(isValidBIP32PathSegment(`1`)).toBe(true);
+    expect(isValidBIP32PathSegment(`1'`)).toBe(true);
+    expect(isValidBIP32PathSegment(`1000`)).toBe(true);
+    expect(isValidBIP32PathSegment(`1000'`)).toBe(true);
   });
 
   it.each(['foo', `123''`, `'123'`, `123'/456'`, ...inputs])(
     'returns false if the index is invalid',
     (input) => {
       // @ts-expect-error Invalid type.
-      expect(isValidBIP32Path(input)).toBe(false);
+      expect(isValidBIP32PathSegment(input)).toBe(false);
     },
   );
 });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -23,6 +23,7 @@ import {
   decodeBase58check,
   mnemonicPhraseToBytes,
   getBytesUnsafe,
+  isValidBIP32Path,
 } from './utils';
 
 // Inputs used for testing non-negative integers
@@ -195,6 +196,24 @@ describe('isValidBIP32Index', () => {
   it.each(inputs)('returns false if the index is invalid', (input) => {
     expect(isValidBIP32Index(input)).toBe(false);
   });
+});
+
+describe('isValidBIP32Path', () => {
+  it('returns true if the path is valid', () => {
+    expect(isValidBIP32Path(`0`)).toBe(true);
+    expect(isValidBIP32Path(`0'`)).toBe(true);
+    expect(isValidBIP32Path(`1`)).toBe(true);
+    expect(isValidBIP32Path(`1'`)).toBe(true);
+    expect(isValidBIP32Path(`1000`)).toBe(true);
+    expect(isValidBIP32Path(`1000'`)).toBe(true);
+  });
+
+  it.each(['foo', `123''`, `'123'`, `123'/456'`])(
+    'returns false if the index is invalid',
+    (input) => {
+      expect(isValidBIP32Path(input)).toBe(false);
+    },
+  );
 });
 
 describe('isHardened', () => {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -199,7 +199,7 @@ describe('isValidBIP32Index', () => {
 });
 
 describe('isValidBIP32PathSegment', () => {
-  it('returns true if the path is valid', () => {
+  it('returns true if the path segment is valid', () => {
     expect(isValidBIP32PathSegment(`0`)).toBe(true);
     expect(isValidBIP32PathSegment(`0'`)).toBe(true);
     expect(isValidBIP32PathSegment(`1`)).toBe(true);
@@ -209,7 +209,7 @@ describe('isValidBIP32PathSegment', () => {
   });
 
   it.each(['foo', `123''`, `'123'`, `123'/456'`, ...inputs])(
-    'returns false if the index is invalid',
+    'returns false if the path segment is invalid',
     (input) => {
       // @ts-expect-error Invalid type.
       expect(isValidBIP32PathSegment(input)).toBe(false);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -176,15 +176,17 @@ export function isValidBIP32Index(index: number): boolean {
  * Check if the value is a valid BIP-32 path segment, i.e., a string of the form
  * `0'`.
  *
- * @param path - The BIP-32 path to test.
- * @returns Whether the path is a valid BIP-32 path.
+ * @param segment - The BIP-32 path segment to test.
+ * @returns Whether the path segment is a valid BIP-32 path segment.
  */
-export function isValidBIP32PathSegment(path: string): path is UnprefixedNode {
-  if (typeof path !== 'string') {
+export function isValidBIP32PathSegment(
+  segment: string,
+): segment is UnprefixedNode {
+  if (typeof segment !== 'string') {
     return false;
   }
 
-  const match = path.match(UNPREFIXED_BIP_32_PATH_REGEX);
+  const match = segment.match(UNPREFIXED_BIP_32_PATH_REGEX);
   if (!match?.groups) {
     return false;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -173,13 +173,13 @@ export function isValidBIP32Index(index: number): boolean {
 }
 
 /**
- * Check if the value is a valid BIP-32 path, i.e., a string of the form
+ * Check if the value is a valid BIP-32 path segment, i.e., a string of the form
  * `0'`.
  *
  * @param path - The BIP-32 path to test.
  * @returns Whether the path is a valid BIP-32 path.
  */
-export function isValidBIP32Path(path: string): path is UnprefixedNode {
+export function isValidBIP32PathSegment(path: string): path is UnprefixedNode {
   if (typeof path !== 'string') {
     return false;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,6 +13,8 @@ import {
   HardenedBIP32Node,
   MAX_BIP_32_INDEX,
   UnhardenedBIP32Node,
+  UNPREFIXED_BIP_32_PATH_REGEX,
+  UnprefixedNode,
 } from './constants';
 import { curves, SupportedCurve } from './curves';
 
@@ -168,6 +170,27 @@ export function validateBIP32Index(addressIndex: number) {
  */
 export function isValidBIP32Index(index: number): boolean {
   return isValidInteger(index) && index <= MAX_BIP_32_INDEX;
+}
+
+/**
+ * Check if the value is a valid BIP-32 path, i.e., a string of the form
+ * `0'`.
+ *
+ * @param path - The BIP-32 path to test.
+ * @returns Whether the path is a valid BIP-32 path.
+ */
+export function isValidBIP32Path(path: string): path is UnprefixedNode {
+  if (typeof path !== 'string') {
+    return false;
+  }
+
+  const match = path.match(UNPREFIXED_BIP_32_PATH_REGEX);
+  if (!match?.groups) {
+    return false;
+  }
+
+  const index = parseInt(match.groups.index, 10);
+  return isValidBIP32Index(index);
 }
 
 /**


### PR DESCRIPTION
This PR adds a new function, `isValidBIP32Path`, which can be used to check if a string is a valid BIP-32 path in the form `${number}'`. It will check if the index is `0 <= n <= 2**32 - 1`.