### PR TITLE
Support Cardano key derivation according to CIP3-Icarus

### DIFF
--- a/scripts/generate-vectors.ts
+++ b/scripts/generate-vectors.ts
@@ -12,7 +12,7 @@ import {
 } from '../src';
 import { type Curve } from '../src/curves';
 import {
-  entropyToCip3IcarusMasterNode,
+  entropyToCip3MasterNode,
   createBip39KeyFromSeed,
 } from '../src/derivers/bip39';
 
@@ -62,7 +62,7 @@ function getRandomSeed(length = randomInt(16, 64)) {
  * @returns A random BIP-32 path.
  */
 function getRandomPath(
-  spec: 'bip32' | 'slip10' | 'cip3Icarus',
+  spec: 'bip32' | 'slip10' | 'cip3',
   length = randomInt(1, 20),
   hardened?: boolean,
 ) {
@@ -88,7 +88,7 @@ function getRandomPath(
  */
 async function getRandomKeyVector(
   node: SLIP10Node,
-  spec: 'bip32' | 'slip10' | 'cip3Icarus',
+  spec: 'bip32' | 'slip10' | 'cip3',
   hardened?: boolean,
 ) {
   const path = getRandomPath(spec, undefined, hardened);
@@ -120,7 +120,7 @@ async function getRandomKeyVector(
  * @param curve - The curve to use. Defaults to secp256k1.
  */
 async function getRandomVector(
-  spec: 'bip32' | 'slip10' | 'cip3Icarus',
+  spec: 'bip32' | 'slip10' | 'cip3',
   amount = 10,
   hardened?: boolean,
   curve: Curve = secp256k1,
@@ -130,7 +130,7 @@ async function getRandomVector(
     curve.masterNodeGenerationSpec === 'slip10'
       ? await createBip39KeyFromSeed(seed, curve)
       : // in the context of tests, we assume seed to be just random bytes which we use here as entropy
-        await entropyToCip3IcarusMasterNode(seed, curve);
+        await entropyToCip3MasterNode(seed, curve);
 
   return {
     hexSeed: bytesToHex(seed),
@@ -161,7 +161,7 @@ async function getRandomVector(
  * @returns The random vectors.
  */
 async function getRandomVectors(
-  spec: 'bip32' | 'slip10' | 'cip3Icarus',
+  spec: 'bip32' | 'slip10' | 'cip3',
   amount = 10,
   hardened?: boolean,
   curve: Curve = secp256k1,
@@ -193,10 +193,10 @@ async function getOutput() {
       unhardened: await getRandomVectors('slip10', 50, false),
       mixed: await getRandomVectors('bip32', 50),
     },
-    cip3Icarus: {
-      hardened: await getRandomVectors('cip3Icarus', 50, true, ed25519Bip32),
-      unhardened: await getRandomVectors('cip3Icarus', 50, false, ed25519Bip32),
-      mixed: await getRandomVectors('cip3Icarus', 50, undefined, ed25519Bip32),
+    cip3: {
+      hardened: await getRandomVectors('cip3', 50, true, ed25519Bip32),
+      unhardened: await getRandomVectors('cip3', 50, false, ed25519Bip32),
+      mixed: await getRandomVectors('cip3', 50, undefined, ed25519Bip32),
     },
   };
 }

--- a/scripts/generate-vectors.ts
+++ b/scripts/generate-vectors.ts
@@ -11,10 +11,7 @@ import {
   ed25519Bip32,
 } from '../src';
 import { type Curve } from '../src/curves';
-import {
-  entropyToCip3MasterNode,
-  createBip39KeyFromSeed,
-} from '../src/derivers/bip39';
+import { deriveChildKey } from '../src/derivers/bip39';
 
 /**
  * Get a random boolean value.
@@ -126,11 +123,7 @@ async function getRandomVector(
   curve: Curve = secp256k1,
 ) {
   const seed = getRandomSeed();
-  const node =
-    curve.masterNodeGenerationSpec === 'slip10'
-      ? await createBip39KeyFromSeed(seed, curve)
-      : // in the context of tests, we assume seed to be just random bytes which we use here as entropy
-        await entropyToCip3MasterNode(seed, curve);
+  const node = await deriveChildKey({ path: seed, curve });
 
   return {
     hexSeed: bytesToHex(seed),

--- a/scripts/generate-vectors.ts
+++ b/scripts/generate-vectors.ts
@@ -8,9 +8,13 @@ import {
   ed25519,
   MAX_BIP_32_INDEX,
   secp256k1,
+  ed25519Bip32,
 } from '../src';
-import type { Curve } from '../src/curves';
-import { createBip39KeyFromSeed } from '../src/derivers/bip39';
+import { type Curve } from '../src/curves';
+import {
+  entropyToCip3IcarusMasterNode,
+  createBip39KeyFromSeed,
+} from '../src/derivers/bip39';
 
 /**
  * Get a random boolean value.
@@ -58,7 +62,7 @@ function getRandomSeed(length = randomInt(16, 64)) {
  * @returns A random BIP-32 path.
  */
 function getRandomPath(
-  spec: 'bip32' | 'slip10',
+  spec: 'bip32' | 'slip10' | 'cip3Icarus',
   length = randomInt(1, 20),
   hardened?: boolean,
 ) {
@@ -84,7 +88,7 @@ function getRandomPath(
  */
 async function getRandomKeyVector(
   node: SLIP10Node,
-  spec: 'bip32' | 'slip10',
+  spec: 'bip32' | 'slip10' | 'cip3Icarus',
   hardened?: boolean,
 ) {
   const path = getRandomPath(spec, undefined, hardened);
@@ -116,13 +120,17 @@ async function getRandomKeyVector(
  * @param curve - The curve to use. Defaults to secp256k1.
  */
 async function getRandomVector(
-  spec: 'bip32' | 'slip10',
+  spec: 'bip32' | 'slip10' | 'cip3Icarus',
   amount = 10,
   hardened?: boolean,
   curve: Curve = secp256k1,
 ) {
   const seed = getRandomSeed();
-  const node = await createBip39KeyFromSeed(seed, curve);
+  const node =
+    curve.masterNodeGenerationSpec === 'slip10'
+      ? await createBip39KeyFromSeed(seed, curve)
+      : // in the context of tests, we assume seed to be just random bytes which we use here as entropy
+        await entropyToCip3IcarusMasterNode(seed, curve);
 
   return {
     hexSeed: bytesToHex(seed),
@@ -153,7 +161,7 @@ async function getRandomVector(
  * @returns The random vectors.
  */
 async function getRandomVectors(
-  spec: 'bip32' | 'slip10',
+  spec: 'bip32' | 'slip10' | 'cip3Icarus',
   amount = 10,
   hardened?: boolean,
   curve: Curve = secp256k1,
@@ -184,6 +192,11 @@ async function getOutput() {
       },
       unhardened: await getRandomVectors('slip10', 50, false),
       mixed: await getRandomVectors('bip32', 50),
+    },
+    cip3Icarus: {
+      hardened: await getRandomVectors('cip3Icarus', 50, true, ed25519Bip32),
+      unhardened: await getRandomVectors('cip3Icarus', 50, false, ed25519Bip32),
+      mixed: await getRandomVectors('cip3Icarus', 50, undefined, ed25519Bip32),
     },
   };
 }

--- a/src/SLIP10Node.test.ts
+++ b/src/SLIP10Node.test.ts
@@ -525,7 +525,7 @@ describe('SLIP10Node', () => {
           specification: 'bip32',
         }),
       ).rejects.toThrow(
-        'Invalid curve: Only the following curves are supported: secp256k1, ed25519.',
+        'Invalid curve: Only the following curves are supported: secp256k1, ed25519, ed25519Bip32.',
       );
     });
   });

--- a/src/SLIP10Node.ts
+++ b/src/SLIP10Node.ts
@@ -347,7 +347,10 @@ export class SLIP10Node implements SLIP10NodeInterface {
   }
 
   public get fingerprint(): number {
-    return getFingerprint(this.compressedPublicKeyBytes);
+    return getFingerprint(
+      this.compressedPublicKeyBytes,
+      getCurveByName(this.curve).compressedPublicKeyLength,
+    );
   }
 
   /**

--- a/src/SLIP10Node.ts
+++ b/src/SLIP10Node.ts
@@ -171,7 +171,10 @@ export class SLIP10Node implements SLIP10NodeInterface {
     const curveObject = getCurveByName(curve);
 
     if (privateKey) {
-      const privateKeyBytes = getBytesUnsafe(privateKey, BYTES_KEY_LENGTH);
+      const privateKeyBytes = getBytesUnsafe(
+        privateKey,
+        curveObject.privateKeyLength,
+      );
       assert(
         curveObject.isValidPrivateKey(privateKeyBytes),
         `Invalid private key: Value is not a valid ${curve} private key.`,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -34,6 +34,12 @@ export type HardenedSLIP10Node = `slip10:${number}'`;
 export type UnhardenedSLIP10Node = `slip10:${number}`;
 export type SLIP10PathNode = HardenedSLIP10Node | UnhardenedSLIP10Node;
 
+export type HardenedCIP3IcarusNode = `cip3Icarus:${number}'`;
+export type UnhardenedCIP3IcarusNode = `cip3Icarus:${number}`;
+export type CIP3IcarusPathNode =
+  | HardenedCIP3IcarusNode
+  | UnhardenedCIP3IcarusNode;
+
 export const BIP44PurposeNodeToken = `bip32:44'`;
 
 export const UNPREFIXED_PATH_REGEX = /^\d+$/u;
@@ -58,6 +64,13 @@ export const BIP_32_PATH_REGEX = /^bip32:\d+'?$/u;
  * -  slip10:0'
  */
 export const SLIP_10_PATH_REGEX = /^slip10:\d+'?$/u;
+
+/**
+ * e.g.
+ * -  cip3Icarus:0
+ * -  cip3Icarus:0'
+ */
+export const CIP_3_ICARUS_PATH_REGEX = /^cip3Icarus:\d+'?$/u;
 
 /**
  * bip39:<SPACE_DELMITED_SEED_PHRASE>
@@ -164,10 +177,13 @@ export type HDPathTuple = RootedHDPathTuple | PartialHDPathTuple;
 
 export type RootedSLIP10PathTuple = readonly [
   BIP39Node,
-  ...(BIP32Node[] | SLIP10PathNode[]),
+  ...(BIP32Node[] | SLIP10PathNode[] | CIP3IcarusPathNode[]),
 ];
 
-export type SLIP10PathTuple = readonly BIP32Node[] | readonly SLIP10PathNode[];
+export type SLIP10PathTuple =
+  | readonly BIP32Node[]
+  | readonly SLIP10PathNode[]
+  | readonly CIP3IcarusPathNode[];
 export type SLIP10Path = RootedSLIP10PathTuple | SLIP10PathTuple;
 
 export type FullHDPathTuple = RootedHDPathTuple5;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -34,11 +34,9 @@ export type HardenedSLIP10Node = `slip10:${number}'`;
 export type UnhardenedSLIP10Node = `slip10:${number}`;
 export type SLIP10PathNode = HardenedSLIP10Node | UnhardenedSLIP10Node;
 
-export type HardenedCIP3IcarusNode = `cip3Icarus:${number}'`;
-export type UnhardenedCIP3IcarusNode = `cip3Icarus:${number}`;
-export type CIP3IcarusPathNode =
-  | HardenedCIP3IcarusNode
-  | UnhardenedCIP3IcarusNode;
+export type HardenedCIP3Node = `cip3:${number}'`;
+export type UnhardenedCIP3Node = `cip3:${number}`;
+export type CIP3PathNode = HardenedCIP3Node | UnhardenedCIP3Node;
 
 export const BIP44PurposeNodeToken = `bip32:44'`;
 
@@ -67,10 +65,10 @@ export const SLIP_10_PATH_REGEX = /^slip10:\d+'?$/u;
 
 /**
  * e.g.
- * -  cip3Icarus:0
- * -  cip3Icarus:0'
+ * -  cip3:0
+ * -  cip3:0'
  */
-export const CIP_3_ICARUS_PATH_REGEX = /^cip3Icarus:\d+'?$/u;
+export const CIP_3_PATH_REGEX = /^cip3:\d+'?$/u;
 
 /**
  * bip39:<SPACE_DELMITED_SEED_PHRASE>
@@ -177,13 +175,13 @@ export type HDPathTuple = RootedHDPathTuple | PartialHDPathTuple;
 
 export type RootedSLIP10PathTuple = readonly [
   BIP39Node,
-  ...(BIP32Node[] | SLIP10PathNode[] | CIP3IcarusPathNode[]),
+  ...(BIP32Node[] | SLIP10PathNode[] | CIP3PathNode[]),
 ];
 
 export type SLIP10PathTuple =
   | readonly BIP32Node[]
   | readonly SLIP10PathNode[]
-  | readonly CIP3IcarusPathNode[];
+  | readonly CIP3PathNode[];
 export type SLIP10Path = RootedSLIP10PathTuple | SLIP10PathTuple;
 
 export type FullHDPathTuple = RootedHDPathTuple5;

--- a/src/curves/curve.ts
+++ b/src/curves/curve.ts
@@ -25,6 +25,7 @@ export type Curve = {
   publicAdd: (publicKey: Uint8Array, tweak: Uint8Array) => Uint8Array;
   compressPublicKey: (publicKey: Uint8Array) => Uint8Array;
   decompressPublicKey: (publicKey: Uint8Array) => Uint8Array;
+  privateKeyLength: number;
 } & (
   | {
       masterNodeGenerationSpec: 'slip10';

--- a/src/curves/curve.ts
+++ b/src/curves/curve.ts
@@ -33,7 +33,7 @@ export type Curve = {
     }
   | {
       name: Extract<SupportedCurve, 'ed25519Bip32'>;
-      masterNodeGenerationSpec: 'cip3Icarus';
+      masterNodeGenerationSpec: 'cip3';
     }
 );
 

--- a/src/curves/curve.ts
+++ b/src/curves/curve.ts
@@ -10,6 +10,16 @@ export const curves = {
   ed25519Bip32,
 };
 
+type CurveSpecification =
+  | {
+      masterNodeGenerationSpec: 'slip10';
+      name: Extract<SupportedCurve, 'secp256k1' | 'ed25519'>;
+    }
+  | {
+      name: Extract<SupportedCurve, 'ed25519Bip32'>;
+      masterNodeGenerationSpec: 'cip3';
+    };
+
 export type Curve = {
   secret: Uint8Array;
   deriveUnhardenedKeys: boolean;
@@ -27,16 +37,7 @@ export type Curve = {
   decompressPublicKey: (publicKey: Uint8Array) => Uint8Array;
   privateKeyLength: number;
   compressedPublicKeyLength: number;
-} & (
-  | {
-      masterNodeGenerationSpec: 'slip10';
-      name: Extract<SupportedCurve, 'secp256k1' | 'ed25519'>;
-    }
-  | {
-      name: Extract<SupportedCurve, 'ed25519Bip32'>;
-      masterNodeGenerationSpec: 'cip3';
-    }
-);
+} & CurveSpecification;
 
 /**
  * Get a curve by name.

--- a/src/curves/curve.ts
+++ b/src/curves/curve.ts
@@ -1,4 +1,5 @@
 import * as ed25519 from './ed25519';
+import * as ed25519Bip32 from './ed25519Bip32';
 import * as secp256k1 from './secp256k1';
 
 export type SupportedCurve = keyof typeof curves;
@@ -6,10 +7,10 @@ export type SupportedCurve = keyof typeof curves;
 export const curves = {
   secp256k1,
   ed25519,
+  ed25519Bip32,
 };
 
 export type Curve = {
-  name: SupportedCurve;
   secret: Uint8Array;
   deriveUnhardenedKeys: boolean;
   publicKeyLength: number;
@@ -24,7 +25,16 @@ export type Curve = {
   publicAdd: (publicKey: Uint8Array, tweak: Uint8Array) => Uint8Array;
   compressPublicKey: (publicKey: Uint8Array) => Uint8Array;
   decompressPublicKey: (publicKey: Uint8Array) => Uint8Array;
-};
+} & (
+  | {
+      masterNodeGenerationSpec: 'slip10';
+      name: Extract<SupportedCurve, 'secp256k1' | 'ed25519'>;
+    }
+  | {
+      name: Extract<SupportedCurve, 'ed25519Bip32'>;
+      masterNodeGenerationSpec: 'cip3Icarus';
+    }
+);
 
 /**
  * Get a curve by name.

--- a/src/curves/curve.ts
+++ b/src/curves/curve.ts
@@ -26,6 +26,7 @@ export type Curve = {
   compressPublicKey: (publicKey: Uint8Array) => Uint8Array;
   decompressPublicKey: (publicKey: Uint8Array) => Uint8Array;
   privateKeyLength: number;
+  compressedPublicKeyLength: number;
 } & (
   | {
       masterNodeGenerationSpec: 'slip10';

--- a/src/curves/ed25519.ts
+++ b/src/curves/ed25519.ts
@@ -41,3 +41,5 @@ export const decompressPublicKey = (publicKey: Uint8Array): Uint8Array => {
   // Ed25519 public keys don't have a compressed form.
   return publicKey;
 };
+
+export const masterNodeGenerationSpec = 'slip10';

--- a/src/curves/ed25519.ts
+++ b/src/curves/ed25519.ts
@@ -42,4 +42,6 @@ export const decompressPublicKey = (publicKey: Uint8Array): Uint8Array => {
   return publicKey;
 };
 
+export const privateKeyLength = 32;
+
 export const masterNodeGenerationSpec = 'slip10';

--- a/src/curves/ed25519.ts
+++ b/src/curves/ed25519.ts
@@ -45,3 +45,5 @@ export const decompressPublicKey = (publicKey: Uint8Array): Uint8Array => {
 export const privateKeyLength = 32;
 
 export const masterNodeGenerationSpec = 'slip10';
+
+export const compressedPublicKeyLength = 33;

--- a/src/curves/ed25519Bip32.test.ts
+++ b/src/curves/ed25519Bip32.test.ts
@@ -18,7 +18,7 @@ describe('getPublicKey', () => {
 });
 
 describe('publicAdd', () => {
-  it(`returns correct public key from private key`, async () => {
+  it('returns correct public key from private key', async () => {
     const publicKey = hexToBytes(fixtures.cip3[0].nodes.bip39Node.publicKey);
     const tweak = hexToBytes(fixtures.cip3[0].nodes.purposeNode.publicKey);
     const added = ed25519Bip32.publicAdd(publicKey, tweak);

--- a/src/curves/ed25519Bip32.test.ts
+++ b/src/curves/ed25519Bip32.test.ts
@@ -1,0 +1,34 @@
+import { bytesToHex, hexToBytes } from '@metamask/utils';
+
+import { ed25519Bip32 } from '.';
+import fixtures from '../../test/fixtures';
+
+describe('getPublicKey', () => {
+  fixtures.cip3Icarus.forEach((fixture) => {
+    Object.values(fixture.nodes).forEach((node) => {
+      it(`returns correct public key from private key`, async () => {
+        const publicKey = await ed25519Bip32.getPublicKey(
+          hexToBytes(node.privateKey),
+        );
+
+        expect(bytesToHex(publicKey)).toBe(node.publicKey);
+      });
+    });
+  });
+});
+
+describe('publicAdd', () => {
+  it(`returns correct public key from private key`, async () => {
+    const _publicKey = hexToBytes(
+      fixtures.cip3Icarus[0].nodes.bip39Node.publicKey,
+    );
+    const _tweak = hexToBytes(
+      fixtures.cip3Icarus[0].nodes.purposeNode.publicKey,
+    );
+    const added = ed25519Bip32.publicAdd(_publicKey, _tweak);
+
+    expect(bytesToHex(added)).toBe(
+      '0xf78d2a445afe9c961ac196fbac282b499d9ab6bbe8801354ee06fc22d46503e2',
+    );
+  });
+});

--- a/src/curves/ed25519Bip32.test.ts
+++ b/src/curves/ed25519Bip32.test.ts
@@ -19,9 +19,9 @@ describe('getPublicKey', () => {
 
 describe('publicAdd', () => {
   it(`returns correct public key from private key`, async () => {
-    const _publicKey = hexToBytes(fixtures.cip3[0].nodes.bip39Node.publicKey);
-    const _tweak = hexToBytes(fixtures.cip3[0].nodes.purposeNode.publicKey);
-    const added = ed25519Bip32.publicAdd(_publicKey, _tweak);
+    const publicKey = hexToBytes(fixtures.cip3[0].nodes.bip39Node.publicKey);
+    const tweak = hexToBytes(fixtures.cip3[0].nodes.purposeNode.publicKey);
+    const added = ed25519Bip32.publicAdd(publicKey, tweak);
 
     expect(bytesToHex(added)).toBe(
       '0xf78d2a445afe9c961ac196fbac282b499d9ab6bbe8801354ee06fc22d46503e2',

--- a/src/curves/ed25519Bip32.test.ts
+++ b/src/curves/ed25519Bip32.test.ts
@@ -2,6 +2,13 @@ import { bytesToHex, hexToBytes } from '@metamask/utils';
 
 import { ed25519Bip32 } from '.';
 import fixtures from '../../test/fixtures';
+import {
+  bytesToNumberLE,
+  compressPublicKey,
+  decompressPublicKey,
+  isValidPrivateKey,
+  multiplyWithBase,
+} from './ed25519Bip32';
 
 describe('getPublicKey', () => {
   fixtures.cip3.forEach((fixture) => {
@@ -26,5 +33,58 @@ describe('publicAdd', () => {
     expect(bytesToHex(added)).toBe(
       '0xf78d2a445afe9c961ac196fbac282b499d9ab6bbe8801354ee06fc22d46503e2',
     );
+  });
+});
+
+describe('isValidPrivateKey', () => {
+  it('returns true for bigint input', () => {
+    const { privateKey } = fixtures.cip3[0].nodes.bip39Node;
+    expect(isValidPrivateKey(privateKey)).toBe(true);
+  });
+});
+
+describe('compressPublicKey', () => {
+  it('returns the same Uint8Array that was input', () => {
+    const publicKey = Uint8Array.from(
+      Buffer.from(fixtures.cip3[0].nodes.bip39Node.publicKey, 'hex'),
+    );
+    expect(compressPublicKey(publicKey)).toStrictEqual(publicKey);
+  });
+});
+
+describe('decompressPublicKey', () => {
+  it('returns the same Uint8Array that was input', () => {
+    const publicKey = Uint8Array.from(
+      Buffer.from(fixtures.cip3[0].nodes.bip39Node.publicKey, 'hex'),
+    );
+    expect(decompressPublicKey(publicKey)).toStrictEqual(publicKey);
+  });
+});
+
+describe('bytesToNumberLE', () => {
+  it('converts bytes to little endian bignumber', () => {
+    const bytes = Uint8Array.from([
+      240, 230, 228, 13, 229, 184, 174, 13, 156, 72, 248, 206, 127, 130, 146,
+      49, 175, 244, 32, 215, 146, 255, 153, 93, 197, 96, 64, 249, 123, 140, 119,
+      72,
+    ]);
+    expect(bytesToNumberLE(bytes)).toBe(
+      32777749485515042639882960539696351427945957558989008047469858024981459691248n,
+    );
+  });
+});
+
+describe('multiplyWithBase', () => {
+  it('multiplies bytes with the curve base', () => {
+    const bytes = Uint8Array.from([
+      240, 230, 228, 13, 229, 184, 174, 13, 156, 72, 248, 206, 127, 130, 146,
+      49, 175, 244, 32, 215, 146, 255, 153, 93, 197, 96, 64, 249, 123, 140, 119,
+      72,
+    ]);
+    const expectedResult = Uint8Array.from([
+      64, 197, 223, 88, 143, 127, 45, 60, 205, 81, 148, 125, 195, 249, 173, 214,
+      27, 176, 227, 21, 216, 243, 146, 168, 189, 206, 85, 135, 89, 11, 210, 27,
+    ]);
+    expect(multiplyWithBase(bytes)).toStrictEqual(expectedResult);
   });
 });

--- a/src/curves/ed25519Bip32.test.ts
+++ b/src/curves/ed25519Bip32.test.ts
@@ -6,7 +6,7 @@ import fixtures from '../../test/fixtures';
 describe('getPublicKey', () => {
   fixtures.cip3.forEach((fixture) => {
     Object.values(fixture.nodes).forEach((node) => {
-      it(`returns correct public key from private key`, async () => {
+      it('returns correct public key from private key', async () => {
         const publicKey = await ed25519Bip32.getPublicKey(
           hexToBytes(node.privateKey),
         );

--- a/src/curves/ed25519Bip32.test.ts
+++ b/src/curves/ed25519Bip32.test.ts
@@ -4,7 +4,7 @@ import { ed25519Bip32 } from '.';
 import fixtures from '../../test/fixtures';
 
 describe('getPublicKey', () => {
-  fixtures.cip3Icarus.forEach((fixture) => {
+  fixtures.cip3.forEach((fixture) => {
     Object.values(fixture.nodes).forEach((node) => {
       it(`returns correct public key from private key`, async () => {
         const publicKey = await ed25519Bip32.getPublicKey(
@@ -19,12 +19,8 @@ describe('getPublicKey', () => {
 
 describe('publicAdd', () => {
   it(`returns correct public key from private key`, async () => {
-    const _publicKey = hexToBytes(
-      fixtures.cip3Icarus[0].nodes.bip39Node.publicKey,
-    );
-    const _tweak = hexToBytes(
-      fixtures.cip3Icarus[0].nodes.purposeNode.publicKey,
-    );
+    const _publicKey = hexToBytes(fixtures.cip3[0].nodes.bip39Node.publicKey);
+    const _tweak = hexToBytes(fixtures.cip3[0].nodes.purposeNode.publicKey);
     const added = ed25519Bip32.publicAdd(_publicKey, _tweak);
 
     expect(bytesToHex(added)).toBe(

--- a/src/curves/ed25519Bip32.ts
+++ b/src/curves/ed25519Bip32.ts
@@ -77,16 +77,16 @@ export const getPublicKey = async (
 /**
  * Adds a tweak to a public key.
  *
- * @param _publicKey - The public key.
- * @param _tweak - The tweak to add.
+ * @param publicKey - The public key.
+ * @param tweak - The tweak to add.
  * @returns The resulting public key.
  */
 export const publicAdd = (
   publicKey: Uint8Array,
   tweak: Uint8Array,
 ): Uint8Array => {
-  return ed25519.ExtendedPoint.fromHex(remove0x(bytesToHex(_publicKey)))
-    .add(ed25519.ExtendedPoint.fromHex(remove0x(bytesToHex(_tweak))))
+  return ed25519.ExtendedPoint.fromHex(remove0x(bytesToHex(publicKey)))
+    .add(ed25519.ExtendedPoint.fromHex(remove0x(bytesToHex(tweak))))
     .toRawBytes();
 };
 

--- a/src/curves/ed25519Bip32.ts
+++ b/src/curves/ed25519Bip32.ts
@@ -82,4 +82,6 @@ export const decompressPublicKey = (publicKey: Uint8Array): Uint8Array => {
   return publicKey;
 };
 
+export const privateKeyLength = 64;
+
 export const masterNodeGenerationSpec = 'cip3Icarus';

--- a/src/curves/ed25519Bip32.ts
+++ b/src/curves/ed25519Bip32.ts
@@ -81,3 +81,5 @@ export const decompressPublicKey = (publicKey: Uint8Array): Uint8Array => {
   // Ed25519 public keys don't have a compressed form.
   return publicKey;
 };
+
+export const masterNodeGenerationSpec = 'cip3Icarus';

--- a/src/curves/ed25519Bip32.ts
+++ b/src/curves/ed25519Bip32.ts
@@ -1,0 +1,83 @@
+import {
+  stringToBytes,
+  bytesToHex,
+  hexToBigInt,
+  remove0x,
+} from '@metamask/utils';
+import { mod } from '@noble/curves/abstract/modular';
+import { ed25519 } from '@noble/curves/ed25519';
+
+export const curve = ed25519.CURVE;
+
+/**
+ * Named after whitepaper: BIP32-Ed25519 Hierarchical Deterministic Keys over a Non-linear Keyspace
+ * https://input-output-hk.github.io/adrestia/static/Ed25519_BIP.pdf
+ * "vanilla" "ed25519" curve follows SLIP10: https://tezos.stackexchange.com/questions/2837/can-i-use-bip32-hd-key-pairs-to-derive-ed25519-addresses
+ * note that that the important difference of the "bip32" version is that it allows unhardened key derivation
+ */
+export const name = 'ed25519Bip32';
+
+// Secret is empty string if not provided by user
+export const secret = stringToBytes('');
+
+/**
+ * Always returns true.
+ * For root node derivation, https://github.com/cardano-foundation/CIPs/blob/09d7d8ee1bd64f7e6b20b5a6cae088039dce00cb/CIP-0003/Icarus.md does not mention any cases when the private key is invalid.
+ * For child node derivation, https://input-output-hk.github.io/adrestia/static/Ed25519_BIP.pdf does not mention any cases when the private key is invalid.
+ *
+ * @param _privateKey - The private key to check.
+ * @returns True.
+ */
+export const isValidPrivateKey = (_privateKey: Uint8Array | string | bigint) =>
+  true;
+
+export const deriveUnhardenedKeys = true;
+
+export const publicKeyLength = 32;
+
+const bytesToNumberLE = (bytes: Uint8Array): bigint => {
+  return hexToBigInt(bytesToHex(Uint8Array.from(bytes).reverse()));
+};
+
+const modN = (a: bigint) => {
+  return mod(a, curve.n);
+};
+
+// Little-endian SHA512 with modulo n
+const modNLE = (hash: Uint8Array): bigint => {
+  return modN(bytesToNumberLE(hash));
+};
+
+// equivalent to https://github.com/jedisct1/libsodium/blob/93a6e79750a31bc0b946bf483b2ba1c77f9e94ce/src/libsodium/crypto_scalarmult/ed25519/ref10/scalarmult_ed25519_ref10.c#L105
+// which is used by cardano-js-sdk/crypto https://github.com/input-output-hk/cardano-js-sdk/blob/8a6db2a251cd1c956f52730a0d35de2b7fc67404/packages/crypto/src/Bip32/Bip32PrivateKey.ts#L161
+const multiplyWithBase = (key: Uint8Array): Uint8Array => {
+  const scalar = modNLE(key); // The actual scalar
+  const point = ed25519.ExtendedPoint.BASE.multiply(scalar); // Point on Edwards curve aka public key
+  return point.toRawBytes(); // Uint8Array representation
+};
+
+export const getPublicKey = async (
+  privateKey: Uint8Array,
+  _compressed?: boolean,
+): Promise<Uint8Array> => {
+  return multiplyWithBase(privateKey.slice(0, 32));
+};
+
+export const publicAdd = (
+  _publicKey: Uint8Array,
+  _tweak: Uint8Array,
+): Uint8Array => {
+  return ed25519.ExtendedPoint.fromHex(remove0x(bytesToHex(_publicKey)))
+    .add(ed25519.ExtendedPoint.fromHex(remove0x(bytesToHex(_tweak))))
+    .toRawBytes();
+};
+
+export const compressPublicKey = (publicKey: Uint8Array): Uint8Array => {
+  // Ed25519 public keys don't have a compressed form.
+  return publicKey;
+};
+
+export const decompressPublicKey = (publicKey: Uint8Array): Uint8Array => {
+  // Ed25519 public keys don't have a compressed form.
+  return publicKey;
+};

--- a/src/curves/ed25519Bip32.ts
+++ b/src/curves/ed25519Bip32.ts
@@ -39,19 +39,11 @@ const bytesToNumberLE = (bytes: Uint8Array): bigint => {
   return hexToBigInt(bytesToHex(Uint8Array.from(bytes).reverse()));
 };
 
-const modN = (a: bigint) => {
-  return mod(a, curve.n);
-};
-
-// Little-endian SHA512 with modulo n
-const modNLE = (hash: Uint8Array): bigint => {
-  return modN(bytesToNumberLE(hash));
-};
-
 // equivalent to https://github.com/jedisct1/libsodium/blob/93a6e79750a31bc0b946bf483b2ba1c77f9e94ce/src/libsodium/crypto_scalarmult/ed25519/ref10/scalarmult_ed25519_ref10.c#L105
 // which is used by cardano-js-sdk/crypto https://github.com/input-output-hk/cardano-js-sdk/blob/8a6db2a251cd1c956f52730a0d35de2b7fc67404/packages/crypto/src/Bip32/Bip32PrivateKey.ts#L161
 const multiplyWithBase = (key: Uint8Array): Uint8Array => {
-  const scalar = modNLE(key); // The actual scalar
+  // Little-endian SHA512 with modulo n
+  const scalar = mod(bytesToNumberLE(key), curve.n); // The actual scalar
   const point = ed25519.ExtendedPoint.BASE.multiply(scalar); // Point on Edwards curve aka public key
   return point.toRawBytes(); // Uint8Array representation
 };

--- a/src/curves/ed25519Bip32.ts
+++ b/src/curves/ed25519Bip32.ts
@@ -85,3 +85,5 @@ export const decompressPublicKey = (publicKey: Uint8Array): Uint8Array => {
 export const privateKeyLength = 64;
 
 export const masterNodeGenerationSpec = 'cip3';
+
+export const compressedPublicKeyLength = 32;

--- a/src/curves/ed25519Bip32.ts
+++ b/src/curves/ed25519Bip32.ts
@@ -41,7 +41,7 @@ export const publicKeyLength = 32;
  * @param bytes - The Uint8Array of bytes to convert.
  * @returns The converted bigint value.
  */
-const bytesToNumberLE = (bytes: Uint8Array): bigint => {
+export const bytesToNumberLE = (bytes: Uint8Array): bigint => {
   return hexToBigInt(bytesToHex(Uint8Array.from(bytes).reverse()));
 };
 
@@ -53,7 +53,7 @@ const bytesToNumberLE = (bytes: Uint8Array): bigint => {
  * @param key - The key to multiply with the base point.
  * @returns The resulting point on the Edwards curve.
  */
-const multiplyWithBase = (key: Uint8Array): Uint8Array => {
+export const multiplyWithBase = (key: Uint8Array): Uint8Array => {
   // Little-endian SHA512 with modulo n
   const scalar = mod(bytesToNumberLE(key), curve.n); // The actual scalar
   const point = ed25519.ExtendedPoint.BASE.multiply(scalar); // Point on Edwards curve aka public key

--- a/src/curves/ed25519Bip32.ts
+++ b/src/curves/ed25519Bip32.ts
@@ -35,12 +35,24 @@ export const deriveUnhardenedKeys = true;
 
 export const publicKeyLength = 32;
 
+/**
+ * Converts a Uint8Array of bytes to a bigint in little-endian format.
+ *
+ * @param bytes - The Uint8Array of bytes to convert.
+ * @returns The converted bigint value.
+ */
 const bytesToNumberLE = (bytes: Uint8Array): bigint => {
   return hexToBigInt(bytesToHex(Uint8Array.from(bytes).reverse()));
 };
 
-// equivalent to https://github.com/jedisct1/libsodium/blob/93a6e79750a31bc0b946bf483b2ba1c77f9e94ce/src/libsodium/crypto_scalarmult/ed25519/ref10/scalarmult_ed25519_ref10.c#L105
-// which is used by cardano-js-sdk/crypto https://github.com/input-output-hk/cardano-js-sdk/blob/8a6db2a251cd1c956f52730a0d35de2b7fc67404/packages/crypto/src/Bip32/Bip32PrivateKey.ts#L161
+/**
+ * Multiplies the given key with the base point on the Edwards curve.
+ * equivalent to https://github.com/jedisct1/libsodium/blob/93a6e79750a31bc0b946bf483b2ba1c77f9e94ce/src/libsodium/crypto_scalarmult/ed25519/ref10/scalarmult_ed25519_ref10.c#L105 .
+ * which is used by cardano-js-sdk/crypto https://github.com/input-output-hk/cardano-js-sdk/blob/8a6db2a251cd1c956f52730a0d35de2b7fc67404/packages/crypto/src/Bip32/Bip32PrivateKey.ts#L161 .
+ *
+ * @param key - The key to multiply with the base point.
+ * @returns The resulting point on the Edwards curve.
+ */
 const multiplyWithBase = (key: Uint8Array): Uint8Array => {
   // Little-endian SHA512 with modulo n
   const scalar = mod(bytesToNumberLE(key), curve.n); // The actual scalar
@@ -48,6 +60,13 @@ const multiplyWithBase = (key: Uint8Array): Uint8Array => {
   return point.toRawBytes(); // Uint8Array representation
 };
 
+/**
+ * Calculates the public key corresponding to a given private key.
+ *
+ * @param privateKey - The private key.
+ * @param _compressed - Optional parameter to indicate if the public key should be compressed.
+ * @returns The public key.
+ */
 export const getPublicKey = async (
   privateKey: Uint8Array,
   _compressed?: boolean,
@@ -55,6 +74,13 @@ export const getPublicKey = async (
   return multiplyWithBase(privateKey.slice(0, 32));
 };
 
+/**
+ * Adds a tweak to a public key.
+ *
+ * @param _publicKey - The public key.
+ * @param _tweak - The tweak to add.
+ * @returns The resulting public key.
+ */
 export const publicAdd = (
   _publicKey: Uint8Array,
   _tweak: Uint8Array,
@@ -64,11 +90,23 @@ export const publicAdd = (
     .toRawBytes();
 };
 
+/**
+ * Compresses an Ed25519 public key.
+ *
+ * @param publicKey - The public key to compress.
+ * @returns The compressed public key.
+ */
 export const compressPublicKey = (publicKey: Uint8Array): Uint8Array => {
   // Ed25519 public keys don't have a compressed form.
   return publicKey;
 };
 
+/**
+ * Decompresses a compressed Ed25519Bip32 public key.
+ *
+ * @param publicKey - The compressed public key.
+ * @returns The decompressed public key.
+ */
 export const decompressPublicKey = (publicKey: Uint8Array): Uint8Array => {
   // Ed25519 public keys don't have a compressed form.
   return publicKey;

--- a/src/curves/ed25519Bip32.ts
+++ b/src/curves/ed25519Bip32.ts
@@ -84,4 +84,4 @@ export const decompressPublicKey = (publicKey: Uint8Array): Uint8Array => {
 
 export const privateKeyLength = 64;
 
-export const masterNodeGenerationSpec = 'cip3Icarus';
+export const masterNodeGenerationSpec = 'cip3';

--- a/src/curves/ed25519Bip32.ts
+++ b/src/curves/ed25519Bip32.ts
@@ -82,8 +82,8 @@ export const getPublicKey = async (
  * @returns The resulting public key.
  */
 export const publicAdd = (
-  _publicKey: Uint8Array,
-  _tweak: Uint8Array,
+  publicKey: Uint8Array,
+  tweak: Uint8Array,
 ): Uint8Array => {
   return ed25519.ExtendedPoint.fromHex(remove0x(bytesToHex(_publicKey)))
     .add(ed25519.ExtendedPoint.fromHex(remove0x(bytesToHex(_tweak))))

--- a/src/curves/index.ts
+++ b/src/curves/index.ts
@@ -1,3 +1,4 @@
 export * from './curve';
 export * as secp256k1 from './secp256k1';
 export * as ed25519 from './ed25519';
+export * as ed25519Bip32 from './ed25519Bip32';

--- a/src/curves/secp256k1.ts
+++ b/src/curves/secp256k1.ts
@@ -55,3 +55,5 @@ export const decompressPublicKey = (publicKey: Uint8Array): Uint8Array => {
   const point = secp256k1.ProjectivePoint.fromHex(publicKey);
   return point.toRawBytes(false);
 };
+
+export const masterNodeGenerationSpec = 'slip10';

--- a/src/curves/secp256k1.ts
+++ b/src/curves/secp256k1.ts
@@ -59,3 +59,5 @@ export const decompressPublicKey = (publicKey: Uint8Array): Uint8Array => {
 export const privateKeyLength = 32;
 
 export const masterNodeGenerationSpec = 'slip10';
+
+export const compressedPublicKeyLength = 33;

--- a/src/curves/secp256k1.ts
+++ b/src/curves/secp256k1.ts
@@ -56,4 +56,6 @@ export const decompressPublicKey = (publicKey: Uint8Array): Uint8Array => {
   return point.toRawBytes(false);
 };
 
+export const privateKeyLength = 32;
+
 export const masterNodeGenerationSpec = 'slip10';

--- a/src/derivation.test.ts
+++ b/src/derivation.test.ts
@@ -24,8 +24,8 @@ const ethereumBip32PathParts = [
 
 describe('derivation', () => {
   describe('deriveKeyFromPath', () => {
-    it('derives the correct account key for cip3Icarus', async () => {
-      const fixture = fixtures.cip3Icarus[0];
+    it('derives the correct account key for cip3', async () => {
+      const fixture = fixtures.cip3[0];
 
       const { accountNode } = fixture.nodes;
       // generate parent key
@@ -33,7 +33,7 @@ describe('derivation', () => {
       const accountPath = fixture.derivationPath.slice(0, 3);
 
       const cardanoBip32Path = accountPath.map(
-        (pathElement) => `cip3Icarus:${pathElement}`,
+        (pathElement) => `cip3:${pathElement}`,
       );
       const multipath = [bip39Part, ...cardanoBip32Path] as SLIP10Path;
       const node = await deriveKeyFromPath({

--- a/src/derivation.test.ts
+++ b/src/derivation.test.ts
@@ -1,7 +1,7 @@
 import { bytesToHex } from '@metamask/utils';
 
 import fixtures from '../test/fixtures';
-import type { HDPathTuple } from './constants';
+import type { HDPathTuple, SLIP10Path } from './constants';
 import { secp256k1 } from './curves';
 import { deriveKeyFromPath, validatePathSegment } from './derivation';
 import { derivers } from './derivers';
@@ -24,6 +24,25 @@ const ethereumBip32PathParts = [
 
 describe('derivation', () => {
   describe('deriveKeyFromPath', () => {
+    it('derives the correct account key for cip3Icarus', async () => {
+      const fixture = fixtures.cip3Icarus[0];
+
+      const { accountNode } = fixture.nodes;
+      // generate parent key
+      const bip39Part = bip39MnemonicToMultipath(fixture.mnemonic);
+      const accountPath = fixture.derivationPath.slice(0, 3);
+
+      const cardanoBip32Path = accountPath.map(
+        (pathElement) => `cip3Icarus:${pathElement}`,
+      );
+      const multipath = [bip39Part, ...cardanoBip32Path] as SLIP10Path;
+      const node = await deriveKeyFromPath({
+        path: multipath,
+        curve: 'ed25519Bip32',
+      });
+
+      expect(node.privateKey).toBe(accountNode.privateKey);
+    });
     it('derives full BIP-44 paths', async () => {
       // generate keys
       const keys = await Promise.all(

--- a/src/derivation.test.ts
+++ b/src/derivation.test.ts
@@ -43,6 +43,7 @@ describe('derivation', () => {
 
       expect(node.privateKey).toBe(accountNode.privateKey);
     });
+
     it('derives full BIP-44 paths', async () => {
       // generate keys
       const keys = await Promise.all(

--- a/src/derivation.ts
+++ b/src/derivation.ts
@@ -8,7 +8,7 @@ import {
   BIP_39_PATH_REGEX,
   MIN_BIP_44_DEPTH,
   SLIP_10_PATH_REGEX,
-  CIP_3_ICARUS_PATH_REGEX,
+  CIP_3_PATH_REGEX,
 } from './constants';
 import type { SupportedCurve } from './curves';
 import { getCurveByName } from './curves';
@@ -172,7 +172,7 @@ export function validatePathSegment(
         !startsWithBip39 &&
         !BIP_32_PATH_REGEX.test(node) &&
         !SLIP_10_PATH_REGEX.test(node) &&
-        !CIP_3_ICARUS_PATH_REGEX.test(node)
+        !CIP_3_PATH_REGEX.test(node)
       ) {
         throw getMalformedError();
       }
@@ -180,7 +180,7 @@ export function validatePathSegment(
       node instanceof Uint8Array ||
       (!BIP_32_PATH_REGEX.test(node) &&
         !SLIP_10_PATH_REGEX.test(node) &&
-        !CIP_3_ICARUS_PATH_REGEX.test(node))
+        !CIP_3_PATH_REGEX.test(node))
     ) {
       throw getMalformedError();
     }

--- a/src/derivation.ts
+++ b/src/derivation.ts
@@ -8,6 +8,7 @@ import {
   BIP_39_PATH_REGEX,
   MIN_BIP_44_DEPTH,
   SLIP_10_PATH_REGEX,
+  CIP_3_ICARUS_PATH_REGEX,
 } from './constants';
 import type { SupportedCurve } from './curves';
 import { getCurveByName } from './curves';
@@ -170,13 +171,16 @@ export function validatePathSegment(
         !(node instanceof Uint8Array) &&
         !startsWithBip39 &&
         !BIP_32_PATH_REGEX.test(node) &&
-        !SLIP_10_PATH_REGEX.test(node)
+        !SLIP_10_PATH_REGEX.test(node) &&
+        !CIP_3_ICARUS_PATH_REGEX.test(node)
       ) {
         throw getMalformedError();
       }
     } else if (
       node instanceof Uint8Array ||
-      (!BIP_32_PATH_REGEX.test(node) && !SLIP_10_PATH_REGEX.test(node))
+      (!BIP_32_PATH_REGEX.test(node) &&
+        !SLIP_10_PATH_REGEX.test(node) &&
+        !CIP_3_ICARUS_PATH_REGEX.test(node))
     ) {
       throw getMalformedError();
     }

--- a/src/derivers/bip39.test.ts
+++ b/src/derivers/bip39.test.ts
@@ -6,8 +6,13 @@ import {
 } from '@metamask/utils';
 import * as hmacModule from '@noble/hashes/hmac';
 
-import { secp256k1 } from '../curves';
-import { createBip39KeyFromSeed } from './bip39';
+import fixtures from '../../test/fixtures';
+import { secp256k1, ed25519Bip32 } from '../curves';
+import {
+  entropyToCip3IcarusMasterNode,
+  createBip39KeyFromSeed,
+  deriveChildKey,
+} from './bip39';
 
 describe('createBip39KeyFromSeed', () => {
   const RANDOM_SEED = hexToBytes(
@@ -64,4 +69,32 @@ describe('createBip39KeyFromSeed', () => {
       );
     },
   );
+});
+
+describe('Cip3Icarus', () => {
+  fixtures.cip3Icarus.forEach((fixture) => {
+    describe('entropyToCip3IcarusMasterNode', () => {
+      it('derives the correct bip39 key for ed25519Bip32 curve', async () => {
+        const result = await entropyToCip3IcarusMasterNode(
+          hexToBytes(fixture.entropyHex),
+          ed25519Bip32,
+        );
+        const { bip39Node } = fixture.nodes;
+        expect(result.privateKey).toBe(bip39Node.privateKey);
+        expect(result.chainCode).toBe(bip39Node.chainCode);
+      });
+    });
+
+    describe('deriveChildKey', () => {
+      it('derives the correct child key for ed25519Bip32 curve from mnemonic', async () => {
+        const result = await deriveChildKey({
+          path: fixture.mnemonic,
+          curve: ed25519Bip32,
+        });
+        const { bip39Node } = fixture.nodes;
+        expect(result.privateKey).toBe(bip39Node.privateKey);
+        expect(result.chainCode).toBe(bip39Node.chainCode);
+      });
+    });
+  });
 });

--- a/src/derivers/bip39.test.ts
+++ b/src/derivers/bip39.test.ts
@@ -7,7 +7,7 @@ import {
 import * as hmacModule from '@noble/hashes/hmac';
 
 import fixtures from '../../test/fixtures';
-import { secp256k1, ed25519Bip32 } from '../curves';
+import { secp256k1, ed25519Bip32, type Curve } from '../curves';
 import {
   entropyToCip3MasterNode,
   createBip39KeyFromSeed,
@@ -69,6 +69,17 @@ describe('createBip39KeyFromSeed', () => {
       );
     },
   );
+
+  it('throws with unsupported masterNodeGenerationSpec error', async () => {
+    await expect(
+      deriveChildKey({
+        path: '',
+        curve: {
+          masterNodeGenerationSpec: 'notValidMasterNodeGenerationSpec',
+        } as unknown as Curve,
+      }),
+    ).rejects.toThrow('Unsupported master node generation spec.');
+  });
 });
 
 describe('Cip3', () => {

--- a/src/derivers/bip39.test.ts
+++ b/src/derivers/bip39.test.ts
@@ -9,7 +9,7 @@ import * as hmacModule from '@noble/hashes/hmac';
 import fixtures from '../../test/fixtures';
 import { secp256k1, ed25519Bip32 } from '../curves';
 import {
-  entropyToCip3IcarusMasterNode,
+  entropyToCip3MasterNode,
   createBip39KeyFromSeed,
   deriveChildKey,
 } from './bip39';
@@ -71,11 +71,11 @@ describe('createBip39KeyFromSeed', () => {
   );
 });
 
-describe('Cip3Icarus', () => {
-  fixtures.cip3Icarus.forEach((fixture) => {
-    describe('entropyToCip3IcarusMasterNode', () => {
+describe('Cip3', () => {
+  fixtures.cip3.forEach((fixture) => {
+    describe('entropyToCip3MasterNode', () => {
       it('derives the correct bip39 key for ed25519Bip32 curve', async () => {
-        const result = await entropyToCip3IcarusMasterNode(
+        const result = await entropyToCip3MasterNode(
           hexToBytes(fixture.entropyHex),
           ed25519Bip32,
         );

--- a/src/derivers/bip39.ts
+++ b/src/derivers/bip39.ts
@@ -34,8 +34,8 @@ export async function deriveChildKey({
   path,
   curve,
 }: DeriveChildKeyArgs): Promise<SLIP10Node> {
-  if (curve.masterNodeGenerationSpec === 'cip3Icarus') {
-    return entropyToCip3IcarusMasterNode(
+  if (curve.masterNodeGenerationSpec === 'cip3') {
+    return entropyToCip3MasterNode(
       mnemonicToEntropy(path, englishWordlist),
       curve,
     );
@@ -97,9 +97,9 @@ export async function createBip39KeyFromSeed(
  * @param curve - The curve to use.
  * @returns The root key pair consisting of 64-byte private key and 32-byte chain code.
  */
-export async function entropyToCip3IcarusMasterNode(
+export async function entropyToCip3MasterNode(
   entropy: Uint8Array,
-  curve: Extract<Curve, { masterNodeGenerationSpec: 'cip3Icarus' }>,
+  curve: Extract<Curve, { masterNodeGenerationSpec: 'cip3' }>,
 ): Promise<SLIP10Node> {
   const rootNode = pbkdf2(sha512, curve.secret, entropy, {
     c: 4096,

--- a/src/derivers/bip39.ts
+++ b/src/derivers/bip39.ts
@@ -74,6 +74,7 @@ export async function createBip39KeyFromSeed(
 
   const masterFingerprint = getFingerprint(
     await curve.getPublicKey(privateKey, true),
+    curve.compressedPublicKeyLength,
   );
 
   return SLIP10Node.fromExtendedKey({
@@ -120,6 +121,7 @@ export async function entropyToCip3MasterNode(
 
   const masterFingerprint = getFingerprint(
     await curve.getPublicKey(privateKey),
+    curve.compressedPublicKeyLength,
   );
 
   return SLIP10Node.fromExtendedKey({

--- a/src/derivers/bip39.ts
+++ b/src/derivers/bip39.ts
@@ -117,6 +117,7 @@ export async function entropyToCip3MasterNode(
   rootNode[0] &= 0b1111_1000;
   rootNode[31] &= 0b0001_1111;
   rootNode[31] |= 0b0100_0000;
+  /* eslint-enable no-bitwise */
 
   const privateKey = rootNode.slice(0, curve.privateKeyLength);
   const chainCode = rootNode.slice(curve.privateKeyLength);

--- a/src/derivers/bip39.ts
+++ b/src/derivers/bip39.ts
@@ -1,7 +1,8 @@
-import { mnemonicToSeed } from '@metamask/scure-bip39';
+import { mnemonicToEntropy, mnemonicToSeed } from '@metamask/scure-bip39';
 import { wordlist as englishWordlist } from '@metamask/scure-bip39/dist/wordlists/english';
 import { assert } from '@metamask/utils';
 import { hmac } from '@noble/hashes/hmac';
+import { pbkdf2 } from '@noble/hashes/pbkdf2';
 import { sha512 } from '@noble/hashes/sha512';
 
 import type { DeriveChildKeyArgs } from '.';
@@ -33,6 +34,12 @@ export async function deriveChildKey({
   path,
   curve,
 }: DeriveChildKeyArgs): Promise<SLIP10Node> {
+  if (curve.masterNodeGenerationSpec === 'cip3Icarus') {
+    return entropyToCip3IcarusMasterNode(
+      mnemonicToEntropy(path, englishWordlist),
+      curve,
+    );
+  }
   return createBip39KeyFromSeed(
     await mnemonicToSeed(path, englishWordlist),
     curve,
@@ -49,7 +56,7 @@ export async function deriveChildKey({
  */
 export async function createBip39KeyFromSeed(
   seed: Uint8Array,
-  curve: Curve,
+  curve: Extract<Curve, { masterNodeGenerationSpec: 'slip10' }>,
 ): Promise<SLIP10Node> {
   assert(
     seed.length >= 16 && seed.length <= 64,
@@ -67,6 +74,52 @@ export async function createBip39KeyFromSeed(
 
   const masterFingerprint = getFingerprint(
     await curve.getPublicKey(privateKey, true),
+  );
+
+  return SLIP10Node.fromExtendedKey({
+    privateKey,
+    chainCode,
+    masterFingerprint,
+    depth: 0,
+    parentFingerprint: 0,
+    index: 0,
+    curve: curve.name,
+  });
+}
+
+/**
+ * Create a {@link SLIP10Node} from BIP-39 entropy.
+ * This function is consistent with the Icarus derivation scheme.
+ * Icarus root key derivation scheme: https://github.com/cardano-foundation/CIPs/blob/09d7d8ee1bd64f7e6b20b5a6cae088039dce00cb/CIP-0003/Icarus.md.
+ * CIP3: https://github.com/cardano-foundation/CIPs/blob/09d7d8ee1bd64f7e6b20b5a6cae088039dce00cb/CIP-0003/CIP-0003.md#master-key-generation.
+ *
+ * @param entropy - The entropy value.
+ * @param curve - The curve to use.
+ * @returns The root key pair consisting of 64-byte private key and 32-byte chain code.
+ */
+export async function entropyToCip3IcarusMasterNode(
+  entropy: Uint8Array,
+  curve: Extract<Curve, { masterNodeGenerationSpec: 'cip3Icarus' }>,
+): Promise<SLIP10Node> {
+  const rootNode = pbkdf2(sha512, curve.secret, entropy, {
+    c: 4096,
+    dkLen: 96,
+  });
+
+  // Consistent with the Icarus derivation scheme.
+  // https://github.com/cardano-foundation/CIPs/blob/09d7d8ee1bd64f7e6b20b5a6cae088039dce00cb/CIP-0003/Icarus.md
+  /* eslint-disable no-bitwise */
+  rootNode[0] &= 0b1111_1000;
+  rootNode[31] &= 0b0001_1111;
+  rootNode[31] |= 0b0100_0000;
+
+  const privateKey = rootNode.slice(0, curve.privateKeyLength);
+  const chainCode = rootNode.slice(curve.privateKeyLength);
+
+  assert(curve.isValidPrivateKey(privateKey), 'Invalid private key.');
+
+  const masterFingerprint = getFingerprint(
+    await curve.getPublicKey(privateKey),
   );
 
   return SLIP10Node.fromExtendedKey({

--- a/src/derivers/bip39.ts
+++ b/src/derivers/bip39.ts
@@ -34,16 +34,20 @@ export async function deriveChildKey({
   path,
   curve,
 }: DeriveChildKeyArgs): Promise<SLIP10Node> {
-  if (curve.masterNodeGenerationSpec === 'cip3') {
-    return entropyToCip3MasterNode(
-      mnemonicToEntropy(path, englishWordlist),
-      curve,
-    );
+  switch (curve.masterNodeGenerationSpec) {
+    case 'slip10':
+      return createBip39KeyFromSeed(
+        await mnemonicToSeed(path, englishWordlist),
+        curve,
+      );
+    case 'cip3':
+      return entropyToCip3MasterNode(
+        mnemonicToEntropy(path, englishWordlist),
+        curve,
+      );
+    default:
+      throw new Error('Unsupported master node generation spec.');
   }
-  return createBip39KeyFromSeed(
-    await mnemonicToSeed(path, englishWordlist),
-    curve,
-  );
 }
 
 /**

--- a/src/derivers/cip3.test.ts
+++ b/src/derivers/cip3.test.ts
@@ -20,7 +20,7 @@ import {
 } from './cip3';
 
 const fixtureNodeToParentNode = (
-  fixtureNode: typeof fixtures.cip3[number]['nodes'][keyof typeof fixtures.cip3[number]['nodes']],
+  fixtureNode: (typeof fixtures.cip3)[number]['nodes'][keyof (typeof fixtures.cip3)[number]['nodes']],
 ) => ({
   privateKeyBytes: hexToBytes(fixtureNode.privateKey),
   publicKeyBytes: hexToBytes(fixtureNode.publicKey),

--- a/src/derivers/cip3.test.ts
+++ b/src/derivers/cip3.test.ts
@@ -2,12 +2,13 @@ import { bytesToHex, hexToBytes } from '@metamask/utils';
 
 import fixtures from '../../test/fixtures';
 import { BIP_32_HARDENED_OFFSET } from '../constants';
-import { ed25519Bip32 } from '../curves';
+import { ed25519, ed25519Bip32 } from '../curves';
 import { SLIP10Node } from '../SLIP10Node';
 import {
   add,
   bigIntToBytes,
   bytesToBigInt,
+  type Cip3SupportedCurve,
   deriveChainCode,
   deriveChildKey,
   derivePrivateKey,
@@ -163,6 +164,18 @@ describe('Cip3', () => {
 
         expect(JSON.stringify(addressIndexNodeRes)).toBe(
           JSON.stringify(addressIndexNode),
+        );
+      });
+
+      it('throws with unsupported curve error', async () => {
+        await expect(
+          deriveChildKey({
+            node: await SLIP10Node.fromJSON(bip39Node),
+            path: purpose,
+            curve: ed25519 as unknown as Cip3SupportedCurve,
+          }),
+        ).rejects.toThrow(
+          `Unsupported curve: Only ed25519Bip32 is supported by CIP3.`,
         );
       });
     });

--- a/src/derivers/cip3.test.ts
+++ b/src/derivers/cip3.test.ts
@@ -24,6 +24,7 @@ describe('Cip3', () => {
     describe('derivePrivate', () => {
       const { bip39Node, purposeNode, coinTypeNode, accountNode, changeNode } =
         fixture.nodes;
+
       it('derives hardened private key 1', async () => {
         const privateKey = await derivePrivateKey({
           parentNode: fixtureNodeToParentNode(bip39Node),
@@ -32,6 +33,7 @@ describe('Cip3', () => {
         });
         expect(bytesToHex(privateKey)).toBe(purposeNode.privateKey);
       });
+
       it('derives hardened private key', async () => {
         const privateKey = await derivePrivateKey({
           parentNode: fixtureNodeToParentNode(purposeNode),
@@ -40,6 +42,7 @@ describe('Cip3', () => {
         });
         expect(bytesToHex(privateKey)).toBe(coinTypeNode.privateKey);
       });
+
       it('derives non-hardened private key', async () => {
         const privateKey = await derivePrivateKey({
           parentNode: fixtureNodeToParentNode(accountNode),
@@ -52,6 +55,7 @@ describe('Cip3', () => {
 
     describe('deriveChainCode', () => {
       const { bip39Node, purposeNode, accountNode, changeNode } = fixture.nodes;
+
       it('derives hardened chainCode key', async () => {
         const chainCode = await deriveChainCode({
           parentNode: fixtureNodeToParentNode(bip39Node),
@@ -60,6 +64,7 @@ describe('Cip3', () => {
         });
         expect(bytesToHex(chainCode)).toBe(purposeNode.chainCode);
       });
+
       it('derives non-hardened private key', async () => {
         const chainCode = await deriveChainCode({
           parentNode: fixtureNodeToParentNode(accountNode),
@@ -72,6 +77,7 @@ describe('Cip3', () => {
 
     describe('derivePublicKey', () => {
       const { changeNode, addressIndexNode } = fixture.nodes;
+
       it('derives public key', async () => {
         const chainCode = await derivePublicKey({
           parentNode: fixtureNodeToParentNode(changeNode),
@@ -106,6 +112,7 @@ describe('Cip3', () => {
           JSON.stringify(purposeNode),
         );
       });
+
       it('derives coinType node', async () => {
         const coinTypeNodeRes = await deriveChildKey({
           node: await SLIP10Node.fromJSON(purposeNode),
@@ -117,6 +124,7 @@ describe('Cip3', () => {
           JSON.stringify(coinTypeNode),
         );
       });
+
       it('derives account node', async () => {
         const accountNodeRes = await deriveChildKey({
           node: await SLIP10Node.fromJSON(coinTypeNode),
@@ -128,6 +136,7 @@ describe('Cip3', () => {
           JSON.stringify(accountNode),
         );
       });
+
       it('derives change node', async () => {
         const changeNodeRes = await deriveChildKey({
           node: await SLIP10Node.fromJSON(accountNode),
@@ -137,6 +146,7 @@ describe('Cip3', () => {
 
         expect(JSON.stringify(changeNodeRes)).toBe(JSON.stringify(changeNode));
       });
+
       it('derives addressIndex node', async () => {
         const addressIndexNodeRes = await deriveChildKey({
           node: await SLIP10Node.fromJSON(changeNode),

--- a/src/derivers/cip3.test.ts
+++ b/src/derivers/cip3.test.ts
@@ -9,18 +9,18 @@ import {
   deriveChildKey,
   derivePrivateKey,
   derivePublicKey,
-} from './cip3Icarus';
+} from './cip3';
 
 const fixtureNodeToParentNode = (
-  fixtureNode: typeof fixtures.cip3Icarus[number]['nodes'][keyof typeof fixtures.cip3Icarus[number]['nodes']],
+  fixtureNode: typeof fixtures.cip3[number]['nodes'][keyof typeof fixtures.cip3[number]['nodes']],
 ) => ({
   privateKeyBytes: hexToBytes(fixtureNode.privateKey),
   publicKeyBytes: hexToBytes(fixtureNode.publicKey),
   chainCodeBytes: hexToBytes(fixtureNode.chainCode),
 });
 
-describe('Cip3Icarus', () => {
-  fixtures.cip3Icarus.forEach((fixture) => {
+describe('Cip3', () => {
+  fixtures.cip3.forEach((fixture) => {
     describe('derivePrivate', () => {
       const { bip39Node, purposeNode, coinTypeNode, accountNode, changeNode } =
         fixture.nodes;

--- a/src/derivers/cip3.ts
+++ b/src/derivers/cip3.ts
@@ -33,7 +33,7 @@ import { generateEntropy, getValidatedPath, validateNode } from './shared';
  * @param bytes - The input Uint8Array.
  * @returns A new Uint8Array with the bytes in reversed order.
  */
-const toReversed = (bytes: Uint8Array) => bytes.slice().reverse();
+export const toReversed = (bytes: Uint8Array) => bytes.slice().reverse();
 
 /**
  * Converts an array of bytes to a BigInt.
@@ -41,7 +41,7 @@ const toReversed = (bytes: Uint8Array) => bytes.slice().reverse();
  * @param bytes - The array of bytes to convert.
  * @returns The BigInt representation of the bytes.
  */
-const bytesToBigInt = (bytes: Uint8Array) => {
+export const bytesToBigInt = (bytes: Uint8Array) => {
   const reversed = toReversed(bytes);
   const bytesInHex = bytesToHex(reversed);
   return BigInt(bytesInHex);
@@ -53,7 +53,7 @@ const bytesToBigInt = (bytes: Uint8Array) => {
  * @param bigInt - The BigInt to convert.
  * @returns The byte array representation of the BigInt.
  */
-const bigIntToBytes = (bigInt: bigint) => {
+export const bigIntToBytes = (bigInt: bigint) => {
   const hexadecimal = bigInt.toString(16);
   return toReversed(hexToBytes(hexadecimal));
 };
@@ -64,7 +64,7 @@ const bigIntToBytes = (bigInt: bigint) => {
  * @param bytes - The bytes array to pad.
  * @returns The padded bytes array.
  */
-const padEnd32Bytes = (bytes: Uint8Array) => {
+export const padEnd32Bytes = (bytes: Uint8Array) => {
   return concatBytes([
     bytes,
     new Uint8Array(Math.max(32 - bytes.length, 0)).fill(0),
@@ -77,7 +77,7 @@ const padEnd32Bytes = (bytes: Uint8Array) => {
  * @param bytes - Little-Endian big number in bytes.
  * @returns PadEnd32Bytes(left[0, 28] * 8)).
  */
-const trunc28Mul8 = (bytes: Uint8Array): Uint8Array => {
+export const trunc28Mul8 = (bytes: Uint8Array): Uint8Array => {
   const truncLeftMul8 = bytesToBigInt(bytes.slice(0, 28)) * BigInt(8);
   return padEnd32Bytes(bigIntToBytes(truncLeftMul8));
 };
@@ -88,7 +88,7 @@ const trunc28Mul8 = (bytes: Uint8Array): Uint8Array => {
  * @param bytes - Little-Endian big number in bytes.
  * @returns PadEnd32Bytes(mod(bytes, 2^256))).
  */
-const mod2Pow256 = (bytes: Uint8Array): Uint8Array => {
+export const mod2Pow256 = (bytes: Uint8Array): Uint8Array => {
   return padEnd32Bytes(
     bigIntToBytes(mod(bytesToBigInt(bytes), BigInt(2) ** BigInt(256))),
   );
@@ -101,7 +101,7 @@ const mod2Pow256 = (bytes: Uint8Array): Uint8Array => {
  * @param right - Right hand side Little-Endian big number.
  * @returns PadEnd32Bytes(left + right).
  */
-const add = (left: Uint8Array, right: Uint8Array): Uint8Array => {
+export const add = (left: Uint8Array, right: Uint8Array): Uint8Array => {
   const added = bytesToBigInt(left) + bytesToBigInt(right);
   return padEnd32Bytes(bigIntToBytes(added)).slice(0, 32);
 };
@@ -114,7 +114,11 @@ const add = (left: Uint8Array, right: Uint8Array): Uint8Array => {
  * @param childIndex - Child index.
  * @returns PadEnd32Bytes(left + right).
  */
-const getKeyExtension = (tag: number, key: Uint8Array, childIndex: number) => {
+export const getKeyExtension = (
+  tag: number,
+  key: Uint8Array,
+  childIndex: number,
+) => {
   return concatBytes([
     new Uint8Array([tag]),
     key,

--- a/src/derivers/cip3.ts
+++ b/src/derivers/cip3.ts
@@ -23,21 +23,47 @@ import { generateEntropy, getValidatedPath, validateNode } from './shared';
  * - See https://input-output-hk.github.io/adrestia/static/Ed25519_BIP.pdf.
  */
 
-// Native BigInt uses big-endian. Since cip3(bip32Edd25519) uses little-endian, we need to reverse the bytes
-// and have separate functions for bigIntToBytes and bytesToBigInt, .slice() is used just to make a copy of the array
+/**
+ * Reverses the order of bytes in a Uint8Array.
+ *
+ * Native BigInt uses big-endian. Since cip3(bip32Edd25519) uses little-endian.
+ * We need to reverse the bytes and have separate functions for bigIntToBytes and bytesToBigInt.
+ * .slice() is used just to make a copy of the array.
+ *
+ * @param bytes - The input Uint8Array.
+ * @returns A new Uint8Array with the bytes in reversed order.
+ */
 const toReversed = (bytes: Uint8Array) => bytes.slice().reverse();
 
+/**
+ * Converts an array of bytes to a BigInt.
+ *
+ * @param bytes - The array of bytes to convert.
+ * @returns The BigInt representation of the bytes.
+ */
 const bytesToBigInt = (bytes: Uint8Array) => {
   const reversed = toReversed(bytes);
   const bytesInHex = bytesToHex(reversed);
   return BigInt(bytesInHex);
 };
 
+/**
+ * Converts a BigInt to a byte array.
+ *
+ * @param bigInt - The BigInt to convert.
+ * @returns The byte array representation of the BigInt.
+ */
 const bigIntToBytes = (bigInt: bigint) => {
   const hexadecimal = bigInt.toString(16);
   return toReversed(hexToBytes(hexadecimal));
 };
 
+/**
+ * Pads end of the given bytes array with zeros to a length of 32 bytes.
+ *
+ * @param bytes - The bytes array to pad.
+ * @returns The padded bytes array.
+ */
 const padEnd32Bytes = (bytes: Uint8Array) => {
   return concatBytes([
     bytes,

--- a/src/derivers/cip3.ts
+++ b/src/derivers/cip3.ts
@@ -126,7 +126,7 @@ export const getKeyExtension = (
   ]);
 };
 
-type Cip3SupportedCurve = Extract<Curve, { name: 'ed25519Bip32' }>;
+export type Cip3SupportedCurve = Extract<Curve, { name: 'ed25519Bip32' }>;
 
 type DeriveKeyBaseArgs = { childIndex: number };
 

--- a/src/derivers/cip3.ts
+++ b/src/derivers/cip3.ts
@@ -351,7 +351,7 @@ export async function deriveChildKey(
 
   assert(
     !isHardened,
-    "Invalid parameters: Cannot derive hardened child keys without a private key.",
+    'Invalid parameters: Cannot derive hardened child keys without a private key.',
   );
 
   const parentNode = {

--- a/src/derivers/cip3.ts
+++ b/src/derivers/cip3.ts
@@ -23,7 +23,7 @@ import { generateEntropy, getValidatedPath, validateNode } from './shared';
  * - See https://input-output-hk.github.io/adrestia/static/Ed25519_BIP.pdf.
  */
 
-// Native BigInt uses big-endian. Since cip3Icarus(bip32Edd25519) uses little-endian, we need to reverse the bytes
+// Native BigInt uses big-endian. Since cip3(bip32Edd25519) uses little-endian, we need to reverse the bytes
 // and have separate functions for bigIntToBytes and bytesToBigInt, .slice() is used just to make a copy of the array
 const toReversed = (bytes: Uint8Array) => bytes.slice().reverse();
 
@@ -96,7 +96,7 @@ const getKeyExtension = (tag: number, key: Uint8Array, childIndex: number) => {
   ]);
 };
 
-type Cip3IcarusSupportedCurve = Extract<Curve, { name: 'ed25519Bip32' }>;
+type Cip3SupportedCurve = Extract<Curve, { name: 'ed25519Bip32' }>;
 
 type DeriveKeyBaseArgs = { childIndex: number };
 
@@ -214,7 +214,7 @@ const PUBLIC_KEY_TAGS = {
 };
 
 type DerivePublicKeyArgs = DeriveWithoutPrivateArgs & {
-  curve: Cip3IcarusSupportedCurve;
+  curve: Cip3SupportedCurve;
 };
 
 /**
@@ -258,8 +258,8 @@ export const derivePublicKey = async ({
   return curve.publicAdd(parentNode.publicKeyBytes, right);
 };
 
-type Cip3IcarusDeriveChildKeyArgs = DeriveChildKeyArgs & {
-  curve: Cip3IcarusSupportedCurve;
+type Cip3DeriveChildKeyArgs = DeriveChildKeyArgs & {
+  curve: Cip3SupportedCurve;
 };
 
 /**
@@ -269,7 +269,7 @@ type Cip3IcarusDeriveChildKeyArgs = DeriveChildKeyArgs & {
  * @returns SLIP10Node.
  */
 export async function deriveChildKey(
-  options: Cip3IcarusDeriveChildKeyArgs,
+  options: Cip3DeriveChildKeyArgs,
 ): Promise<SLIP10Node> {
   const { curve, node, path } = options;
   validateNode(node);
@@ -277,7 +277,7 @@ export async function deriveChildKey(
   const { childIndex, isHardened } = getValidatedPath(path, node, curve);
   if (curve.name !== 'ed25519Bip32' || !node) {
     throw new Error(
-      'Unsupported curve: Only ed25519Bip32 is supported by CIP3Icarus.',
+      'Unsupported curve: Only ed25519Bip32 is supported by CIP3.',
     );
   }
 

--- a/src/derivers/cip3.ts
+++ b/src/derivers/cip3.ts
@@ -351,7 +351,7 @@ export async function deriveChildKey(
 
   assert(
     !isHardened,
-    "Cannot derive hardened because we don't have the private key",
+    "Invalid parameters: Cannot derive hardened child keys without a private key.",
   );
 
   const parentNode = {

--- a/src/derivers/cip3Icarus.test.ts
+++ b/src/derivers/cip3Icarus.test.ts
@@ -1,0 +1,153 @@
+import { bytesToHex, hexToBytes } from '@metamask/utils';
+
+import fixtures from '../../test/fixtures';
+import { BIP_32_HARDENED_OFFSET } from '../constants';
+import { ed25519Bip32 } from '../curves';
+import { SLIP10Node } from '../SLIP10Node';
+import {
+  deriveChainCode,
+  deriveChildKey,
+  derivePrivateKey,
+  derivePublicKey,
+} from './cip3Icarus';
+
+const fixtureNodeToParentNode = (
+  fixtureNode: typeof fixtures.cip3Icarus[number]['nodes'][keyof typeof fixtures.cip3Icarus[number]['nodes']],
+) => ({
+  privateKeyBytes: hexToBytes(fixtureNode.privateKey),
+  publicKeyBytes: hexToBytes(fixtureNode.publicKey),
+  chainCodeBytes: hexToBytes(fixtureNode.chainCode),
+});
+
+describe('Cip3Icarus', () => {
+  fixtures.cip3Icarus.forEach((fixture) => {
+    describe('derivePrivate', () => {
+      const { bip39Node, purposeNode, coinTypeNode, accountNode, changeNode } =
+        fixture.nodes;
+      it('derives hardened private key 1', async () => {
+        const privateKey = await derivePrivateKey({
+          parentNode: fixtureNodeToParentNode(bip39Node),
+          isHardened: true,
+          childIndex: purposeNode.index - BIP_32_HARDENED_OFFSET,
+        });
+        expect(bytesToHex(privateKey)).toBe(purposeNode.privateKey);
+      });
+      it('derives hardened private key', async () => {
+        const privateKey = await derivePrivateKey({
+          parentNode: fixtureNodeToParentNode(purposeNode),
+          isHardened: true,
+          childIndex: coinTypeNode.index - BIP_32_HARDENED_OFFSET,
+        });
+        expect(bytesToHex(privateKey)).toBe(coinTypeNode.privateKey);
+      });
+      it('derives non-hardened private key', async () => {
+        const privateKey = await derivePrivateKey({
+          parentNode: fixtureNodeToParentNode(accountNode),
+          isHardened: false,
+          childIndex: changeNode.index,
+        });
+        expect(bytesToHex(privateKey)).toBe(changeNode.privateKey);
+      });
+    });
+
+    describe('deriveChainCode', () => {
+      const { bip39Node, purposeNode, accountNode, changeNode } = fixture.nodes;
+      it('derives hardened chainCode key', async () => {
+        const chainCode = await deriveChainCode({
+          parentNode: fixtureNodeToParentNode(bip39Node),
+          isHardened: true,
+          childIndex: purposeNode.index - BIP_32_HARDENED_OFFSET,
+        });
+        expect(bytesToHex(chainCode)).toBe(purposeNode.chainCode);
+      });
+      it('derives non-hardened private key', async () => {
+        const chainCode = await deriveChainCode({
+          parentNode: fixtureNodeToParentNode(accountNode),
+          isHardened: false,
+          childIndex: changeNode.index,
+        });
+        expect(bytesToHex(chainCode)).toBe(changeNode.chainCode);
+      });
+    });
+
+    describe('derivePublicKey', () => {
+      const { changeNode, addressIndexNode } = fixture.nodes;
+      it('derives public key', async () => {
+        const chainCode = await derivePublicKey({
+          parentNode: fixtureNodeToParentNode(changeNode),
+          childIndex: addressIndexNode.index,
+          isHardened: false,
+          curve: ed25519Bip32,
+        });
+        expect(bytesToHex(chainCode)).toBe(addressIndexNode.publicKey);
+      });
+    });
+
+    describe('deriveChildKey', () => {
+      const [purpose, coinType, accountIndex, change, addressIndex] =
+        fixture.derivationPath;
+      const {
+        bip39Node,
+        purposeNode,
+        coinTypeNode,
+        accountNode,
+        changeNode,
+        addressIndexNode,
+      } = fixture.nodes;
+
+      it('derives purpose node', async () => {
+        const purposeNodeRes = await deriveChildKey({
+          node: await SLIP10Node.fromJSON(bip39Node),
+          path: purpose,
+          curve: ed25519Bip32,
+        });
+
+        expect(JSON.stringify(purposeNodeRes)).toBe(
+          JSON.stringify(purposeNode),
+        );
+      });
+      it('derives coinType node', async () => {
+        const coinTypeNodeRes = await deriveChildKey({
+          node: await SLIP10Node.fromJSON(purposeNode),
+          path: coinType,
+          curve: ed25519Bip32,
+        });
+
+        expect(JSON.stringify(coinTypeNodeRes)).toBe(
+          JSON.stringify(coinTypeNode),
+        );
+      });
+      it('derives account node', async () => {
+        const accountNodeRes = await deriveChildKey({
+          node: await SLIP10Node.fromJSON(coinTypeNode),
+          path: accountIndex,
+          curve: ed25519Bip32,
+        });
+
+        expect(JSON.stringify(accountNodeRes)).toBe(
+          JSON.stringify(accountNode),
+        );
+      });
+      it('derives change node', async () => {
+        const changeNodeRes = await deriveChildKey({
+          node: await SLIP10Node.fromJSON(accountNode),
+          path: change,
+          curve: ed25519Bip32,
+        });
+
+        expect(JSON.stringify(changeNodeRes)).toBe(JSON.stringify(changeNode));
+      });
+      it('derives addressIndex node', async () => {
+        const addressIndexNodeRes = await deriveChildKey({
+          node: await SLIP10Node.fromJSON(changeNode),
+          path: addressIndex,
+          curve: ed25519Bip32,
+        });
+
+        expect(JSON.stringify(addressIndexNodeRes)).toBe(
+          JSON.stringify(addressIndexNode),
+        );
+      });
+    });
+  });
+});

--- a/src/derivers/cip3Icarus.ts
+++ b/src/derivers/cip3Icarus.ts
@@ -1,0 +1,358 @@
+import { assert, bytesToHex, concatBytes, hexToBytes } from '@metamask/utils';
+
+import type { DeriveChildKeyArgs } from '.';
+import { BIP_32_HARDENED_OFFSET } from '../constants';
+import { type Curve, mod } from '../curves';
+import { SLIP10Node } from '../SLIP10Node';
+import { numberToUint32 } from '../utils';
+import { generateEntropy, getValidatedPath, validateNode } from './shared';
+
+/**
+ * CIP-3 https://github.com/cardano-foundation/CIPs/blob/09d7d8ee1bd64f7e6b20b5a6cae088039dce00cb/CIP-0003/CIP-0003.md.
+ *
+ * CIP-3 defines standards for deriving keys on Cardano.
+ *
+ * Key attributes.
+ * - Root/Master key is derived from entropy, not seed. For this implementation we work with Icarus standard as it is the most widely used.
+ * - See https://github.com/cardano-foundation/CIPs/blob/09d7d8ee1bd64f7e6b20b5a6cae088039dce00cb/CIP-0003/Icarus.md.
+ *
+ * - HD node consists of a 64 byte private key, 32 byte public key and 32 byte chain code.
+ * - See https://github.com/cardano-foundation/CIPs/blob/09d7d8ee1bd64f7e6b20b5a6cae088039dce00cb/CIP-0003/CIP-0003.md#master-key-generation.
+ *
+ * - For derivation of BIP32 HD nodes, it uses modified version called BIP32-Ed25519.
+ * - See https://input-output-hk.github.io/adrestia/static/Ed25519_BIP.pdf.
+ */
+
+// Native BigInt uses big-endian. Since cip3Icarus(bip32Edd25519) uses little-endian, we need to reverse the bytes
+// and have separate functions for bigIntToBytes and bytesToBigInt, .slice() is used just to make a copy of the array
+const toReversed = (bytes: Uint8Array) => bytes.slice().reverse();
+
+const bytesToBigInt = (bytes: Uint8Array) => {
+  const reversed = toReversed(bytes);
+  const bytesInHex = bytesToHex(reversed);
+  return BigInt(bytesInHex);
+};
+
+const bigIntToBytes = (bigInt: bigint) => {
+  const hexadecimal = bigInt.toString(16);
+  return toReversed(hexToBytes(hexadecimal));
+};
+
+const padEnd32Bytes = (bytes: Uint8Array) => {
+  return concatBytes([
+    bytes,
+    new Uint8Array(Math.max(32 - bytes.length, 0)).fill(0),
+  ]);
+};
+
+/**
+ * Truncates to first 28 bytes and multiplies by 8.
+ *
+ * @param bytes - Little-Endian big number in bytes.
+ * @returns PadEnd32Bytes(left[0, 28] * 8)).
+ */
+const trunc28Mul8 = (bytes: Uint8Array): Uint8Array => {
+  const truncLeftMul8 = bytesToBigInt(bytes.slice(0, 28)) * BigInt(8);
+  return padEnd32Bytes(bigIntToBytes(truncLeftMul8));
+};
+
+/**
+ * Does module 2^256.
+ *
+ * @param bytes - Little-Endian big number in bytes.
+ * @returns PadEnd32Bytes(mod(bytes, 2^256))).
+ */
+const mod2Pow256 = (bytes: Uint8Array): Uint8Array => {
+  return padEnd32Bytes(
+    bigIntToBytes(mod(bytesToBigInt(bytes), BigInt(2) ** BigInt(256))),
+  );
+};
+
+/**
+ * Adds the left to the right.
+ *
+ * @param left - Left hand side Little-Endian big number.
+ * @param right - Right hand side Little-Endian big number.
+ * @returns PadEnd32Bytes(left + right).
+ */
+const add = (left: Uint8Array, right: Uint8Array): Uint8Array => {
+  const added = bytesToBigInt(left) + bytesToBigInt(right);
+  return padEnd32Bytes(bigIntToBytes(added)).slice(0, 32);
+};
+
+/**
+ * Concat tag, key and childIndex.
+ *
+ * @param tag - Key specific tag.
+ * @param key - Key.
+ * @param childIndex - Child index.
+ * @returns PadEnd32Bytes(left + right).
+ */
+const getKeyExtension = (tag: number, key: Uint8Array, childIndex: number) => {
+  return concatBytes([
+    new Uint8Array([tag]),
+    key,
+    numberToUint32(childIndex, true),
+  ]);
+};
+
+type Cip3IcarusSupportedCurve = Extract<Curve, { name: 'ed25519Bip32' }>;
+
+type DeriveKeyBaseArgs = { childIndex: number };
+
+type DeriveWithPrivateArgs = DeriveKeyBaseArgs & {
+  parentNode: {
+    privateKeyBytes: Uint8Array;
+    chainCodeBytes: Uint8Array;
+    publicKeyBytes: Uint8Array;
+  };
+  isHardened: boolean;
+};
+
+const Z_TAGS = {
+  normal: 2,
+  hardened: 0,
+};
+
+/**
+ * Derives a private child key.
+ *
+ * Following "Section V. BIP32-ED25519: SPECIFICATION, C.1,2" in https://input-output-hk.github.io/adrestia/static/Ed25519_BIP.pdf.
+ *
+ * @param param1 - The parameters for deriving a child key.
+ * @param param1.parentNode - The parent node containing private key, chain code, and public key.
+ * @param param1.childIndex - The index of the child key.
+ * @param param1.isHardened - Indicates if the child key is hardened.
+ * @returns The derived child key.
+ */
+export const derivePrivateKey = async ({
+  parentNode,
+  childIndex,
+  isHardened,
+}: DeriveWithPrivateArgs) => {
+  // extension = i >= 2^31 ? (0x00||kp||i) : (0x02||Ap||i)
+  const extension = isHardened
+    ? getKeyExtension(
+        Z_TAGS.hardened,
+        parentNode.privateKeyBytes,
+        childIndex + BIP_32_HARDENED_OFFSET,
+      )
+    : getKeyExtension(Z_TAGS.normal, parentNode.publicKeyBytes, childIndex);
+
+  // entropy = Fcp(extension)
+  const entropy = generateEntropy({
+    chainCode: parentNode.chainCodeBytes,
+    extension,
+  });
+
+  const zl = entropy.subarray(0, 32);
+  const zr = entropy.subarray(32);
+
+  const parentKl = parentNode.privateKeyBytes.subarray(0, 32);
+  const parentKr = parentNode.privateKeyBytes.subarray(32);
+
+  // 8[ZL] + kPL
+  const childKl = add(trunc28Mul8(zl), parentKl);
+  // ZR + kPR
+  const childKr = add(zr, mod2Pow256(parentKr));
+  return concatBytes([childKl, childKr]);
+};
+
+type DeriveWithoutPrivateArgs = DeriveKeyBaseArgs & {
+  parentNode: {
+    chainCodeBytes: Uint8Array;
+    publicKeyBytes: Uint8Array;
+  };
+  isHardened: false;
+};
+
+const CHAIN_CODE_TAGS = {
+  normal: 3,
+  hardened: 1,
+};
+
+/**
+ * Derives a child chainCode.
+ *
+ * Following "Section V. BIP32-ED25519: SPECIFICATION, C.3" in https://input-output-hk.github.io/adrestia/static/Ed25519_BIP.pdf.
+ *
+ * @param param1 - The parameters for deriving a child chainCode.
+ * @param param1.parentNode - The parent node containing optionally a private key, chain code, and public key.
+ * @param param1.childIndex - The index of the child key.
+ * @param param1.isHardened - Indicates if the child key is hardened.
+ * @returns The derived child chainCode.
+ */
+export const deriveChainCode = async ({
+  parentNode,
+  childIndex,
+  isHardened,
+}: DeriveWithPrivateArgs | DeriveWithoutPrivateArgs) => {
+  // extension = i >= 2^31 ? (0x01||kp||i) : (0x03||Ap||i)
+  const extension = isHardened
+    ? getKeyExtension(
+        CHAIN_CODE_TAGS.hardened,
+        parentNode.privateKeyBytes,
+        childIndex + BIP_32_HARDENED_OFFSET,
+      )
+    : getKeyExtension(
+        CHAIN_CODE_TAGS.normal,
+        parentNode.publicKeyBytes,
+        childIndex,
+      );
+
+  // entropy = Fcp(extension)
+  const entropy = generateEntropy({
+    chainCode: parentNode.chainCodeBytes,
+    extension,
+  });
+
+  return entropy.subarray(32);
+};
+
+const PUBLIC_KEY_TAGS = {
+  normal: 2,
+};
+
+type DerivePublicKeyArgs = DeriveWithoutPrivateArgs & {
+  curve: Cip3IcarusSupportedCurve;
+};
+
+/**
+ * Derives a public key.
+ *
+ * Following "Section V. BIP32-ED25519: SPECIFICATION, D" in https://input-output-hk.github.io/adrestia/static/Ed25519_BIP.pdf.
+ *
+ * @param param1 - The parameters for deriving a child public key.
+ * @param param1.parentNode - The parent node containing chain code, and public key.
+ * @param param1.childIndex - The index of the child key.
+ * @param param1.curve - Derivation curve.
+ * @returns The derived child public key.
+ */
+export const derivePublicKey = async ({
+  parentNode,
+  childIndex,
+  curve,
+}: DerivePublicKeyArgs) => {
+  // extension = (0x02||Ap||i)
+  const extension = getKeyExtension(
+    PUBLIC_KEY_TAGS.normal,
+    parentNode.publicKeyBytes,
+    childIndex,
+  );
+
+  // entropy = Fcp(extension)
+  const entropy = generateEntropy({
+    chainCode: parentNode.chainCodeBytes,
+    extension,
+  });
+
+  const zl = entropy.slice(0, 32);
+
+  // right = [8ZL] * B
+  const right = await curve.getPublicKey(
+    // [8ZL]
+    trunc28Mul8(zl),
+  );
+
+  // Ai = AP + [8ZL]B,
+  return curve.publicAdd(parentNode.publicKeyBytes, right);
+};
+
+type Cip3IcarusDeriveChildKeyArgs = DeriveChildKeyArgs & {
+  curve: Cip3IcarusSupportedCurve;
+};
+
+/**
+ * Derive a SLIP-10 child key with a given path from a parent key.
+ *
+ * @param options - The options for deriving a child key.
+ * @returns SLIP10Node.
+ */
+export async function deriveChildKey(
+  options: Cip3IcarusDeriveChildKeyArgs,
+): Promise<SLIP10Node> {
+  const { curve, node, path } = options;
+  validateNode(node);
+
+  const { childIndex, isHardened } = getValidatedPath(path, node, curve);
+  if (curve.name !== 'ed25519Bip32' || !node) {
+    throw new Error(
+      'Unsupported curve: Only ed25519Bip32 is supported by CIP3Icarus.',
+    );
+  }
+
+  const actualChildIndex =
+    childIndex + (isHardened ? BIP_32_HARDENED_OFFSET : 0);
+
+  const {
+    privateKeyBytes,
+    chainCodeBytes,
+    publicKeyBytes,
+    masterFingerprint,
+    depth,
+    fingerprint: parentFingerprint,
+  } = node;
+
+  if (privateKeyBytes) {
+    const parentNode = {
+      privateKeyBytes,
+      chainCodeBytes,
+      publicKeyBytes,
+    };
+
+    const privateKey = await derivePrivateKey({
+      parentNode,
+      childIndex,
+      isHardened,
+    });
+
+    const chainCode = await deriveChainCode({
+      parentNode,
+      childIndex,
+      isHardened,
+    });
+
+    return SLIP10Node.fromExtendedKey({
+      privateKey: bytesToHex(privateKey),
+      chainCode: bytesToHex(chainCode),
+      masterFingerprint,
+      depth: depth + 1,
+      parentFingerprint,
+      index: actualChildIndex,
+      curve: curve.name,
+    });
+  }
+
+  assert(
+    !isHardened,
+    "Cannot derive hardened because we don't have the private key",
+  );
+
+  const parentNode = {
+    chainCodeBytes,
+    publicKeyBytes,
+  };
+
+  const publicKey = await derivePublicKey({
+    parentNode,
+    childIndex,
+    isHardened: false,
+    curve,
+  });
+
+  const chainCode = await deriveChainCode({
+    parentNode,
+    childIndex,
+    isHardened: false,
+  });
+
+  return SLIP10Node.fromExtendedKey({
+    publicKey: bytesToHex(publicKey),
+    chainCode: bytesToHex(chainCode),
+    masterFingerprint,
+    depth: depth + 1,
+    parentFingerprint,
+    index: actualChildIndex,
+    curve: curve.name,
+  });
+}

--- a/src/derivers/index.ts
+++ b/src/derivers/index.ts
@@ -2,6 +2,7 @@ import type { Curve } from '../curves';
 import type { SLIP10Node } from '../SLIP10Node';
 import * as bip32 from './bip32';
 import * as bip39 from './bip39';
+import * as cip3Icarus from './cip3Icarus';
 import * as slip10 from './slip10';
 
 export type DerivedKeys = {
@@ -27,6 +28,7 @@ export const derivers = {
   bip32,
   bip39,
   slip10,
+  cip3Icarus,
 };
 
 export { createBip39KeyFromSeed } from './bip39';

--- a/src/derivers/index.ts
+++ b/src/derivers/index.ts
@@ -2,7 +2,7 @@ import type { Curve } from '../curves';
 import type { SLIP10Node } from '../SLIP10Node';
 import * as bip32 from './bip32';
 import * as bip39 from './bip39';
-import * as cip3Icarus from './cip3Icarus';
+import * as cip3 from './cip3';
 import * as slip10 from './slip10';
 
 export type DerivedKeys = {
@@ -28,7 +28,7 @@ export const derivers = {
   bip32,
   bip39,
   slip10,
-  cip3Icarus,
+  cip3,
 };
 
 export { createBip39KeyFromSeed } from './bip39';

--- a/src/derivers/shared.ts
+++ b/src/derivers/shared.ts
@@ -512,7 +512,7 @@ function validatePath(
  * @param curve - The curve to validate the path against.
  * @returns The child index and whether it is hardened.
  */
-function getValidatedPath(
+export function getValidatedPath(
   path: string | Uint8Array,
   node: SLIP10Node,
   curve: Curve,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -7,6 +7,7 @@ import {
   isValidBIP32PathSegment,
   createBip39KeyFromSeed,
   mnemonicPhraseToBytes,
+  ed25519Bip32,
 } from '.';
 
 // This is purely for coverage shenanigans
@@ -18,6 +19,7 @@ describe('index', () => {
     expect(SLIP10Node).toBeDefined();
     expect(secp256k1).toBeDefined();
     expect(ed25519).toBeDefined();
+    expect(ed25519Bip32).toBeDefined();
     expect(isValidBIP32PathSegment).toBeDefined();
     expect(createBip39KeyFromSeed).toBeDefined();
     expect(mnemonicPhraseToBytes).toBeDefined();

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ export type {
 } from './SLIP10Node';
 export { SLIP10Node } from './SLIP10Node';
 export type { SupportedCurve } from './curves';
-export { secp256k1, ed25519 } from './curves';
+export { secp256k1, ed25519, ed25519Bip32 } from './curves';
 export type {
   BIP44CoinTypeNodeInterface,
   CoinTypeHDPathTuple,

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -406,16 +406,16 @@ describe('getFingerprint', () => {
       'xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi',
     );
 
-    expect(getFingerprint(node.compressedPublicKeyBytes)).toBe(876747070);
+    expect(getFingerprint(node.compressedPublicKeyBytes, 33)).toBe(876747070);
   });
 
   it('throws if the public key is not a valid Uint8Array', () => {
-    expect(() => getFingerprint(new Uint8Array(33).fill(0))).toThrow(
-      'Invalid public key: The key must be a 33 or 32-byte, non-zero byte array.',
+    expect(() => getFingerprint(new Uint8Array(33).fill(0), 33)).toThrow(
+      'Invalid public key: The key must be 33 byte, non-zero byte array.',
     );
 
-    expect(() => getFingerprint(new Uint8Array(65).fill(1))).toThrow(
-      'Invalid public key: The key must be a 33 or 32-byte, non-zero byte array.',
+    expect(() => getFingerprint(new Uint8Array(65).fill(1), 33)).toThrow(
+      'Invalid public key: The key must be 33 byte, non-zero byte array.',
     );
   });
 });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -411,11 +411,11 @@ describe('getFingerprint', () => {
 
   it('throws if the public key is not a valid Uint8Array', () => {
     expect(() => getFingerprint(new Uint8Array(33).fill(0))).toThrow(
-      'Invalid public key: The key must be a 33-byte, non-zero byte array.',
+      'Invalid public key: The key must be a 33 or 32-byte, non-zero byte array.',
     );
 
     expect(() => getFingerprint(new Uint8Array(65).fill(1))).toThrow(
-      'Invalid public key: The key must be a 33-byte, non-zero byte array.',
+      'Invalid public key: The key must be a 33 or 32-byte, non-zero byte array.',
     );
   });
 });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -411,11 +411,11 @@ describe('getFingerprint', () => {
 
   it('throws if the public key is not a valid Uint8Array', () => {
     expect(() => getFingerprint(new Uint8Array(33).fill(0), 33)).toThrow(
-      'Invalid public key: The key must be 33 byte, non-zero byte array.',
+      'Invalid public key: The key must be a 33-byte, non-zero byte array.',
     );
 
     expect(() => getFingerprint(new Uint8Array(65).fill(1), 33)).toThrow(
-      'Invalid public key: The key must be 33 byte, non-zero byte array.',
+      'Invalid public key: The key must be a 33-byte, non-zero byte array.',
     );
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -438,13 +438,14 @@ export function validateCurve(
  * Get a 4-byte-long `Uint8Array` from a numeric value.
  *
  * @param value - The value to convert to a `Uint8Array`.
+ * @param littleEndian - Whether to use little endian byte order.
  * @returns The `Uint8Array` corresponding to the `bigint` value.
  */
-export function numberToUint32(value: number) {
+export function numberToUint32(value: number, littleEndian = false) {
   const bytes = new Uint8Array(4);
   const view = createDataView(bytes);
 
-  view.setUint32(0, value, false);
+  view.setUint32(0, value, littleEndian);
 
   return bytes;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -379,9 +379,9 @@ export const encodeBase58check = (value: Uint8Array): string => {
  * @returns The fingerprint of the public key.
  */
 export const getFingerprint = (publicKey: Uint8Array): number => {
-  if (!isValidBytesKey(publicKey, 33)) {
+  if (!isValidBytesKey(publicKey, 33) && !isValidBytesKey(publicKey, 32)) {
     throw new Error(
-      `Invalid public key: The key must be a 33-byte, non-zero byte array.`,
+      `Invalid public key: The key must be a 33 or 32-byte, non-zero byte array.`,
     );
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -385,7 +385,7 @@ export const getFingerprint = (
 ): number => {
   if (!isValidBytesKey(publicKey, compressedPublicKeyLength)) {
     throw new Error(
-      `Invalid public key: The key must be ${compressedPublicKeyLength} byte, non-zero byte array.`,
+      `Invalid public key: The key must be a ${compressedPublicKeyLength}-byte, non-zero byte array.`,
     );
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -376,12 +376,16 @@ export const encodeBase58check = (value: Uint8Array): string => {
  * Get the fingerprint of a compressed public key as number.
  *
  * @param publicKey - The compressed public key to get the fingerprint for.
+ * @param compressedPublicKeyLength - The length of the compressed public key.
  * @returns The fingerprint of the public key.
  */
-export const getFingerprint = (publicKey: Uint8Array): number => {
-  if (!isValidBytesKey(publicKey, 33) && !isValidBytesKey(publicKey, 32)) {
+export const getFingerprint = (
+  publicKey: Uint8Array,
+  compressedPublicKeyLength: number,
+): number => {
+  if (!isValidBytesKey(publicKey, compressedPublicKeyLength)) {
     throw new Error(
-      `Invalid public key: The key must be a 33 or 32-byte, non-zero byte array.`,
+      `Invalid public key: The key must be ${compressedPublicKeyLength} byte, non-zero byte array.`,
     );
   }
 

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -445,6 +445,190 @@ export default {
       ],
     },
   ],
+  cip3Icarus: [
+    {
+      // taken from CIP-03 test vectors https://github.com/cardano-foundation/CIPs/blob/09d7d8ee1bd64f7e6b20b5a6cae088039dce00cb/CIP-0003/Icarus.md#test-vectors
+      mnemonic:
+        'eight country switch draw meat scout mystery blade tip drift useless good keep usage title',
+      entropyHex: '46e62370a138a182a498b8e2885bc032379ddf38',
+      derivationPath: [`1852'`, `1815'`, `0'`, `0`, `0`],
+      nodes: {
+        bip39Node: {
+          depth: 0,
+          masterFingerprint: 1247889873,
+          parentFingerprint: 0,
+          index: 0,
+          curve: 'ed25519Bip32',
+          privateKey:
+            '0xc065afd2832cd8b087c4d9ab7011f481ee1e0721e78ea5dd609f3ab3f156d245d176bd8fd4ec60b4731c3918a2a72a0226c0cd119ec35b47e4d55884667f552a',
+          publicKey:
+            '0x757e95578798ef733ad93be322fb043053d56b445d3fe502bcf7cb4a6b0f0c6a',
+          chainCode:
+            '0x23f7fdcd4a10c6cd2c7393ac61d877873e248f417634aa3d812af327ffe9d620',
+        },
+        // rest of the nodes generated using cardano-serialization-lib
+        // https://gist.github.com/PeterBenc/342ded2c787b8140912076c7e210e3db
+        purposeNode: {
+          depth: 1,
+          masterFingerprint: 1247889873,
+          parentFingerprint: 1247889873,
+          index: 2147485500,
+          curve: 'ed25519Bip32',
+          privateKey:
+            '0x98f25c3313e03b7843072514c5f024782072406b37569403423d2361f356d2459ecc73a09adb2aa37e9f8530fd1e6745eee1ea248a85417a700e774182c7fa3d',
+          publicKey:
+            '0xd4674357f268cdb95e6b6f3c6eb2fe32f3b59932acbd1baddea4320005225d66',
+          chainCode:
+            '0x864cf884b7faf31f33733e6fc900d4446394d8d6ee55610473ef24c6bb3fb91f',
+        },
+        coinTypeNode: {
+          depth: 2,
+          masterFingerprint: 1247889873,
+          parentFingerprint: 186342781,
+          index: 2147485463,
+          curve: 'ed25519Bip32',
+          privateKey:
+            '0x504e9dc3ed6d22231a0e43cd250fcda7757b42aa9affae5f20dea1fef956d2450cc3d2abd5b6a6626d73d789a6ad77cd0e5d92e093dc5a1484c71e4f996f495e',
+          publicKey:
+            '0x9490b1415b20f286a76092d5b091f8240c169cbe5fd0695b66fbf43934ec6461',
+          chainCode:
+            '0xb84879a6adef2f9d283e8a1815cfb946ee5ce70873632097bb723ac2565d8002',
+        },
+        accountNode: {
+          depth: 3,
+          masterFingerprint: 1247889873,
+          parentFingerprint: 1372272135,
+          index: 2147483648,
+          curve: 'ed25519Bip32',
+          privateKey:
+            '0xf80081fa05eece83236e612463aafad20d6b92eee67479a1977959540057d2452173fe9a0fccf61cf2cc7c52638f2ded6c08002a71424ca5b93681ee7a385828',
+          publicKey:
+            '0x7f376415131590bf8cc88e8466fd24a6f95eebd6c2271d89cb51a81402618c9b',
+          chainCode:
+            '0x332b13689518700be3c6d330d72490c42e8a98b7495889a27851e543319fb095',
+        },
+        changeNode: {
+          depth: 4,
+          masterFingerprint: 1247889873,
+          parentFingerprint: 3705424019,
+          index: 0,
+          curve: 'ed25519Bip32',
+          privateKey:
+            '0x00b5105515ee89a7718c0bdbe05c9613a17a5907f5943dacfde9802f0157d2458bddfc042979fb8b30cb13437edc7ec7c1836676e063780d5db0b8ae84babe4e',
+          publicKey:
+            '0x4fc838b965349324a94379b4fe9ec2319c6574f30ac55c8e4e76de55f2981296',
+          chainCode:
+            '0x47b1b5663a3bddf78d9698ca580263af68a907eed0dd6421ef2daf62c20d61b9',
+        },
+        addressIndexNode: {
+          depth: 5,
+          masterFingerprint: 1247889873,
+          parentFingerprint: 3669962052,
+          index: 0,
+          curve: 'ed25519Bip32',
+          privateKey:
+            '0x00df3ecf0e02979dd9ee569d09412c1f370f476054aaa1ef3cf5a08c0557d245a6ad0fe81ab55e36178f5866dc8f83cf57239fdeee35c737ef887964aae20500',
+          publicKey:
+            '0xcc9809944150c00f3913cd2b103e9b42fe6243fc36a76f9eb800692e2bda3f2e',
+          chainCode:
+            '0x2b2dd0a9b83141f6650c40abec9ed52ecaa6a567825cb2c7a14b9452bca0c020',
+        },
+      },
+    },
+    {
+      // fixture for 24-word mnemonic since trezor implementation of mnemonic to entropy for cardano had a bug that manifested only for 24 word mnemonics and it caused trezor to deviate
+      // https://github.com/cardano-foundation/CIPs/blob/master/CIP-0003/Icarus.md#trezor
+      // note that this test case has different result since we do not deviate from the standard
+      // https://github.com/trezor/trezor-firmware/pull/1388/files#diff-17c19a8d23037f23062138997edf774fde43ab9dfbf7726d1f701edb6a2f133eR105
+      mnemonic:
+        'balance exotic ranch knife glory slow tape favorite yard gym awake ill exist useless parent aim pig stay effort into square gasp credit butter',
+      entropyHex:
+        '11aa02c63dd639987772a0fecd0040b874fde028082aa49a9d1abaed36c04cc0',
+      derivationPath: [`1852'`, `1815'`, `0'`, `0`, `0`],
+      nodes: {
+        bip39Node: {
+          depth: 0,
+          masterFingerprint: 2293781934,
+          parentFingerprint: 0,
+          index: 0,
+          curve: 'ed25519Bip32',
+          privateKey:
+            '0xe04d93999044f13fb435c6db11798e60e14064ebebcf563163e12331738c7748024836e762355f74ce59ef15e0af7ad50e6978a412543ab0bbc3a38451852206',
+          publicKey:
+            '0x3478b7d11022ab519ae6f1747d8078eb07740903fe1f7aff5909292ae39177f5',
+          chainCode:
+            '0x88f086ca813a0ce774983cfb6c88611996b2571ae2f1da894ca2fd639218d7c1',
+        },
+        // rest of the nodes generated using cardano-serialization-lib
+        // https://gist.github.com/PeterBenc/342ded2c787b8140912076c7e210e3db
+        purposeNode: {
+          depth: 1,
+          masterFingerprint: 2293781934,
+          parentFingerprint: 2293781934,
+          index: 2147485500,
+          curve: 'ed25519Bip32',
+          privateKey:
+            '0x305c7df2d77b116892dd47019a0913ad0769216e16b73d0fca6088dd748c774843861f9f2a07aff8e51c7807d92bc6ee432154a992227c0df2821d96c3a2763d',
+          publicKey:
+            '0x5a067a7fdfb79a5160b5a1b3d297e035ef193a9b464b08bfacbaab08b0798cb2',
+          chainCode:
+            '0xf13851cc3517cb6b3603ce00a7570c50f41c2c4d20edbfcdee160190f1ef9362',
+        },
+        coinTypeNode: {
+          depth: 2,
+          masterFingerprint: 2293781934,
+          parentFingerprint: 2022252320,
+          index: 2147485463,
+          curve: 'ed25519Bip32',
+          privateKey:
+            '0xd08b653d6f960079db25f38e8428f7f2891bd1c92b63ad7e0015265c768c77485bf55f8ccbb0a7188ebafcbd30219300ce3b86f54b11e236961efc814688810e',
+          publicKey:
+            '0x18bd1deaaa518b0ea46669c54c51606d505555ffc4cc6592f4bc57b41653e118',
+          chainCode:
+            '0xeb6b4805fa0f23448e20cdbb15b977cb908f4c744c0a2c0c4ee78608190d5e8a',
+        },
+        accountNode: {
+          depth: 3,
+          masterFingerprint: 2293781934,
+          parentFingerprint: 3388798503,
+          index: 2147483648,
+          curve: 'ed25519Bip32',
+          privateKey:
+            '0xe81381a5e59e98dc7eaffecc83d918ad8331938eedf3429d7d29dbfa768c774899268aba2b299d9513de3a33c134fedd19d209701456fe86757c9f64230c010f',
+          publicKey:
+            '0xce43a6e8929052830856bb58c132e5fe32c2f95697edd700a549c0bb3bf47d6f',
+          chainCode:
+            '0xa83a29374a48f18c8a423a34eb1c34dabe72b74669776999b9e87ff6bb48df7a',
+        },
+        changeNode: {
+          depth: 4,
+          masterFingerprint: 2293781934,
+          parentFingerprint: 2105312604,
+          index: 0,
+          curve: 'ed25519Bip32',
+          privateKey:
+            '0x5049005d5a97d5ea60753fb511460079a56b9981bc2e75f05e40dd46788c7748d664152bff95f76efdd0052643eb096eea6f18b6793365563bcaa12b3aa04fed',
+          publicKey:
+            '0xd756d64d9accf0a209bd7f1d2bd23500038191ff90635554fc05bff5ddd940bf',
+          chainCode:
+            '0x9534f22f806433f52d280508d89943cec05685072bbc82fa714e0d55f23f17fd',
+        },
+        addressIndexNode: {
+          depth: 5,
+          masterFingerprint: 2293781934,
+          parentFingerprint: 2627281642,
+          index: 0,
+          curve: 'ed25519Bip32',
+          privateKey:
+            '0xf0e6e40de5b8ae0d9c48f8ce7f829231aff420d792ff995dc56040f97b8c7748377ede2ad5468ce8103d2f3af977bb081c3c6aba76b36b72e56a7ba38559224d',
+          publicKey:
+            '0x40c5df588f7f2d3ccd51947dc3f9add61bb0e315d8f392a8bdce5587590bd21b',
+          chainCode:
+            '0x329c850f00e15cfa47ee8b74154c8a545fb8af4557586de29a9cd0ae72325b2f',
+        },
+      },
+    },
+  ],
 
   // The BIP-32 specification invalid extended key test vectors.
   // https://github.com/bitcoin/bips/blob/a3a397c82384220fc871852c809f73898a4d547c/bip-0032.mediawiki#test-vector-5

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -445,7 +445,7 @@ export default {
       ],
     },
   ],
-  cip3Icarus: [
+  cip3: [
     {
       // taken from CIP-03 test vectors https://github.com/cardano-foundation/CIPs/blob/09d7d8ee1bd64f7e6b20b5a6cae088039dce00cb/CIP-0003/Icarus.md#test-vectors
       mnemonic:

--- a/test/vectors.test.ts
+++ b/test/vectors.test.ts
@@ -11,7 +11,7 @@ import {
 } from '../src/derivers/bip39';
 import derivationVectors from './vectors/derivation.json';
 
-type Vector = typeof derivationVectors.bip32.hardened[0];
+type Vector = (typeof derivationVectors.bip32.hardened)[0];
 
 const masterNodeFromSeed = async (seed: Uint8Array, curve: Curve) => {
   return curve.masterNodeGenerationSpec === 'slip10'

--- a/test/vectors.test.ts
+++ b/test/vectors.test.ts
@@ -7,7 +7,7 @@ import type { Curve } from '../src/curves';
 import { ed25519Bip32, ed25519 } from '../src/curves';
 import {
   createBip39KeyFromSeed,
-  entropyToCip3IcarusMasterNode,
+  entropyToCip3MasterNode,
 } from '../src/derivers/bip39';
 import derivationVectors from './vectors/derivation.json';
 
@@ -17,7 +17,7 @@ const masterNodeFromSeed = async (seed: Uint8Array, curve: Curve) => {
   return curve.masterNodeGenerationSpec === 'slip10'
     ? createBip39KeyFromSeed(seed, curve)
     : // in the context of tests, we assume seed to be just random bytes which we use here as entropy
-      entropyToCip3IcarusMasterNode(seed, curve);
+      entropyToCip3MasterNode(seed, curve);
 };
 
 type Options = {
@@ -168,15 +168,15 @@ describe('vectors', () => {
     });
   });
 
-  describe('cip3Icarus', () => {
+  describe('cip3', () => {
     describe('hardened', () => {
-      for (const vector of derivationVectors.cip3Icarus.hardened) {
+      for (const vector of derivationVectors.cip3.hardened) {
         generateTests(vector, { curve: ed25519Bip32 });
       }
     });
 
     describe('unhardened', () => {
-      for (const vector of derivationVectors.cip3Icarus.unhardened) {
+      for (const vector of derivationVectors.cip3.unhardened) {
         generateTests(vector, {
           publicDerivation: true,
           curve: ed25519Bip32,
@@ -185,7 +185,7 @@ describe('vectors', () => {
     });
 
     describe('mixed', () => {
-      for (const vector of derivationVectors.cip3Icarus.mixed) {
+      for (const vector of derivationVectors.cip3.mixed) {
         generateTests(vector, { curve: ed25519Bip32 });
       }
     });


### PR DESCRIPTION
### What is the current state of things and why does it need to change?

- currently, this lib supports `secp256k1` and `ed25519`
- while developing a Snap for Cardano, we realized that keys derived by snap, using (`getBip32Entropy`) are different from keys that would standard Cardano wallet give, for the same mnemonic
- this inconsistency could lead to confusion and interoperability issues
- currently developed Cardano snap, relies on these changes, and is blocked by this. (note that changes need to be made also to `metamask-snaps` and `metamask-extension` repos, which are ready, awaiting feedback on this)



### What is the solution your changes offer and how does it work?

- by supporting derivation which is consistent with Cardano standard, we enable current Cardano users to use their existing mnemonics in Metamask and get the same wallet they used until now.
- similarily, we would enable current Metamask users to use their mnemonic in standard Cardano wallets and retrieve same addresses as they would through Cardano-Metamask snap.

For this reasons
- we add a new derivation `curve`, called `ed25519Bip32`, this curve implements a slight modification of how standard `ed25519` is used in SLIP10. 

- we add a new `deriver`, called `cip3Icarus` which derives keys according to `CIP3` (which is the standard for Cardano)

- from the interface point of view, these changes allow us to call 

  ```js
  await deriveKeyFromPath({
     path: ["cip3Icarus:1852'", "cip3Icarus: 1815'"],
     curve: 'ed25519Bip32',
  })
  ```

  which returns keys consistent with Cardano derivation standard



**A longer explanation, also present in the code**

[CIP-3](https://github.com/cardano-foundation/CIPs/blob/09d7d8ee1bd64f7e6b20b5a6cae088039dce00cb/CIP-0003/CIP-0003.md) defines standards for deriving keys on Cardano.
 
 Key attributes

   * Root/Master key is derived from entropy, not seed. For this implementation we work with **Icarus** standard as it is the most widely used. See https://github.com/cardano-foundation/CIPs/blob/09d7d8ee1bd64f7e6b20b5a6cae088039dce00cb/CIP-0003/Icarus.md.
     
   * HD node consists of a 64 byte private key, 32 byte public key and 32 byte chain code. See https://github.com/cardano-foundation/CIPs/blob/09d7d8ee1bd64f7e6b20b5a6cae088039dce00cb/CIP-0003/CIP-0003.md#master-key-generation.
     
   * For derivation of BIP32 HD nodes, it uses modified implementation of ed25519 called BIP32-Ed25519. See https://input-output-hk.github.io/adrestia/static/Ed25519_BIP.pdf.


### Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

All sources are referenced in the code, and explained quite extensively, namely

- [CIP3](https://github.com/cardano-foundation/CIPs/blob/09d7d8ee1bd64f7e6b20b5a6cae088039dce00cb/CIP-0003/CIP-0003.md)
- [ed25519Bip32](https://input-output-hk.github.io/adrestia/static/Ed25519_BIP.pdf)

Reference implementations

- [cardano-js-sdk](https://github.com/input-output-hk/cardano-js-sdk/tree/master/packages/crypto)
- [cardano-crypto.js](https://github.com/vacuumlabs/cardano-crypto.js)