### PR TITLE
Export `mnemonicPhraseToBytes` and `createBip39KeyFromSeed`

### DIFF
--- a/src/derivers/index.test.ts
+++ b/src/derivers/index.test.ts
@@ -1,0 +1,7 @@
+import { createBip39KeyFromSeed } from '.';
+
+describe('index', () => {
+  it('has expected exports', () => {
+    expect(createBip39KeyFromSeed).toBeDefined();
+  });
+});

--- a/src/derivers/index.ts
+++ b/src/derivers/index.ts
@@ -1,8 +1,8 @@
-import type { Curve } from '../curves';
-import type { SLIP10Node } from '../SLIP10Node';
 import * as bip32 from './bip32';
 import * as bip39 from './bip39';
 import * as slip10 from './slip10';
+import type { Curve } from '../curves';
+import type { SLIP10Node } from '../SLIP10Node';
 
 export type DerivedKeys = {
   /**
@@ -28,3 +28,5 @@ export const derivers = {
   bip39,
   slip10,
 };
+
+export { createBip39KeyFromSeed } from './bip39';

--- a/src/derivers/index.ts
+++ b/src/derivers/index.ts
@@ -1,8 +1,8 @@
+import type { Curve } from '../curves';
+import type { SLIP10Node } from '../SLIP10Node';
 import * as bip32 from './bip32';
 import * as bip39 from './bip39';
 import * as slip10 from './slip10';
-import type { Curve } from '../curves';
-import type { SLIP10Node } from '../SLIP10Node';
 
 export type DerivedKeys = {
   /**

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -5,6 +5,8 @@ import {
   secp256k1,
   ed25519,
   isValidBIP32PathSegment,
+  createBip39KeyFromSeed,
+  mnemonicPhraseToBytes,
 } from '.';
 
 // This is purely for coverage shenanigans
@@ -17,5 +19,7 @@ describe('index', () => {
     expect(secp256k1).toBeDefined();
     expect(ed25519).toBeDefined();
     expect(isValidBIP32PathSegment).toBeDefined();
+    expect(createBip39KeyFromSeed).toBeDefined();
+    expect(mnemonicPhraseToBytes).toBeDefined();
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,4 +29,5 @@ export {
 } from './BIP44CoinTypeNode';
 export * from './constants';
 export type { CoinTypeToAddressIndices } from './utils';
-export { isValidBIP32PathSegment } from './utils';
+export { isValidBIP32PathSegment, mnemonicPhraseToBytes } from './utils';
+export { createBip39KeyFromSeed } from './derivers';


### PR DESCRIPTION
These functions are used in the Snaps repo, but cannot be imported anymore from `./dist` after #147.