### PR TITLE
Check if BIP-32 path segment is `<= 2^31-1`

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,8 @@ export const BYTES_KEY_LENGTH = 32;
 export const MIN_BIP_44_DEPTH = 0;
 export const MAX_BIP_44_DEPTH = 5;
 
-export const MAX_BIP_32_INDEX = 0xffffffff;
+export const MAX_UNHARDENED_BIP_32_INDEX = 0x7fffffff; // 2^31 - 1
+export const MAX_BIP_32_INDEX = 0xffffffff; // 2^32 - 1
 
 export type MinBIP44Depth = typeof MIN_BIP_44_DEPTH;
 export type MaxBIP44Depth = typeof MAX_BIP_44_DEPTH;

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -206,9 +206,10 @@ describe('isValidBIP32PathSegment', () => {
     expect(isValidBIP32PathSegment(`1'`)).toBe(true);
     expect(isValidBIP32PathSegment(`1000`)).toBe(true);
     expect(isValidBIP32PathSegment(`1000'`)).toBe(true);
+    expect(isValidBIP32PathSegment(`${2 ** 31 - 1}'`)).toBe(true);
   });
 
-  it.each(['foo', `123''`, `'123'`, `123'/456'`, ...inputs])(
+  it.each([`${2 ** 31}'`, 'foo', `123''`, `'123'`, `123'/456'`, ...inputs])(
     'returns false if the path segment is invalid',
     (input) => {
       // @ts-expect-error Invalid type.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,6 +12,7 @@ import {
   CoinTypeToAddressTuple,
   HardenedBIP32Node,
   MAX_BIP_32_INDEX,
+  MAX_UNHARDENED_BIP_32_INDEX,
   UnhardenedBIP32Node,
   UNPREFIXED_BIP_32_PATH_REGEX,
   UnprefixedNode,
@@ -192,7 +193,7 @@ export function isValidBIP32PathSegment(
   }
 
   const index = parseInt(match.groups.index, 10);
-  return isValidBIP32Index(index);
+  return isValidInteger(index) && index <= MAX_UNHARDENED_BIP_32_INDEX;
 }
 
 /**


### PR DESCRIPTION
Rather than checking if the segment is within `2^32-1` (max value for hardened indices), we need to check if the index is within `2^31-1` (max value for unhardened indices).