### PR TITLE
Export `getBIP44CoinTypeToAddressPathTuple` function

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -8,6 +8,7 @@ import {
   createBip39KeyFromSeed,
   mnemonicPhraseToBytes,
   ed25519Bip32,
+  getBIP44CoinTypeToAddressPathTuple,
 } from '.';
 
 // This is purely for coverage shenanigans
@@ -23,5 +24,6 @@ describe('index', () => {
     expect(isValidBIP32PathSegment).toBeDefined();
     expect(createBip39KeyFromSeed).toBeDefined();
     expect(mnemonicPhraseToBytes).toBeDefined();
+    expect(getBIP44CoinTypeToAddressPathTuple).toBeDefined();
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,5 +29,9 @@ export {
 } from './BIP44CoinTypeNode';
 export * from './constants';
 export type { CoinTypeToAddressIndices } from './utils';
-export { isValidBIP32PathSegment, mnemonicPhraseToBytes } from './utils';
+export {
+  getBIP44CoinTypeToAddressPathTuple,
+  isValidBIP32PathSegment,
+  mnemonicPhraseToBytes,
+} from './utils';
 export { createBip39KeyFromSeed } from './derivers';


### PR DESCRIPTION
This adds an export for the `getBIP44CoinTypeToAddressPathTuple` function, making it importable from `@metamask/key-tree`.

Closes #168.