### PR TITLE
Remove unneeded modular reduction in CIP-3 private key derivation

### DIFF
--- a/src/derivers/cip3.ts
+++ b/src/derivers/cip3.ts
@@ -184,7 +184,7 @@ export const derivePrivateKey = async ({
   // 8[ZL] + kPL
   const childKl = add(trunc28Mul8(zl), parentKl);
   // ZR + kPR
-  const childKr = add(zr, mod2Pow256(parentKr));
+  const childKr = add(zr, parentKr);
   return concatBytes([childKl, childKr]);
 };
 


### PR DESCRIPTION
As brought up in the recent audit of `key-tree`, modular reduction here is redundant, and does not change the result of the function.

Related to MM-04-002 WP.