### PR TITLE
Add cryptographic functions with option to specify custom functions

### DIFF
--- a/src/cryptography.test.ts
+++ b/src/cryptography.test.ts
@@ -1,4 +1,5 @@
 import { bytesToHex } from '@metamask/utils';
+import { webcrypto } from 'crypto';
 
 import {
   hmacSha512,
@@ -8,6 +9,10 @@ import {
   sha256,
 } from './cryptography';
 import * as utils from './utils';
+
+// Node.js <20 doesn't have `globalThis.crypto`, so we need to define it.
+// TODO: Remove this once we drop support for Node.js <20.
+Object.defineProperty(globalThis, 'crypto', { value: webcrypto });
 
 describe('hmacSha512', () => {
   it('returns the HMAC-SHA-512 when using a custom implementation', async () => {

--- a/src/cryptography.test.ts
+++ b/src/cryptography.test.ts
@@ -1,0 +1,130 @@
+import { bytesToHex } from '@metamask/utils';
+
+import {
+  hmacSha512,
+  keccak256,
+  pbkdf2Sha512,
+  ripemd160,
+  sha256,
+} from './cryptography';
+import * as utils from './utils';
+
+describe('hmacSha512', () => {
+  it('returns the HMAC-SHA-512 when using a custom implementation', async () => {
+    const key = new Uint8Array(32);
+    const data = new Uint8Array(32);
+
+    const hash = new Uint8Array(64).fill(1);
+    const customHmacSha512 = jest.fn().mockResolvedValue(hash);
+
+    const result = await hmacSha512(key, data, {
+      hmacSha512: customHmacSha512,
+    });
+
+    expect(result).toBe(hash);
+    expect(customHmacSha512).toHaveBeenCalledWith(key, data);
+  });
+
+  it('returns the HMAC-SHA-512 when using the Web Crypto API', async () => {
+    const key = new Uint8Array(32);
+    const data = new Uint8Array(32);
+
+    const result = await hmacSha512(key, data);
+    expect(bytesToHex(result)).toBe(
+      '0xbae46cebebbb90409abc5acf7ac21fdb339c01ce15192c52fb9e8aa11a8de9a4ea15a045f2be245fbb98916a9ae81b353e33b9c42a55380c5158241daeb3c6dd',
+    );
+  });
+
+  it('returns the HMAC-SHA-512 when using the fallback', async () => {
+    jest.spyOn(utils, 'isWebCryptoSupported').mockReturnValueOnce(false);
+
+    const key = new Uint8Array(32);
+    const data = new Uint8Array(32);
+
+    const result = await hmacSha512(key, data);
+    expect(bytesToHex(result)).toBe(
+      '0xbae46cebebbb90409abc5acf7ac21fdb339c01ce15192c52fb9e8aa11a8de9a4ea15a045f2be245fbb98916a9ae81b353e33b9c42a55380c5158241daeb3c6dd',
+    );
+  });
+});
+
+describe('keccak256', () => {
+  it('returns the keccak-256 hash of the data', () => {
+    const data = new Uint8Array(32).fill(1);
+    const hash = keccak256(data);
+
+    expect(bytesToHex(hash)).toBe(
+      '0xcebc8882fecbec7fb80d2cf4b312bec018884c2d66667c67a90508214bd8bafc',
+    );
+  });
+});
+
+describe('pbkdf2Sha512', () => {
+  it('returns the PBKDF2-SHA-512 when using a custom implementation', async () => {
+    const password = new Uint8Array(32);
+    const salt = new Uint8Array(32);
+    const iterations = 1000;
+    const keyLength = 64;
+
+    const hash = new Uint8Array(64).fill(1);
+    const customPbkdf2Sha512 = jest.fn().mockResolvedValue(hash);
+
+    const result = await pbkdf2Sha512(password, salt, iterations, keyLength, {
+      pbkdf2Sha512: customPbkdf2Sha512,
+    });
+
+    expect(result).toBe(hash);
+    expect(customPbkdf2Sha512).toHaveBeenCalledWith(
+      password,
+      salt,
+      iterations,
+      keyLength,
+    );
+  });
+
+  it('returns the PBKDF2-SHA-512 when using the Web Crypto API', async () => {
+    const password = new Uint8Array(32);
+    const salt = new Uint8Array(32);
+    const iterations = 1000;
+    const keyLength = 64;
+
+    const result = await pbkdf2Sha512(password, salt, iterations, keyLength);
+    expect(bytesToHex(result)).toBe(
+      '0xab3d65e9e6341a924c752a77b8dc6b78f1e6db5d31df7dd0cc534039dd9662a97bcaf0b959fe78248a49859c7952ddb25d66840f052b27ef1ab60b9446c0c9fd',
+    );
+  });
+
+  it('returns the PBKDF2-SHA-512 when using the fallback', async () => {
+    jest.spyOn(utils, 'isWebCryptoSupported').mockReturnValueOnce(false);
+
+    const password = new Uint8Array(32);
+    const salt = new Uint8Array(32);
+    const iterations = 1000;
+    const keyLength = 64;
+
+    const result = await pbkdf2Sha512(password, salt, iterations, keyLength);
+    expect(bytesToHex(result)).toBe(
+      '0xab3d65e9e6341a924c752a77b8dc6b78f1e6db5d31df7dd0cc534039dd9662a97bcaf0b959fe78248a49859c7952ddb25d66840f052b27ef1ab60b9446c0c9fd',
+    );
+  });
+});
+
+describe('ripemd160', () => {
+  it('returns the RIPEMD-160 hash of the data', () => {
+    const data = new Uint8Array(32).fill(1);
+    const hash = ripemd160(data);
+
+    expect(bytesToHex(hash)).toBe('0x422d0010f16ae8539c53eb57a912890244a9eb5a');
+  });
+});
+
+describe('sha256', () => {
+  it('returns the SHA-256 hash of the data', () => {
+    const data = new Uint8Array(32).fill(1);
+    const hash = sha256(data);
+
+    expect(bytesToHex(hash)).toBe(
+      '0x72cd6e8422c407fb6d098690f1130b7ded7ec2f7f5e1d30bd9d521f015363793',
+    );
+  });
+});

--- a/src/cryptography.ts
+++ b/src/cryptography.ts
@@ -118,7 +118,7 @@ export async function pbkdf2Sha512(
 
   if (isWebCryptoSupported()) {
     /* eslint-disable no-restricted-globals */
-    const result = await crypto.subtle.importKey(
+    const key = await crypto.subtle.importKey(
       'raw',
       password,
       { name: 'PBKDF2' },
@@ -133,7 +133,9 @@ export async function pbkdf2Sha512(
         iterations,
         hash: { name: 'SHA-512' },
       },
-      result,
+      key,
+      // `keyLength` is the number of bytes, but `deriveBits` expects the
+      // number of bits, so we multiply by 8.
       keyLength * 8,
     );
 

--- a/src/cryptography.ts
+++ b/src/cryptography.ts
@@ -24,7 +24,7 @@ export type CryptographicFunctions = {
    * @param password - The password to hash.
    * @param salt - The salt to use.
    * @param iterations - The number of iterations.
-   * @param keyLength - The desired key length.
+   * @param keyLength - The desired key length in bytes.
    * @returns The PBKDF2 of the password.
    */
   pbkdf2Sha512?: (

--- a/src/cryptography.ts
+++ b/src/cryptography.ts
@@ -1,0 +1,176 @@
+import { hmac as nobleHmac } from '@noble/hashes/hmac';
+import { pbkdf2Async as noblePbkdf2 } from '@noble/hashes/pbkdf2';
+import { ripemd160 as nobleRipemd160 } from '@noble/hashes/ripemd160';
+import { sha256 as nobleSha256 } from '@noble/hashes/sha256';
+import { keccak_256 as nobleKeccak256 } from '@noble/hashes/sha3';
+import { sha512 as nobleSha512 } from '@noble/hashes/sha512';
+
+import { isWebCryptoSupported } from './utils';
+
+export type CryptographicFunctions = {
+  /**
+   * Compute the HMAC-SHA-512 of the given data using the given key.
+   *
+   * @param key - The key to use.
+   * @param data - The data to hash.
+   * @returns The HMAC-SHA-512 of the data.
+   */
+  hmacSha512?: (key: Uint8Array, data: Uint8Array) => Promise<Uint8Array>;
+
+  /**
+   * Compute the PBKDF2 of the given password, salt, iterations, and key length.
+   * The hash function used is SHA-512.
+   *
+   * @param password - The password to hash.
+   * @param salt - The salt to use.
+   * @param iterations - The number of iterations.
+   * @param keyLength - The desired key length.
+   * @returns The PBKDF2 of the password.
+   */
+  pbkdf2Sha512?: (
+    password: Uint8Array,
+    salt: Uint8Array,
+    iterations: number,
+    keyLength: number,
+  ) => Promise<Uint8Array>;
+};
+
+/**
+ * Compute the HMAC-SHA-512 of the given data using the given key.
+ *
+ * This function uses the Web Crypto API if available, falling back to a
+ * JavaScript implementation if not.
+ *
+ * @param key - The key to use.
+ * @param data - The data to hash.
+ * @param cryptographicFunctions - The cryptographic functions to use. If
+ * provided, these will be used instead of the built-in implementations.
+ * @returns The HMAC-SHA-512 of the data.
+ */
+export async function hmacSha512(
+  key: Uint8Array,
+  data: Uint8Array,
+  cryptographicFunctions: CryptographicFunctions = {},
+): Promise<Uint8Array> {
+  if (cryptographicFunctions.hmacSha512) {
+    return await cryptographicFunctions.hmacSha512(key, data);
+  }
+
+  if (isWebCryptoSupported()) {
+    /* eslint-disable no-restricted-globals */
+    const subtleKey = await crypto.subtle.importKey(
+      'raw',
+      key,
+      { name: 'HMAC', hash: 'SHA-512' },
+      false,
+      ['sign'],
+    );
+
+    const result = await crypto.subtle.sign('HMAC', subtleKey, data);
+    return new Uint8Array(result);
+    /* eslint-enable no-restricted-globals */
+  }
+
+  return nobleHmac(nobleSha512, key, data);
+}
+
+/**
+ * Compute the Keccak-256 of the given data synchronously.
+ *
+ * Right now this is just a wrapper around `keccak256` from the `@noble/hashes`
+ * package, but it's here in case we want to change the implementation in the
+ * future to allow for asynchronous hashing.
+ *
+ * @param data - The data to hash.
+ * @returns The Keccak-256 of the data.
+ */
+export function keccak256(data: Uint8Array): Uint8Array {
+  return nobleKeccak256(data);
+}
+
+/**
+ * Compute the PBKDF2 of the given password, salt, iterations, and key length.
+ * The hash function used is SHA-512.
+ *
+ * @param password - The password to hash.
+ * @param salt - The salt to use.
+ * @param iterations - The number of iterations.
+ * @param keyLength - The desired key length.
+ * @param cryptographicFunctions - The cryptographic functions to use. If
+ * provided, these will be used instead of the built-in implementations.
+ * @returns The PBKDF2 of the password.
+ */
+export async function pbkdf2Sha512(
+  password: Uint8Array,
+  salt: Uint8Array,
+  iterations: number,
+  keyLength: number,
+  cryptographicFunctions: CryptographicFunctions = {},
+): Promise<Uint8Array> {
+  if (cryptographicFunctions.pbkdf2Sha512) {
+    return await cryptographicFunctions.pbkdf2Sha512(
+      password,
+      salt,
+      iterations,
+      keyLength,
+    );
+  }
+
+  if (isWebCryptoSupported()) {
+    /* eslint-disable no-restricted-globals */
+    const result = await crypto.subtle.importKey(
+      'raw',
+      password,
+      { name: 'PBKDF2' },
+      false,
+      ['deriveBits'],
+    );
+
+    const derivedBits = await crypto.subtle.deriveBits(
+      {
+        name: 'PBKDF2',
+        salt,
+        iterations,
+        hash: { name: 'SHA-512' },
+      },
+      result,
+      keyLength * 8,
+    );
+
+    return new Uint8Array(derivedBits);
+    /* eslint-enable no-restricted-globals */
+  }
+
+  return await noblePbkdf2(nobleSha512, password, salt, {
+    c: iterations,
+    dkLen: keyLength,
+  });
+}
+
+/**
+ * Compute the RIPEMD-160 of the given data.
+ *
+ * Right now this is just a wrapper around `ripemd160` from the `@noble/hashes`
+ * package, but it's here in case we want to change the implementation in the
+ * future to allow for asynchronous hashing.
+ *
+ * @param data - The data to hash.
+ * @returns The RIPEMD-160 of the data.
+ */
+export function ripemd160(data: Uint8Array): Uint8Array {
+  return nobleRipemd160(data);
+}
+
+/**
+ * Compute the SHA-256 of the given data synchronously.
+ *
+ * Right now this is just a wrapper around `sha256` from the `@noble/hashes`
+ * package, but it's here in case we want to change the implementation in the
+ * future to allow for asynchronous hashing.
+ *
+ * @param data - The data to hash.
+ * @returns The SHA-256 of the data.
+ */
+export function sha256(data: Uint8Array): Uint8Array {
+  return nobleSha256(data);
+}

--- a/src/derivers/bip32.ts
+++ b/src/derivers/bip32.ts
@@ -1,8 +1,8 @@
 import { assert } from '@metamask/utils';
-import { keccak_256 as keccak256 } from '@noble/hashes/sha3';
 
 import type { DeriveChildKeyArgs } from '.';
 import { BYTES_KEY_LENGTH } from '../constants';
+import { keccak256 } from '../cryptography';
 import { secp256k1 } from '../curves';
 import type { SLIP10Node } from '../SLIP10Node';
 import { isValidBytesKey, validateBIP32Index } from '../utils';
@@ -102,7 +102,7 @@ async function handleError(
       curve,
     });
 
-    const newEntropy = generateEntropy({
+    const newEntropy = await generateEntropy({
       chainCode,
       extension: secretExtension,
     });
@@ -119,7 +119,7 @@ async function handleError(
     childIndex: childIndex + 1,
   });
 
-  const newEntropy = generateEntropy({
+  const newEntropy = await generateEntropy({
     chainCode,
     extension: publicExtension,
   });

--- a/src/derivers/bip32.ts
+++ b/src/derivers/bip32.ts
@@ -2,6 +2,7 @@ import { assert } from '@metamask/utils';
 
 import type { DeriveChildKeyArgs } from '.';
 import { BYTES_KEY_LENGTH } from '../constants';
+import type { CryptographicFunctions } from '../cryptography';
 import { keccak256 } from '../cryptography';
 import { secp256k1 } from '../curves';
 import type { SLIP10Node } from '../SLIP10Node';
@@ -63,17 +64,20 @@ export function publicKeyToEthAddress(key: Uint8Array) {
  * @param options.path - The derivation path part to derive.
  * @param options.node - The node to derive from.
  * @param options.curve - The curve to use for derivation.
+ * @param cryptographicFunctions - The cryptographic functions to use. If
+ * provided, these will be used instead of the built-in implementations.
  * @returns The derived child key as a {@link SLIP10Node}.
  */
 export async function deriveChildKey(
   options: DeriveChildKeyArgs,
+  cryptographicFunctions?: CryptographicFunctions,
 ): Promise<SLIP10Node> {
   assert(
     options.curve.name === 'secp256k1',
     'Invalid curve: Only secp256k1 is supported by BIP-32.',
   );
 
-  return sharedDeriveChildKey(options, handleError);
+  return sharedDeriveChildKey(options, handleError, cryptographicFunctions);
 }
 
 /**
@@ -82,12 +86,15 @@ export async function deriveChildKey(
  *
  * @param _ - The error that was thrown.
  * @param options - The options for deriving a child key.
+ * @param cryptographicFunctions - The cryptographic functions to use. If
+ * provided, these will be used instead of the built-in implementations.
  * @returns The options for deriving a child key with the child index
  * incremented by one.
  */
 async function handleError(
   _: unknown,
   options: DeriveNodeArgs,
+  cryptographicFunctions?: CryptographicFunctions,
 ): Promise<DeriveNodeArgs> {
   const { childIndex, privateKey, publicKey, isHardened, curve, chainCode } =
     options;
@@ -102,10 +109,13 @@ async function handleError(
       curve,
     });
 
-    const newEntropy = await generateEntropy({
-      chainCode,
-      extension: secretExtension,
-    });
+    const newEntropy = await generateEntropy(
+      {
+        chainCode,
+        extension: secretExtension,
+      },
+      cryptographicFunctions,
+    );
 
     return {
       ...options,

--- a/src/derivers/bip39.test.ts
+++ b/src/derivers/bip39.test.ts
@@ -39,6 +39,22 @@ describe('mnemonicToSeed', () => {
       const generatedSeed = await mnemonicToSeed(mnemonic);
       expect(generatedSeed).toStrictEqual(seed);
     });
+
+    it('throws if the length of the mnemonic phrase is invalid', async () => {
+      await expect(mnemonicToSeed('test')).rejects.toThrow(
+        'Invalid mnemonic phrase: The mnemonic phrase must consist of 12, 15, 18, 21, or 24 words.',
+      );
+    });
+
+    it('throws if the mnemonic phrase contains invalid words', async () => {
+      await expect(
+        mnemonicToSeed(
+          'test test test test test test test test test invalid mnemonic phrase',
+        ),
+      ).rejects.toThrow(
+        'Invalid mnemonic phrase: The mnemonic phrase contains an unknown word.',
+      );
+    });
   });
 
   describe('with passphrase', () => {

--- a/src/derivers/bip39.test.ts
+++ b/src/derivers/bip39.test.ts
@@ -21,6 +21,7 @@ const TEST_MNEMONIC_PHRASE =
 
 describe('mnemonicToSeed', () => {
   describe('without passphrase', () => {
+    // https://github.com/MetaMask/scure-bip39/blob/612c6952ca8aee034e32dd0dc307c1d96e325ae2/test/bip39.test.ts#L127-L132
     const seed = new Uint8Array([
       213, 198, 189, 89, 252, 121, 48, 207, 56, 105, 8, 152, 129, 116, 186, 218,
       26, 71, 225, 55, 201, 122, 153, 178, 5, 235, 40, 132, 179, 248, 166, 147,
@@ -59,6 +60,8 @@ describe('mnemonicToSeed', () => {
 
   describe('with passphrase', () => {
     const passphrase = 'passphrase';
+
+    // https://github.com/MetaMask/scure-bip39/blob/612c6952ca8aee034e32dd0dc307c1d96e325ae2/test/bip39.test.ts#L162-L167
     const seed = new Uint8Array([
       180, 211, 212, 196, 151, 216, 92, 25, 11, 35, 14, 186, 80, 80, 141, 156,
       245, 11, 25, 118, 50, 75, 80, 36, 116, 113, 11, 112, 36, 86, 70, 188, 92,

--- a/src/derivers/bip39.test.ts
+++ b/src/derivers/bip39.test.ts
@@ -4,15 +4,68 @@ import {
   concatBytes,
   hexToBytes,
 } from '@metamask/utils';
-import * as hmacModule from '@noble/hashes/hmac';
 
 import fixtures from '../../test/fixtures';
+import * as cryptography from '../cryptography';
 import { secp256k1, ed25519Bip32, type Curve } from '../curves';
+import { mnemonicPhraseToBytes } from '../utils';
 import {
   entropyToCip3MasterNode,
   createBip39KeyFromSeed,
   deriveChildKey,
+  mnemonicToSeed,
 } from './bip39';
+
+const TEST_MNEMONIC_PHRASE =
+  'pill frown erosion humor invest inquiry rich garment seek such mention punch';
+
+describe('mnemonicToSeed', () => {
+  describe('without passphrase', () => {
+    const seed = new Uint8Array([
+      213, 198, 189, 89, 252, 121, 48, 207, 56, 105, 8, 152, 129, 116, 186, 218,
+      26, 71, 225, 55, 201, 122, 153, 178, 5, 235, 40, 132, 179, 248, 166, 147,
+      18, 128, 248, 25, 184, 206, 113, 170, 71, 235, 73, 144, 0, 134, 22, 244,
+      18, 229, 222, 139, 246, 28, 123, 131, 16, 215, 191, 216, 252, 159, 213,
+      235,
+    ]);
+
+    it('generates the right seed for a string mnemonic phrase', async () => {
+      const generatedSeed = await mnemonicToSeed(TEST_MNEMONIC_PHRASE);
+      expect(generatedSeed).toStrictEqual(seed);
+    });
+
+    it('generates the right seed for a Uint8Array mnemonic phrase', async () => {
+      const mnemonic = mnemonicPhraseToBytes(TEST_MNEMONIC_PHRASE);
+      const generatedSeed = await mnemonicToSeed(mnemonic);
+      expect(generatedSeed).toStrictEqual(seed);
+    });
+  });
+
+  describe('with passphrase', () => {
+    const passphrase = 'passphrase';
+    const seed = new Uint8Array([
+      180, 211, 212, 196, 151, 216, 92, 25, 11, 35, 14, 186, 80, 80, 141, 156,
+      245, 11, 25, 118, 50, 75, 80, 36, 116, 113, 11, 112, 36, 86, 70, 188, 92,
+      156, 172, 167, 83, 159, 47, 149, 92, 107, 130, 66, 39, 251, 34, 169, 115,
+      143, 121, 110, 166, 28, 221, 93, 252, 165, 155, 127, 19, 138, 107, 135,
+    ]);
+
+    it('generates the right seed for a string mnemonic phrase', async () => {
+      const generatedSeed = await mnemonicToSeed(
+        TEST_MNEMONIC_PHRASE,
+        passphrase,
+      );
+
+      expect(generatedSeed).toStrictEqual(seed);
+    });
+
+    it('generates the right seed for a Uint8Array mnemonic phrase', async () => {
+      const mnemonic = mnemonicPhraseToBytes(TEST_MNEMONIC_PHRASE);
+      const generatedSeed = await mnemonicToSeed(mnemonic, passphrase);
+      expect(generatedSeed).toStrictEqual(seed);
+    });
+  });
+});
 
 describe('createBip39KeyFromSeed', () => {
   const RANDOM_SEED = hexToBytes(
@@ -37,7 +90,9 @@ describe('createBip39KeyFromSeed', () => {
 
   it('throws if the private key is zero', async () => {
     // Mock the hmac function to return a zero private key.
-    jest.spyOn(hmacModule, 'hmac').mockImplementation(() => new Uint8Array(64));
+    jest
+      .spyOn(cryptography, 'hmacSha512')
+      .mockResolvedValueOnce(new Uint8Array(64));
 
     await expect(
       createBip39KeyFromSeed(RANDOM_SEED, secp256k1),
@@ -57,10 +112,8 @@ describe('createBip39KeyFromSeed', () => {
 
       // Mock the hmac function to return a private key larger than the curve order.
       jest
-        .spyOn(hmacModule, 'hmac')
-        .mockImplementation(() =>
-          concatBytes([privateKey, new Uint8Array(32)]),
-        );
+        .spyOn(cryptography, 'hmacSha512')
+        .mockResolvedValueOnce(concatBytes([privateKey, new Uint8Array(32)]));
 
       await expect(
         createBip39KeyFromSeed(RANDOM_SEED, secp256k1),

--- a/src/derivers/bip39.ts
+++ b/src/derivers/bip39.ts
@@ -11,6 +11,31 @@ import type { Curve } from '../curves';
 import { SLIP10Node } from '../SLIP10Node';
 import { getFingerprint } from '../utils';
 
+const MNEMONIC_PHRASE_LENGTHS = [12, 15, 18, 21, 24];
+
+/**
+ * Validate a BIP-39 mnemonic phrase. The phrase must:
+ *
+ * - Consist of 12, 15, 18, 21, or 24 words.
+ * - Contain only words from the English wordlist.
+ *
+ * @param mnemonicPhrase - The mnemonic phrase to validate.
+ * @throws If the mnemonic phrase is invalid.
+ */
+function validateMnemonicPhrase(mnemonicPhrase: string) {
+  const words = mnemonicPhrase.split(' ');
+
+  assert(
+    MNEMONIC_PHRASE_LENGTHS.includes(words.length),
+    `Invalid mnemonic phrase: The mnemonic phrase must consist of 12, 15, 18, 21, or 24 words.`,
+  );
+
+  assert(
+    words.every((word) => englishWordlist.includes(word)),
+    'Invalid mnemonic phrase: The mnemonic phrase contains an unknown word.',
+  );
+}
+
 /**
  * Encode a BIP-39 mnemonic phrase to a `Uint8Array` for use in seed generation.
  * If the mnemonic is already a `Uint8Array`, it is assumed to contain the
@@ -25,14 +50,16 @@ function encodeMnemonicPhrase(
   wordlist: string[],
 ) {
   if (typeof mnemonic === 'string') {
+    validateMnemonicPhrase(mnemonic);
     return stringToBytes(mnemonic.normalize('NFKD'));
   }
 
-  return stringToBytes(
-    Array.from(new Uint16Array(mnemonic.buffer))
-      .map((i) => wordlist[i])
-      .join(' '),
-  );
+  const mnemonicString = Array.from(new Uint16Array(mnemonic.buffer))
+    .map((i) => wordlist[i])
+    .join(' ');
+
+  validateMnemonicPhrase(mnemonicString);
+  return stringToBytes(mnemonicString);
 }
 
 /**

--- a/src/derivers/bip39.ts
+++ b/src/derivers/bip39.ts
@@ -119,7 +119,6 @@ export async function deriveChildKey(
       );
     case 'cip3':
       return entropyToCip3MasterNode(
-        // TODO: Replace this.
         mnemonicToEntropy(path, englishWordlist),
         curve,
         cryptographicFunctions,

--- a/src/derivers/bip39.ts
+++ b/src/derivers/bip39.ts
@@ -77,9 +77,10 @@ export async function mnemonicToSeed(
   passphrase = '',
   cryptographicFunctions?: CryptographicFunctions,
 ) {
+  const salt = `mnemonic${passphrase}`.normalize('NFKD');
   return await pbkdf2Sha512(
     encodeMnemonicPhrase(mnemonic, englishWordlist),
-    stringToBytes(`mnemonic${passphrase}`.normalize('NFKD')),
+    stringToBytes(salt),
     2048,
     64,
     cryptographicFunctions,

--- a/src/derivers/cip3.ts
+++ b/src/derivers/cip3.ts
@@ -170,7 +170,7 @@ export const derivePrivateKey = async ({
     : getKeyExtension(Z_TAGS.normal, parentNode.publicKeyBytes, childIndex);
 
   // entropy = Fcp(extension)
-  const entropy = generateEntropy({
+  const entropy = await generateEntropy({
     chainCode: parentNode.chainCodeBytes,
     extension,
   });
@@ -231,7 +231,7 @@ export const deriveChainCode = async ({
       );
 
   // entropy = Fcp(extension)
-  const entropy = generateEntropy({
+  const entropy = await generateEntropy({
     chainCode: parentNode.chainCodeBytes,
     extension,
   });
@@ -271,7 +271,7 @@ export const derivePublicKey = async ({
   );
 
   // entropy = Fcp(extension)
-  const entropy = generateEntropy({
+  const entropy = await generateEntropy({
     chainCode: parentNode.chainCodeBytes,
     extension,
   });

--- a/src/derivers/index.test.ts
+++ b/src/derivers/index.test.ts
@@ -1,7 +1,8 @@
-import { createBip39KeyFromSeed } from '.';
+import { createBip39KeyFromSeed, mnemonicToSeed } from '.';
 
 describe('index', () => {
   it('has expected exports', () => {
     expect(createBip39KeyFromSeed).toBeDefined();
+    expect(mnemonicToSeed).toBeDefined();
   });
 });

--- a/src/derivers/index.ts
+++ b/src/derivers/index.ts
@@ -31,4 +31,4 @@ export const derivers = {
   cip3,
 };
 
-export { createBip39KeyFromSeed } from './bip39';
+export { createBip39KeyFromSeed, mnemonicToSeed } from './bip39';

--- a/src/derivers/index.ts
+++ b/src/derivers/index.ts
@@ -1,3 +1,4 @@
+import type { CryptographicFunctions } from '../cryptography';
 import type { Curve } from '../curves';
 import type { SLIP10Node } from '../SLIP10Node';
 import * as bip32 from './bip32';
@@ -21,7 +22,10 @@ export type DeriveChildKeyArgs = {
 };
 
 export type Deriver = {
-  deriveChildKey: (args: DeriveChildKeyArgs) => Promise<SLIP10Node>;
+  deriveChildKey: (
+    args: DeriveChildKeyArgs,
+    cryptographicFunctions?: CryptographicFunctions,
+  ) => Promise<SLIP10Node>;
 };
 
 export const derivers = {

--- a/src/derivers/shared.ts
+++ b/src/derivers/shared.ts
@@ -4,11 +4,10 @@ import {
   concatBytes,
   hexToBytes,
 } from '@metamask/utils';
-import { hmac } from '@noble/hashes/hmac';
-import { sha512 } from '@noble/hashes/sha512';
 
 import type { DeriveChildKeyArgs, DerivedKeys } from '.';
 import { BIP_32_HARDENED_OFFSET, UNPREFIXED_PATH_REGEX } from '../constants';
+import { hmacSha512 } from '../cryptography';
 import type { Curve } from '../curves';
 import { mod } from '../curves';
 import { SLIP10Node } from '../SLIP10Node';
@@ -59,7 +58,7 @@ export async function deriveChildKey(
       curve,
     });
 
-    const entropy = generateEntropy({
+    const entropy = await generateEntropy({
       chainCode: node.chainCodeBytes,
       extension: secretExtension,
     });
@@ -79,7 +78,7 @@ export async function deriveChildKey(
     childIndex,
   });
 
-  const entropy = generateEntropy({
+  const entropy = await generateEntropy({
     chainCode: node.chainCodeBytes,
     extension: publicExtension,
   });
@@ -464,8 +463,11 @@ type GenerateEntropyArgs = {
  * @param args.extension - The extension bytes.
  * @returns The generated entropy bytes.
  */
-export function generateEntropy({ chainCode, extension }: GenerateEntropyArgs) {
-  return hmac(sha512, chainCode, extension);
+export async function generateEntropy({
+  chainCode,
+  extension,
+}: GenerateEntropyArgs) {
+  return await hmacSha512(chainCode, extension);
 }
 
 /**

--- a/src/derivers/slip10.ts
+++ b/src/derivers/slip10.ts
@@ -50,7 +50,7 @@ async function handleError(
   // generated as follows:
   // Key material (32 bytes), child chain code (32 bytes) =
   //   HMAC-SHA512(parent chain code, 0x01 || chain code from invalid key || index).
-  const newEntropy = generateEntropy({
+  const newEntropy = await generateEntropy({
     chainCode,
     extension: concatBytes([
       0x01,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -9,6 +9,7 @@ import {
   mnemonicPhraseToBytes,
   ed25519Bip32,
   getBIP44CoinTypeToAddressPathTuple,
+  mnemonicToSeed,
 } from '.';
 
 // This is purely for coverage shenanigans
@@ -25,5 +26,6 @@ describe('index', () => {
     expect(createBip39KeyFromSeed).toBeDefined();
     expect(mnemonicPhraseToBytes).toBeDefined();
     expect(getBIP44CoinTypeToAddressPathTuple).toBeDefined();
+    expect(mnemonicToSeed).toBeDefined();
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,4 +34,4 @@ export {
   isValidBIP32PathSegment,
   mnemonicPhraseToBytes,
 } from './utils';
-export { createBip39KeyFromSeed } from './derivers';
+export { createBip39KeyFromSeed, mnemonicToSeed } from './derivers';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,5 @@
 import { wordlist as englishWordlist } from '@metamask/scure-bip39/dist/wordlists/english';
 import { assert, createDataView, hexToBytes } from '@metamask/utils';
-import { ripemd160 } from '@noble/hashes/ripemd160';
-import { sha256 } from '@noble/hashes/sha256';
 import { base58check as scureBase58check } from '@scure/base';
 
 import type {
@@ -19,6 +17,7 @@ import {
   MAX_UNHARDENED_BIP_32_INDEX,
   UNPREFIXED_BIP_32_PATH_REGEX,
 } from './constants';
+import { ripemd160, sha256 } from './cryptography';
 import type { SupportedCurve } from './curves';
 import { curves } from './curves';
 
@@ -452,4 +451,14 @@ export function numberToUint32(value: number, littleEndian = false) {
   view.setUint32(0, value, littleEndian);
 
   return bytes;
+}
+
+/**
+ * A utility function to check if the Web Crypto API is supported in the current
+ * environment.
+ *
+ * @returns Whether the Web Crypto API is supported.
+ */
+export function isWebCryptoSupported() {
+  return Boolean(globalThis.crypto?.subtle);
 }

--- a/test/reference-implementations.test.ts
+++ b/test/reference-implementations.test.ts
@@ -1,3 +1,5 @@
+import { webcrypto } from 'crypto';
+
 import type { SLIP10Node, HDPathTuple } from '../src';
 import { BIP44Node, BIP44PurposeNodeToken } from '../src';
 import { ed25519, secp256k1 } from '../src/curves';
@@ -7,282 +9,121 @@ import {
   getBIP44CoinTypeToAddressPathTuple,
   hexStringToBytes,
 } from '../src/utils';
+import * as utils from '../src/utils';
 import fixtures from './fixtures';
 
+// Node.js <20 doesn't have `globalThis.crypto`, so we need to define it.
+// TODO: Remove this once we drop support for Node.js <20.
+Object.defineProperty(globalThis, 'crypto', { value: webcrypto });
+
 describe('reference implementation tests', () => {
-  describe('local', () => {
-    const { addresses, mnemonic } = fixtures.local;
-    const mnemonicBip39Node = `bip39:${mnemonic}` as const;
-
-    describe('BIP44Node', () => {
-      it('derives the expected keys', async () => {
-        // Ethereum coin type node
-        const node = await BIP44Node.fromDerivationPath({
-          derivationPath: [
-            mnemonicBip39Node,
-            BIP44PurposeNodeToken,
-            `bip32:60'`,
-          ],
-        });
-
-        for (let index = 0; index < addresses.length; index++) {
-          const expectedAddress = addresses[index];
-          const childNode = await node.derive(
-            getBIP44CoinTypeToAddressPathTuple({ address_index: index }),
-          );
-
-          expect(childNode.address).toStrictEqual(expectedAddress);
-        }
-      });
+  describe('using web crypto API', () => {
+    beforeEach(() => {
+      jest.spyOn(utils, 'isWebCryptoSupported').mockReturnValue(false);
     });
 
-    describe('deriveKeyFromPath', () => {
-      it('derives the expected keys', async () => {
-        // Ethereum coin type key
-        const node = await deriveKeyFromPath({
-          path: [mnemonicBip39Node, BIP44PurposeNodeToken, `bip32:60'`],
-          curve: 'secp256k1',
-        });
+    describe('local', () => {
+      const { addresses, mnemonic } = fixtures.local;
+      const mnemonicBip39Node = `bip39:${mnemonic}` as const;
 
-        for (let index = 0; index < addresses.length; index++) {
-          const expectedAddress = addresses[index];
-          const { address } = await deriveKeyFromPath({
-            path: getBIP44CoinTypeToAddressPathTuple({ address_index: index }),
-            node,
+      describe('BIP44Node', () => {
+        it('derives the expected keys', async () => {
+          // Ethereum coin type node
+          const node = await BIP44Node.fromDerivationPath({
+            derivationPath: [
+              mnemonicBip39Node,
+              BIP44PurposeNodeToken,
+              `bip32:60'`,
+            ],
           });
 
-          expect(address).toStrictEqual(expectedAddress);
-        }
-      });
-    });
-  });
-
-  describe('eth-hd-keyring', () => {
-    const { mnemonic, addresses } = fixtures['eth-hd-keyring'];
-    const mnemonicBip39Node = `bip39:${mnemonic}` as const;
-
-    describe('BIP44Node', () => {
-      it('derives the same keys as the reference implementation', async () => {
-        // Ethereum coin type node
-        const node = await BIP44Node.fromDerivationPath({
-          derivationPath: [
-            mnemonicBip39Node,
-            BIP44PurposeNodeToken,
-            `bip32:60'`,
-          ],
-        });
-
-        const numberOfAccounts = 5;
-        for (let i = 0; i < numberOfAccounts; i++) {
-          const path = getBIP44CoinTypeToAddressPathTuple({ address_index: i });
-          const address = await node
-            .derive(path)
-            .then((childNode) => childNode.address);
-
-          expect(address).toBe(addresses[i]);
-        }
-      });
-
-      it('derives the same keys as the reference implementation using public key derivation', async () => {
-        // Ethereum coin type node
-        const node = await BIP44Node.fromDerivationPath({
-          derivationPath: [
-            mnemonicBip39Node,
-            BIP44PurposeNodeToken,
-            `bip32:60'`,
-          ],
-        });
-
-        const numberOfAccounts = 5;
-        for (let i = 0; i < numberOfAccounts; i++) {
-          const [account, change, index] = getBIP44CoinTypeToAddressPathTuple({
-            address_index: i,
-          });
-          const parentNode = await node.derive([account, change]);
-
-          const address = await parentNode
-            .neuter()
-            .derive([index])
-            .then((childNode) => childNode.address);
-
-          expect(address).toBe(addresses[i]);
-        }
-      });
-    });
-
-    describe('deriveKeyFromPath', () => {
-      it('derives the same keys as the reference implementation', async () => {
-        // Ethereum coin type key
-        const node = await deriveKeyFromPath({
-          path: [mnemonicBip39Node, BIP44PurposeNodeToken, `bip32:60'`],
-          curve: 'secp256k1',
-        });
-
-        const numberOfAccounts = 5;
-        const ourAccounts = [];
-        for (let i = 0; i < numberOfAccounts; i++) {
-          ourAccounts.push(
-            await deriveKeyFromPath({
-              path: getBIP44CoinTypeToAddressPathTuple({ address_index: i }),
-              node,
-            }).then(({ address }) => address),
-          );
-        }
-
-        expect(addresses).toStrictEqual(ourAccounts);
-      });
-    });
-  });
-
-  describe('ethereumjs-wallet', () => {
-    const { sampleAddressIndices, hexSeed, privateKey, address, path } =
-      fixtures['ethereumjs-wallet'];
-    const seed = hexStringToBytes(hexSeed);
-
-    describe('BIP44Node', () => {
-      it('derives the same keys as the reference implementation', async () => {
-        const parentNode = await createBip39KeyFromSeed(seed, secp256k1);
-        const node = await parentNode.derive(path.ours.tuple);
-
-        expect(node.privateKey).toStrictEqual(privateKey);
-        expect(node.address).toStrictEqual(address);
-
-        for (const { index, address: theirAddress } of sampleAddressIndices) {
-          const ourAddress = await node
-            .derive([`bip32:${index}`])
-            .then((childNode) => childNode.address);
-
-          expect(ourAddress).toStrictEqual(theirAddress);
-        }
-      });
-
-      it('derives the same keys as the reference implementation using public key derivation', async () => {
-        const parentNode = await createBip39KeyFromSeed(seed, secp256k1);
-        const node = await parentNode.derive(path.ours.tuple);
-
-        expect(node.privateKey).toStrictEqual(privateKey);
-        expect(node.address).toStrictEqual(address);
-
-        for (const { index, address: theirAddress } of sampleAddressIndices) {
-          const ourAddress = await node
-            .neuter()
-            .derive([`bip32:${index}`])
-            .then((childNode) => childNode.address);
-
-          expect(ourAddress).toStrictEqual(theirAddress);
-        }
-      });
-    });
-
-    describe('deriveKeyFromPath', () => {
-      it('derives the same keys as the reference implementation', async () => {
-        const node = await createBip39KeyFromSeed(seed, secp256k1);
-        const childNode = await deriveKeyFromPath({
-          path: path.ours.tuple,
-          node,
-        });
-
-        expect(childNode.privateKey).toStrictEqual(privateKey);
-        expect(childNode.address).toStrictEqual(address);
-
-        for (const { index, address: theirAddress } of sampleAddressIndices) {
-          const childChildNode = await deriveKeyFromPath({
-            path: [`bip32:${index}`],
-            node: childNode,
-          });
-
-          expect(childChildNode.address).toStrictEqual(theirAddress);
-        }
-      });
-    });
-  });
-
-  describe('BIP-32 specification test vectors', () => {
-    const vectors = fixtures.bip32;
-
-    // We only test the BIP-32 vectors with deriveKeyFromPath, since not all
-    // paths are BIP-44 compatible.
-    describe('deriveKeyFromPath', () => {
-      it('derives the test vector keys', async () => {
-        for (const vector of vectors) {
-          const seed = hexStringToBytes(vector.hexSeed);
-          const node = await createBip39KeyFromSeed(seed, secp256k1);
-
-          for (const keyObj of vector.keys) {
-            const { path, privateKey } = keyObj;
-
-            let targetNode: SLIP10Node;
-
-            // If the path is empty, use the master node
-            if (path.ours.string === '') {
-              targetNode = node;
-            } else {
-              targetNode = await deriveKeyFromPath({
-                path: path.ours.tuple as HDPathTuple,
-                node,
-              });
-            }
-
-            expect(targetNode.privateKey).toStrictEqual(privateKey);
-          }
-        }
-      });
-    });
-  });
-
-  describe('ed25519', () => {
-    describe('SLIP-10', () => {
-      const vectors = fixtures.ed25519.slip10;
-
-      describe('deriveKeyFromPath', () => {
-        it('derives the test vector keys', async () => {
-          for (const { hexSeed, keys } of vectors) {
-            const node = await createBip39KeyFromSeed(
-              hexStringToBytes(hexSeed),
-              ed25519,
+          for (let index = 0; index < addresses.length; index++) {
+            const expectedAddress = addresses[index];
+            const childNode = await node.derive(
+              getBIP44CoinTypeToAddressPathTuple({ address_index: index }),
             );
 
-            for (const { path, privateKey, publicKey } of keys) {
-              let targetNode: SLIP10Node;
-              if (path.ours.string === '') {
-                targetNode = node;
-              } else {
-                targetNode = await deriveKeyFromPath({
-                  path: path.ours.tuple,
-                  node,
-                });
-              }
+            expect(childNode.address).toStrictEqual(expectedAddress);
+          }
+        });
+      });
 
-              expect(targetNode.privateKey).toBe(privateKey);
-              expect(targetNode.publicKey).toBe(publicKey);
-            }
+      describe('deriveKeyFromPath', () => {
+        it('derives the expected keys', async () => {
+          // Ethereum coin type key
+          const node = await deriveKeyFromPath({
+            path: [mnemonicBip39Node, BIP44PurposeNodeToken, `bip32:60'`],
+            curve: 'secp256k1',
+          });
+
+          for (let index = 0; index < addresses.length; index++) {
+            const expectedAddress = addresses[index];
+            const { address } = await deriveKeyFromPath({
+              path: getBIP44CoinTypeToAddressPathTuple({
+                address_index: index,
+              }),
+              node,
+            });
+
+            expect(address).toStrictEqual(expectedAddress);
           }
         });
       });
     });
 
-    describe('ed25519-hd-key', () => {
-      const { sampleKeyIndices, hexSeed, privateKey, path } =
-        fixtures.ed25519['ed25519-hd-key'];
-      const seed = hexStringToBytes(hexSeed);
+    describe('eth-hd-keyring', () => {
+      const { mnemonic, addresses } = fixtures['eth-hd-keyring'];
+      const mnemonicBip39Node = `bip39:${mnemonic}` as const;
 
-      describe('SLIP10Node', () => {
+      describe('BIP44Node', () => {
         it('derives the same keys as the reference implementation', async () => {
           // Ethereum coin type node
-          const parentNode = await createBip39KeyFromSeed(seed, ed25519);
-          const node = await parentNode.derive(path.ours.tuple);
+          const node = await BIP44Node.fromDerivationPath({
+            derivationPath: [
+              mnemonicBip39Node,
+              BIP44PurposeNodeToken,
+              `bip32:60'`,
+            ],
+          });
 
-          expect(node.privateKey).toStrictEqual(privateKey);
+          const numberOfAccounts = 5;
+          for (let i = 0; i < numberOfAccounts; i++) {
+            const path = getBIP44CoinTypeToAddressPathTuple({
+              address_index: i,
+            });
+            const address = await node
+              .derive(path)
+              .then((childNode) => childNode.address);
 
-          for (const {
-            index,
-            privateKey: theirPrivateKey,
-            publicKey: theirPublicKey,
-          } of sampleKeyIndices) {
-            const childNode = await node.derive([`slip10:${index}'`]);
+            expect(address).toBe(addresses[i]);
+          }
+        });
 
-            expect(childNode.privateKey).toStrictEqual(theirPrivateKey);
-            expect(childNode.publicKey).toStrictEqual(theirPublicKey);
+        it('derives the same keys as the reference implementation using public key derivation', async () => {
+          // Ethereum coin type node
+          const node = await BIP44Node.fromDerivationPath({
+            derivationPath: [
+              mnemonicBip39Node,
+              BIP44PurposeNodeToken,
+              `bip32:60'`,
+            ],
+          });
+
+          const numberOfAccounts = 5;
+          for (let i = 0; i < numberOfAccounts; i++) {
+            const [account, change, index] = getBIP44CoinTypeToAddressPathTuple(
+              {
+                address_index: i,
+              },
+            );
+            const parentNode = await node.derive([account, change]);
+
+            const address = await parentNode
+              .neuter()
+              .derive([index])
+              .then((childNode) => childNode.address);
+
+            expect(address).toBe(addresses[i]);
           }
         });
       });
@@ -290,23 +131,515 @@ describe('reference implementation tests', () => {
       describe('deriveKeyFromPath', () => {
         it('derives the same keys as the reference implementation', async () => {
           // Ethereum coin type key
-          const node = await createBip39KeyFromSeed(seed, ed25519);
+          const node = await deriveKeyFromPath({
+            path: [mnemonicBip39Node, BIP44PurposeNodeToken, `bip32:60'`],
+            curve: 'secp256k1',
+          });
+
+          const numberOfAccounts = 5;
+          const ourAccounts = [];
+          for (let i = 0; i < numberOfAccounts; i++) {
+            ourAccounts.push(
+              await deriveKeyFromPath({
+                path: getBIP44CoinTypeToAddressPathTuple({ address_index: i }),
+                node,
+              }).then(({ address }) => address),
+            );
+          }
+
+          expect(addresses).toStrictEqual(ourAccounts);
+        });
+      });
+    });
+
+    describe('ethereumjs-wallet', () => {
+      const { sampleAddressIndices, hexSeed, privateKey, address, path } =
+        fixtures['ethereumjs-wallet'];
+      const seed = hexStringToBytes(hexSeed);
+
+      describe('BIP44Node', () => {
+        it('derives the same keys as the reference implementation', async () => {
+          const parentNode = await createBip39KeyFromSeed(seed, secp256k1);
+          const node = await parentNode.derive(path.ours.tuple);
+
+          expect(node.privateKey).toStrictEqual(privateKey);
+          expect(node.address).toStrictEqual(address);
+
+          for (const { index, address: theirAddress } of sampleAddressIndices) {
+            const ourAddress = await node
+              .derive([`bip32:${index}`])
+              .then((childNode) => childNode.address);
+
+            expect(ourAddress).toStrictEqual(theirAddress);
+          }
+        });
+
+        it('derives the same keys as the reference implementation using public key derivation', async () => {
+          const parentNode = await createBip39KeyFromSeed(seed, secp256k1);
+          const node = await parentNode.derive(path.ours.tuple);
+
+          expect(node.privateKey).toStrictEqual(privateKey);
+          expect(node.address).toStrictEqual(address);
+
+          for (const { index, address: theirAddress } of sampleAddressIndices) {
+            const ourAddress = await node
+              .neuter()
+              .derive([`bip32:${index}`])
+              .then((childNode) => childNode.address);
+
+            expect(ourAddress).toStrictEqual(theirAddress);
+          }
+        });
+      });
+
+      describe('deriveKeyFromPath', () => {
+        it('derives the same keys as the reference implementation', async () => {
+          const node = await createBip39KeyFromSeed(seed, secp256k1);
           const childNode = await deriveKeyFromPath({
-            path: [`slip10:44'`, `slip10:0'`, `slip10:0'`, `slip10:1'`],
+            path: path.ours.tuple,
             node,
           });
 
-          for (const {
-            index,
-            privateKey: theirPrivateKey,
-          } of sampleKeyIndices) {
-            const { privateKey: ourPrivateKey } = await deriveKeyFromPath({
-              path: [`slip10:${index}'`],
+          expect(childNode.privateKey).toStrictEqual(privateKey);
+          expect(childNode.address).toStrictEqual(address);
+
+          for (const { index, address: theirAddress } of sampleAddressIndices) {
+            const childChildNode = await deriveKeyFromPath({
+              path: [`bip32:${index}`],
               node: childNode,
             });
 
-            expect(ourPrivateKey).toStrictEqual(theirPrivateKey);
+            expect(childChildNode.address).toStrictEqual(theirAddress);
           }
+        });
+      });
+    });
+
+    describe('BIP-32 specification test vectors', () => {
+      const vectors = fixtures.bip32;
+
+      // We only test the BIP-32 vectors with deriveKeyFromPath, since not all
+      // paths are BIP-44 compatible.
+      describe('deriveKeyFromPath', () => {
+        it('derives the test vector keys', async () => {
+          for (const vector of vectors) {
+            const seed = hexStringToBytes(vector.hexSeed);
+            const node = await createBip39KeyFromSeed(seed, secp256k1);
+
+            for (const keyObj of vector.keys) {
+              const { path, privateKey } = keyObj;
+
+              let targetNode: SLIP10Node;
+
+              // If the path is empty, use the master node
+              if (path.ours.string === '') {
+                targetNode = node;
+              } else {
+                targetNode = await deriveKeyFromPath({
+                  path: path.ours.tuple as HDPathTuple,
+                  node,
+                });
+              }
+
+              expect(targetNode.privateKey).toStrictEqual(privateKey);
+            }
+          }
+        });
+      });
+    });
+
+    describe('ed25519', () => {
+      describe('SLIP-10', () => {
+        const vectors = fixtures.ed25519.slip10;
+
+        describe('deriveKeyFromPath', () => {
+          it('derives the test vector keys', async () => {
+            for (const { hexSeed, keys } of vectors) {
+              const node = await createBip39KeyFromSeed(
+                hexStringToBytes(hexSeed),
+                ed25519,
+              );
+
+              for (const { path, privateKey, publicKey } of keys) {
+                let targetNode: SLIP10Node;
+                if (path.ours.string === '') {
+                  targetNode = node;
+                } else {
+                  targetNode = await deriveKeyFromPath({
+                    path: path.ours.tuple,
+                    node,
+                  });
+                }
+
+                expect(targetNode.privateKey).toBe(privateKey);
+                expect(targetNode.publicKey).toBe(publicKey);
+              }
+            }
+          });
+        });
+      });
+
+      describe('ed25519-hd-key', () => {
+        const { sampleKeyIndices, hexSeed, privateKey, path } =
+          fixtures.ed25519['ed25519-hd-key'];
+        const seed = hexStringToBytes(hexSeed);
+
+        describe('SLIP10Node', () => {
+          it('derives the same keys as the reference implementation', async () => {
+            // Ethereum coin type node
+            const parentNode = await createBip39KeyFromSeed(seed, ed25519);
+            const node = await parentNode.derive(path.ours.tuple);
+
+            expect(node.privateKey).toStrictEqual(privateKey);
+
+            for (const {
+              index,
+              privateKey: theirPrivateKey,
+              publicKey: theirPublicKey,
+            } of sampleKeyIndices) {
+              const childNode = await node.derive([`slip10:${index}'`]);
+
+              expect(childNode.privateKey).toStrictEqual(theirPrivateKey);
+              expect(childNode.publicKey).toStrictEqual(theirPublicKey);
+            }
+          });
+        });
+
+        describe('deriveKeyFromPath', () => {
+          it('derives the same keys as the reference implementation', async () => {
+            // Ethereum coin type key
+            const node = await createBip39KeyFromSeed(seed, ed25519);
+            const childNode = await deriveKeyFromPath({
+              path: [`slip10:44'`, `slip10:0'`, `slip10:0'`, `slip10:1'`],
+              node,
+            });
+
+            for (const {
+              index,
+              privateKey: theirPrivateKey,
+            } of sampleKeyIndices) {
+              const { privateKey: ourPrivateKey } = await deriveKeyFromPath({
+                path: [`slip10:${index}'`],
+                node: childNode,
+              });
+
+              expect(ourPrivateKey).toStrictEqual(theirPrivateKey);
+            }
+          });
+        });
+      });
+    });
+  });
+
+  describe('using built-in cryptography functions', () => {
+    beforeEach(() => {
+      jest.spyOn(utils, 'isWebCryptoSupported').mockReturnValue(false);
+    });
+
+    describe('local', () => {
+      const { addresses, mnemonic } = fixtures.local;
+      const mnemonicBip39Node = `bip39:${mnemonic}` as const;
+
+      describe('BIP44Node', () => {
+        it('derives the expected keys', async () => {
+          // Ethereum coin type node
+          const node = await BIP44Node.fromDerivationPath({
+            derivationPath: [
+              mnemonicBip39Node,
+              BIP44PurposeNodeToken,
+              `bip32:60'`,
+            ],
+          });
+
+          for (let index = 0; index < addresses.length; index++) {
+            const expectedAddress = addresses[index];
+            const childNode = await node.derive(
+              getBIP44CoinTypeToAddressPathTuple({ address_index: index }),
+            );
+
+            expect(childNode.address).toStrictEqual(expectedAddress);
+          }
+        });
+      });
+
+      describe('deriveKeyFromPath', () => {
+        it('derives the expected keys', async () => {
+          // Ethereum coin type key
+          const node = await deriveKeyFromPath({
+            path: [mnemonicBip39Node, BIP44PurposeNodeToken, `bip32:60'`],
+            curve: 'secp256k1',
+          });
+
+          for (let index = 0; index < addresses.length; index++) {
+            const expectedAddress = addresses[index];
+            const { address } = await deriveKeyFromPath({
+              path: getBIP44CoinTypeToAddressPathTuple({
+                address_index: index,
+              }),
+              node,
+            });
+
+            expect(address).toStrictEqual(expectedAddress);
+          }
+        });
+      });
+    });
+
+    describe('eth-hd-keyring', () => {
+      const { mnemonic, addresses } = fixtures['eth-hd-keyring'];
+      const mnemonicBip39Node = `bip39:${mnemonic}` as const;
+
+      describe('BIP44Node', () => {
+        it('derives the same keys as the reference implementation', async () => {
+          // Ethereum coin type node
+          const node = await BIP44Node.fromDerivationPath({
+            derivationPath: [
+              mnemonicBip39Node,
+              BIP44PurposeNodeToken,
+              `bip32:60'`,
+            ],
+          });
+
+          const numberOfAccounts = 5;
+          for (let i = 0; i < numberOfAccounts; i++) {
+            const path = getBIP44CoinTypeToAddressPathTuple({
+              address_index: i,
+            });
+            const address = await node
+              .derive(path)
+              .then((childNode) => childNode.address);
+
+            expect(address).toBe(addresses[i]);
+          }
+        });
+
+        it('derives the same keys as the reference implementation using public key derivation', async () => {
+          // Ethereum coin type node
+          const node = await BIP44Node.fromDerivationPath({
+            derivationPath: [
+              mnemonicBip39Node,
+              BIP44PurposeNodeToken,
+              `bip32:60'`,
+            ],
+          });
+
+          const numberOfAccounts = 5;
+          for (let i = 0; i < numberOfAccounts; i++) {
+            const [account, change, index] = getBIP44CoinTypeToAddressPathTuple(
+              {
+                address_index: i,
+              },
+            );
+            const parentNode = await node.derive([account, change]);
+
+            const address = await parentNode
+              .neuter()
+              .derive([index])
+              .then((childNode) => childNode.address);
+
+            expect(address).toBe(addresses[i]);
+          }
+        });
+      });
+
+      describe('deriveKeyFromPath', () => {
+        it('derives the same keys as the reference implementation', async () => {
+          // Ethereum coin type key
+          const node = await deriveKeyFromPath({
+            path: [mnemonicBip39Node, BIP44PurposeNodeToken, `bip32:60'`],
+            curve: 'secp256k1',
+          });
+
+          const numberOfAccounts = 5;
+          const ourAccounts = [];
+          for (let i = 0; i < numberOfAccounts; i++) {
+            ourAccounts.push(
+              await deriveKeyFromPath({
+                path: getBIP44CoinTypeToAddressPathTuple({ address_index: i }),
+                node,
+              }).then(({ address }) => address),
+            );
+          }
+
+          expect(addresses).toStrictEqual(ourAccounts);
+        });
+      });
+    });
+
+    describe('ethereumjs-wallet', () => {
+      const { sampleAddressIndices, hexSeed, privateKey, address, path } =
+        fixtures['ethereumjs-wallet'];
+      const seed = hexStringToBytes(hexSeed);
+
+      describe('BIP44Node', () => {
+        it('derives the same keys as the reference implementation', async () => {
+          const parentNode = await createBip39KeyFromSeed(seed, secp256k1);
+          const node = await parentNode.derive(path.ours.tuple);
+
+          expect(node.privateKey).toStrictEqual(privateKey);
+          expect(node.address).toStrictEqual(address);
+
+          for (const { index, address: theirAddress } of sampleAddressIndices) {
+            const ourAddress = await node
+              .derive([`bip32:${index}`])
+              .then((childNode) => childNode.address);
+
+            expect(ourAddress).toStrictEqual(theirAddress);
+          }
+        });
+
+        it('derives the same keys as the reference implementation using public key derivation', async () => {
+          const parentNode = await createBip39KeyFromSeed(seed, secp256k1);
+          const node = await parentNode.derive(path.ours.tuple);
+
+          expect(node.privateKey).toStrictEqual(privateKey);
+          expect(node.address).toStrictEqual(address);
+
+          for (const { index, address: theirAddress } of sampleAddressIndices) {
+            const ourAddress = await node
+              .neuter()
+              .derive([`bip32:${index}`])
+              .then((childNode) => childNode.address);
+
+            expect(ourAddress).toStrictEqual(theirAddress);
+          }
+        });
+      });
+
+      describe('deriveKeyFromPath', () => {
+        it('derives the same keys as the reference implementation', async () => {
+          const node = await createBip39KeyFromSeed(seed, secp256k1);
+          const childNode = await deriveKeyFromPath({
+            path: path.ours.tuple,
+            node,
+          });
+
+          expect(childNode.privateKey).toStrictEqual(privateKey);
+          expect(childNode.address).toStrictEqual(address);
+
+          for (const { index, address: theirAddress } of sampleAddressIndices) {
+            const childChildNode = await deriveKeyFromPath({
+              path: [`bip32:${index}`],
+              node: childNode,
+            });
+
+            expect(childChildNode.address).toStrictEqual(theirAddress);
+          }
+        });
+      });
+    });
+
+    describe('BIP-32 specification test vectors', () => {
+      const vectors = fixtures.bip32;
+
+      // We only test the BIP-32 vectors with deriveKeyFromPath, since not all
+      // paths are BIP-44 compatible.
+      describe('deriveKeyFromPath', () => {
+        it('derives the test vector keys', async () => {
+          for (const vector of vectors) {
+            const seed = hexStringToBytes(vector.hexSeed);
+            const node = await createBip39KeyFromSeed(seed, secp256k1);
+
+            for (const keyObj of vector.keys) {
+              const { path, privateKey } = keyObj;
+
+              let targetNode: SLIP10Node;
+
+              // If the path is empty, use the master node
+              if (path.ours.string === '') {
+                targetNode = node;
+              } else {
+                targetNode = await deriveKeyFromPath({
+                  path: path.ours.tuple as HDPathTuple,
+                  node,
+                });
+              }
+
+              expect(targetNode.privateKey).toStrictEqual(privateKey);
+            }
+          }
+        });
+      });
+    });
+
+    describe('ed25519', () => {
+      describe('SLIP-10', () => {
+        const vectors = fixtures.ed25519.slip10;
+
+        describe('deriveKeyFromPath', () => {
+          it('derives the test vector keys', async () => {
+            for (const { hexSeed, keys } of vectors) {
+              const node = await createBip39KeyFromSeed(
+                hexStringToBytes(hexSeed),
+                ed25519,
+              );
+
+              for (const { path, privateKey, publicKey } of keys) {
+                let targetNode: SLIP10Node;
+                if (path.ours.string === '') {
+                  targetNode = node;
+                } else {
+                  targetNode = await deriveKeyFromPath({
+                    path: path.ours.tuple,
+                    node,
+                  });
+                }
+
+                expect(targetNode.privateKey).toBe(privateKey);
+                expect(targetNode.publicKey).toBe(publicKey);
+              }
+            }
+          });
+        });
+      });
+
+      describe('ed25519-hd-key', () => {
+        const { sampleKeyIndices, hexSeed, privateKey, path } =
+          fixtures.ed25519['ed25519-hd-key'];
+        const seed = hexStringToBytes(hexSeed);
+
+        describe('SLIP10Node', () => {
+          it('derives the same keys as the reference implementation', async () => {
+            // Ethereum coin type node
+            const parentNode = await createBip39KeyFromSeed(seed, ed25519);
+            const node = await parentNode.derive(path.ours.tuple);
+
+            expect(node.privateKey).toStrictEqual(privateKey);
+
+            for (const {
+              index,
+              privateKey: theirPrivateKey,
+              publicKey: theirPublicKey,
+            } of sampleKeyIndices) {
+              const childNode = await node.derive([`slip10:${index}'`]);
+
+              expect(childNode.privateKey).toStrictEqual(theirPrivateKey);
+              expect(childNode.publicKey).toStrictEqual(theirPublicKey);
+            }
+          });
+        });
+
+        describe('deriveKeyFromPath', () => {
+          it('derives the same keys as the reference implementation', async () => {
+            // Ethereum coin type key
+            const node = await createBip39KeyFromSeed(seed, ed25519);
+            const childNode = await deriveKeyFromPath({
+              path: [`slip10:44'`, `slip10:0'`, `slip10:0'`, `slip10:1'`],
+              node,
+            });
+
+            for (const {
+              index,
+              privateKey: theirPrivateKey,
+            } of sampleKeyIndices) {
+              const { privateKey: ourPrivateKey } = await deriveKeyFromPath({
+                path: [`slip10:${index}'`],
+                node: childNode,
+              });
+
+              expect(ourPrivateKey).toStrictEqual(theirPrivateKey);
+            }
+          });
         });
       });
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "esModuleInterop": true,
     "exactOptionalPropertyTypes": true,
     "forceConsistentCasingInFileNames": true,
-    "lib": ["ES2020"],
+    "lib": ["ES2020", "DOM"],
     "module": "CommonJS",
     "moduleResolution": "node",
     "noEmit": true,


### PR DESCRIPTION
This adds cryptographic functions like `hmacSha512`, `pbkdf2Sha512`, with the option to use a custom implementation of these functions. This can be beneficial in environments like React Native, where the native implementation may be much faster than the JavaScript fallback.

These functions will now also use the Web Crypto API if available, which in itself results in a good performance improvement compared to the JavaScript functions.

Closes #195.