### PR TITLE
Add network property

### DIFF
--- a/.depcheckrc.json
+++ b/.depcheckrc.json
@@ -11,6 +11,7 @@
     "eslint-import-resolver-typescript",
     "eslint-plugin-*",
     "prettier-plugin-packagejson",
+    "ts-jest",
     "ts-node",
     "typedoc",
     "typescript-eslint"

--- a/jest.config.js
+++ b/jest.config.js
@@ -99,6 +99,10 @@ module.exports = {
   // A preset that is used as a base for Jest's configuration
   preset: 'ts-jest',
 
+  // Jest doesn't support Prettier 3 yet, so we disable it
+  // TODO: Remove this when bumping to Jest 30
+  prettierPath: null,
+
   // Run tests from one or more projects
   // projects: undefined,
 

--- a/src/BIP44CoinTypeNode.test.ts
+++ b/src/BIP44CoinTypeNode.test.ts
@@ -10,7 +10,7 @@ import {
 } from '.';
 import type { CryptographicFunctions } from './cryptography';
 import { hmacSha512, pbkdf2Sha512 } from './cryptography';
-import { encodeExtendedKey, PRIVATE_KEY_VERSION } from './extended-keys';
+import { encodeExtendedKey } from './extended-keys';
 import { mnemonicPhraseToBytes } from './utils';
 import fixtures from '../test/fixtures';
 
@@ -64,6 +64,7 @@ describe('BIP44CoinTypeNode', () => {
         masterFingerprint: node.masterFingerprint,
         parentFingerprint: node.parentFingerprint,
         index: node.index,
+        network: node.network,
         path: pathString,
         privateKey: node.privateKey,
         publicKey: node.publicKey,
@@ -226,6 +227,7 @@ describe('BIP44CoinTypeNode', () => {
         masterFingerprint: node.masterFingerprint,
         parentFingerprint: node.parentFingerprint,
         index: node.index,
+        network: node.network,
         path: pathString,
         privateKey: node.privateKey,
         publicKey: node.publicKey,
@@ -263,6 +265,7 @@ describe('BIP44CoinTypeNode', () => {
         masterFingerprint: node.masterFingerprint,
         parentFingerprint: node.parentFingerprint,
         index: node.index,
+        network: node.network,
         path: pathString,
         privateKey: node.privateKey,
         publicKey: node.publicKey,
@@ -290,6 +293,7 @@ describe('BIP44CoinTypeNode', () => {
       const functions = getMockFunctions();
       const node = await BIP44CoinTypeNode.fromDerivationPath(
         [defaultBip39NodeToken, BIP44PurposeNodeToken, `bip32:60'`],
+        'mainnet',
         functions,
       );
 
@@ -443,6 +447,7 @@ describe('BIP44CoinTypeNode', () => {
       const functions = getMockFunctions();
       const coinTypeNode = await BIP44CoinTypeNode.fromDerivationPath(
         [defaultBip39NodeToken, BIP44PurposeNodeToken, `bip32:60'`],
+        'mainnet',
         functions,
       );
 
@@ -533,7 +538,7 @@ describe('BIP44CoinTypeNode', () => {
   });
 
   describe('extendedKey', () => {
-    it('returns the extended private key for nodes with a private key', async () => {
+    it('returns the extended private key for nodes with a private key (mainnet)', async () => {
       const coinType = 60;
       const node = await BIP44CoinTypeNode.fromDerivationPath([
         defaultBip39NodeToken,
@@ -542,12 +547,33 @@ describe('BIP44CoinTypeNode', () => {
       ]);
 
       const extendedKey = encodeExtendedKey({
-        version: PRIVATE_KEY_VERSION,
+        type: 'private',
         privateKey: node.privateKeyBytes as Uint8Array,
         chainCode: node.chainCodeBytes,
         depth: node.depth,
         parentFingerprint: node.parentFingerprint,
         index: node.index,
+        network: 'mainnet',
+      });
+
+      expect(node.extendedKey).toStrictEqual(extendedKey);
+    });
+
+    it('returns the extended private key for nodes with a private key (testnet)', async () => {
+      const coinType = 60;
+      const node = await BIP44CoinTypeNode.fromDerivationPath(
+        [defaultBip39NodeToken, BIP44PurposeNodeToken, `bip32:${coinType}'`],
+        'testnet',
+      );
+
+      const extendedKey = encodeExtendedKey({
+        type: 'private',
+        privateKey: node.privateKeyBytes as Uint8Array,
+        chainCode: node.chainCodeBytes,
+        depth: node.depth,
+        parentFingerprint: node.parentFingerprint,
+        index: node.index,
+        network: 'testnet',
       });
 
       expect(node.extendedKey).toStrictEqual(extendedKey);
@@ -575,6 +601,7 @@ describe('BIP44CoinTypeNode', () => {
         masterFingerprint: node.masterFingerprint,
         parentFingerprint: node.parentFingerprint,
         index: node.index,
+        network: node.network,
         path: pathString,
         privateKey: node.privateKey,
         publicKey: node.publicKey,
@@ -587,6 +614,7 @@ describe('BIP44CoinTypeNode', () => {
         masterFingerprint: node.masterFingerprint,
         parentFingerprint: node.parentFingerprint,
         index: node.index,
+        network: node.network,
         path: pathString,
         privateKey: node.privateKey,
         publicKey: node.publicKey,

--- a/src/BIP44CoinTypeNode.ts
+++ b/src/BIP44CoinTypeNode.ts
@@ -8,6 +8,7 @@ import type {
   BIP44PurposeNodeToken,
   CoinTypeHDPathString,
   HardenedBIP32Node,
+  Network,
 } from './constants';
 import { BIP_32_HARDENED_OFFSET } from './constants';
 import type { CryptographicFunctions } from './cryptography';
@@ -92,6 +93,7 @@ export class BIP44CoinTypeNode implements BIP44CoinTypeNodeInterface {
       {
         depth: json.depth,
         index: json.index,
+        network: json.network,
         parentFingerprint: json.parentFingerprint,
         chainCode: hexStringToBytes(json.chainCode),
         privateKey: nullableHexStringToBytes(json.privateKey),
@@ -118,12 +120,15 @@ export class BIP44CoinTypeNode implements BIP44CoinTypeNodeInterface {
    * `0 / 1 / 2 / 3 / 4 / 5`
    *
    * @param derivationPath - The derivation path for the key of this node.
+   * @param network - The network for the node. This is only used for extended
+   * keys, and defaults to `mainnet`.
    * @param cryptographicFunctions - The cryptographic functions to use. If
    * provided, these will be used instead of the built-in implementations.
    * @returns A BIP44CoinType node.
    */
   static async fromDerivationPath(
     derivationPath: CoinTypeHDPathTuple,
+    network?: Network | undefined,
     cryptographicFunctions?: CryptographicFunctions,
   ): Promise<BIP44CoinTypeNode> {
     validateCoinTypeNodeDepth(derivationPath.length - 1);
@@ -131,6 +136,7 @@ export class BIP44CoinTypeNode implements BIP44CoinTypeNodeInterface {
     const node = await BIP44Node.fromDerivationPath(
       {
         derivationPath,
+        network,
       },
       cryptographicFunctions,
     );
@@ -250,6 +256,10 @@ export class BIP44CoinTypeNode implements BIP44CoinTypeNodeInterface {
 
   public get index(): number {
     return this.#node.index;
+  }
+
+  public get network(): Network {
+    return this.#node.network;
   }
 
   public get curve(): SupportedCurve {

--- a/src/BIP44Node.test.ts
+++ b/src/BIP44Node.test.ts
@@ -5,11 +5,7 @@ import type { CryptographicFunctions } from './cryptography';
 import { hmacSha512, pbkdf2Sha512 } from './cryptography';
 import { compressPublicKey } from './curves/secp256k1';
 import { createBip39KeyFromSeed, deriveChildKey } from './derivers/bip39';
-import {
-  encodeExtendedKey,
-  PRIVATE_KEY_VERSION,
-  PUBLIC_KEY_VERSION,
-} from './extended-keys';
+import { encodeExtendedKey } from './extended-keys';
 import { hexStringToBytes, mnemonicPhraseToBytes } from './utils';
 import fixtures from '../test/fixtures';
 
@@ -56,6 +52,7 @@ describe('BIP44Node', () => {
         masterFingerprint: node.masterFingerprint,
         parentFingerprint: node.parentFingerprint,
         index: node.index,
+        network: node.network,
         privateKey: node.privateKey,
         publicKey: node.publicKey,
         chainCode: node.chainCode,
@@ -90,6 +87,7 @@ describe('BIP44Node', () => {
         masterFingerprint: node.masterFingerprint,
         parentFingerprint: node.parentFingerprint,
         index: node.index,
+        network: node.network,
         privateKey: node.privateKey,
         publicKey: node.publicKey,
         chainCode: node.chainCode,
@@ -208,6 +206,7 @@ describe('BIP44Node', () => {
         masterFingerprint: node.masterFingerprint,
         parentFingerprint: node.parentFingerprint,
         index: node.index,
+        network: node.network,
         privateKey: node.privateKey,
         publicKey: node.publicKey,
         chainCode: node.chainCode,
@@ -255,6 +254,7 @@ describe('BIP44Node', () => {
         masterFingerprint: node.masterFingerprint,
         parentFingerprint: node.parentFingerprint,
         index: node.index,
+        network: node.network,
         privateKey: node.privateKey,
         publicKey: node.publicKey,
         chainCode: node.chainCode,
@@ -645,7 +645,7 @@ describe('BIP44Node', () => {
   });
 
   describe('extendedKey', () => {
-    it('returns the extended private key for nodes with a private key', async () => {
+    it('returns the extended private key for nodes with a private key (mainnet)', async () => {
       const node = await BIP44Node.fromDerivationPath({
         derivationPath: [
           defaultBip39NodeToken,
@@ -656,18 +656,43 @@ describe('BIP44Node', () => {
       });
 
       const extendedKey = encodeExtendedKey({
-        version: PRIVATE_KEY_VERSION,
+        type: 'private',
         privateKey: node.privateKeyBytes as Uint8Array,
         chainCode: node.chainCodeBytes,
         depth: node.depth,
         parentFingerprint: node.parentFingerprint,
         index: node.index,
+        network: 'mainnet',
       });
 
       expect(node.extendedKey).toStrictEqual(extendedKey);
     });
 
-    it('returns the extended public key for nodes with a public key', async () => {
+    it('returns the extended private key for nodes with a private key (testnet)', async () => {
+      const node = await BIP44Node.fromDerivationPath({
+        derivationPath: [
+          defaultBip39NodeToken,
+          BIP44PurposeNodeToken,
+          `bip32:0'`,
+          `bip32:0'`,
+        ],
+        network: 'testnet',
+      });
+
+      const extendedKey = encodeExtendedKey({
+        type: 'private',
+        privateKey: node.privateKeyBytes as Uint8Array,
+        chainCode: node.chainCodeBytes,
+        depth: node.depth,
+        parentFingerprint: node.parentFingerprint,
+        index: node.index,
+        network: 'testnet',
+      });
+
+      expect(node.extendedKey).toStrictEqual(extendedKey);
+    });
+
+    it('returns the extended public key for nodes with a public key (mainnet)', async () => {
       const node = await BIP44Node.fromDerivationPath({
         derivationPath: [
           defaultBip39NodeToken,
@@ -680,12 +705,39 @@ describe('BIP44Node', () => {
       const neuteredNode = node.neuter();
 
       const extendedKey = encodeExtendedKey({
-        version: PUBLIC_KEY_VERSION,
+        type: 'public',
         publicKey: neuteredNode.publicKeyBytes,
         chainCode: neuteredNode.chainCodeBytes,
         depth: neuteredNode.depth,
         parentFingerprint: neuteredNode.parentFingerprint,
         index: neuteredNode.index,
+        network: 'mainnet',
+      });
+
+      expect(neuteredNode.extendedKey).toStrictEqual(extendedKey);
+    });
+
+    it('returns the extended public key for nodes with a public key (testnet)', async () => {
+      const node = await BIP44Node.fromDerivationPath({
+        derivationPath: [
+          defaultBip39NodeToken,
+          BIP44PurposeNodeToken,
+          `bip32:0'`,
+          `bip32:0'`,
+        ],
+        network: 'testnet',
+      });
+
+      const neuteredNode = node.neuter();
+
+      const extendedKey = encodeExtendedKey({
+        type: 'public',
+        publicKey: neuteredNode.publicKeyBytes,
+        chainCode: neuteredNode.chainCodeBytes,
+        depth: neuteredNode.depth,
+        parentFingerprint: neuteredNode.parentFingerprint,
+        index: neuteredNode.index,
+        network: 'testnet',
       });
 
       expect(neuteredNode.extendedKey).toStrictEqual(extendedKey);
@@ -754,6 +806,7 @@ describe('BIP44Node', () => {
         masterFingerprint: node.masterFingerprint,
         parentFingerprint: node.parentFingerprint,
         index: node.index,
+        network: node.network,
         privateKey: node.privateKey,
         publicKey: node.publicKey,
         chainCode: node.chainCode,
@@ -764,6 +817,7 @@ describe('BIP44Node', () => {
         masterFingerprint: node.masterFingerprint,
         parentFingerprint: node.parentFingerprint,
         index: node.index,
+        network: node.network,
         privateKey: node.privateKey,
         publicKey: node.publicKey,
         chainCode: node.chainCode,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -185,3 +185,8 @@ export type SLIP10PathTuple =
 export type SLIP10Path = RootedSLIP10PathTuple | SLIP10PathTuple;
 
 export type FullHDPathTuple = RootedHDPathTuple5;
+
+/**
+ * The network for which the HD path is intended.
+ */
+export type Network = 'mainnet' | 'testnet';

--- a/src/derivation.ts
+++ b/src/derivation.ts
@@ -2,7 +2,7 @@ import { assert } from '@metamask/utils';
 
 import { BIP44CoinTypeNode } from './BIP44CoinTypeNode';
 import { BIP44Node } from './BIP44Node';
-import type { SLIP10Path } from './constants';
+import type { Network, SLIP10Path } from './constants';
 import {
   BIP_32_PATH_REGEX,
   BIP_39_PATH_REGEX,
@@ -39,6 +39,7 @@ type DeriveKeyFromPathNodeArgs = BaseDeriveKeyFromPathArgs & {
 };
 
 type DeriveKeyFromPathCurveArgs = BaseDeriveKeyFromPathArgs & {
+  network?: Network | undefined;
   curve: SupportedCurve;
 };
 
@@ -75,6 +76,7 @@ export async function deriveKeyFromPath(
   const { path, depth = path.length } = args;
 
   const node = 'node' in args ? args.node : undefined;
+  const network = 'network' in args ? args.network : node?.network;
   const curve = 'curve' in args ? args.curve : node?.curve;
 
   if (
@@ -122,6 +124,7 @@ export async function deriveKeyFromPath(
             path: pathPart,
             node: derivedNode,
             curve: getCurveByName(curve),
+            network,
           },
           cryptographicFunctions,
         );
@@ -135,6 +138,7 @@ export async function deriveKeyFromPath(
           path: pathNode,
           node: derivedNode,
           curve: getCurveByName(curve),
+          network,
         },
         cryptographicFunctions,
       );

--- a/src/derivers/bip32.test.ts
+++ b/src/derivers/bip32.test.ts
@@ -30,17 +30,18 @@ describe('deriveChildKey', () => {
 
     expect(childNode.index).toBe(BIP_32_HARDENED_OFFSET + 1);
     expect(childNode).toMatchInlineSnapshot(`
-        Object {
-          "chainCode": "0xe7862c5448c2e347dbdd0ee287e69888beec88e958388c927d2eff0e04df88f8",
-          "curve": "secp256k1",
-          "depth": 1,
-          "index": 2147483649,
-          "masterFingerprint": 3293725253,
-          "parentFingerprint": 3293725253,
-          "privateKey": "0xdcc114faa58e3feccf10e6658494c0c48b9d146dec313f0dedbd263547da23dc",
-          "publicKey": "0x044948f8f48422b7608754bf228d93aff08c8e27fa46397afd80632be39f1213f8ca7aa33fd2b3630bdbbfa259841ca66f18de39f1de89a603c34f15378c817c24",
-        }
-      `);
+      Object {
+        "chainCode": "0xe7862c5448c2e347dbdd0ee287e69888beec88e958388c927d2eff0e04df88f8",
+        "curve": "secp256k1",
+        "depth": 1,
+        "index": 2147483649,
+        "masterFingerprint": 3293725253,
+        "network": "mainnet",
+        "parentFingerprint": 3293725253,
+        "privateKey": "0xdcc114faa58e3feccf10e6658494c0c48b9d146dec313f0dedbd263547da23dc",
+        "publicKey": "0x044948f8f48422b7608754bf228d93aff08c8e27fa46397afd80632be39f1213f8ca7aa33fd2b3630bdbbfa259841ca66f18de39f1de89a603c34f15378c817c24",
+      }
+    `);
   });
 
   it.each(fixtures.errorHandling.bip32.keys)(
@@ -81,17 +82,18 @@ describe('deriveChildKey', () => {
 
     expect(childNode.index).toBe(1);
     expect(childNode).toMatchInlineSnapshot(`
-        Object {
-          "chainCode": "0x4304d9e48a694baabefba498c2ef85f9e88307f4f621f79f19cbf5f704483130",
-          "curve": "secp256k1",
-          "depth": 1,
-          "index": 1,
-          "masterFingerprint": 3293725253,
-          "parentFingerprint": 3293725253,
-          "privateKey": undefined,
-          "publicKey": "0x048aa5d3fe38c7e81685f9efa72d8b4e9f2cb61647c954e9cdf324a6eefe8a4a00c2b7fa2b2d3e598c87d244fb4eb8708e402aa5ccd945533f4a6ddbc026f77c7b",
-        }
-      `);
+      Object {
+        "chainCode": "0x4304d9e48a694baabefba498c2ef85f9e88307f4f621f79f19cbf5f704483130",
+        "curve": "secp256k1",
+        "depth": 1,
+        "index": 1,
+        "masterFingerprint": 3293725253,
+        "network": "mainnet",
+        "parentFingerprint": 3293725253,
+        "privateKey": undefined,
+        "publicKey": "0x048aa5d3fe38c7e81685f9efa72d8b4e9f2cb61647c954e9cdf324a6eefe8a4a00c2b7fa2b2d3e598c87d244fb4eb8708e402aa5ccd945533f4a6ddbc026f77c7b",
+      }
+    `);
   });
 
   it('throws an error if the curve is ed25519', async () => {

--- a/src/derivers/index.ts
+++ b/src/derivers/index.ts
@@ -2,6 +2,7 @@ import * as bip32 from './bip32';
 import * as bip39 from './bip39';
 import * as cip3 from './cip3';
 import * as slip10 from './slip10';
+import type { Network } from '../constants';
 import type { CryptographicFunctions } from '../cryptography';
 import type { Curve } from '../curves';
 import type { SLIP10Node } from '../SLIP10Node';
@@ -19,6 +20,7 @@ export type DeriveChildKeyArgs = {
   path: Uint8Array | string;
   curve: Curve;
   node?: SLIP10Node;
+  network?: Network | undefined;
 };
 
 export type Deriver = {

--- a/src/derivers/shared.ts
+++ b/src/derivers/shared.ts
@@ -6,6 +6,7 @@ import {
 } from '@metamask/utils';
 
 import type { DeriveChildKeyArgs, DerivedKeys } from '.';
+import type { Network } from '../constants';
 import { BIP_32_HARDENED_OFFSET, UNPREFIXED_PATH_REGEX } from '../constants';
 import type { CryptographicFunctions } from '../cryptography';
 import { hmacSha512 } from '../cryptography';
@@ -30,6 +31,8 @@ type ErrorHandler = (
  * @param options.path - The derivation path part to derive.
  * @param options.node - The node to derive from.
  * @param options.curve - The curve to use for derivation.
+ * @param options.network - The network for the node. This is only used for
+ * extended keys, and defaults to `mainnet`.
  * @param handleError - A function that can handle errors that occur during
  * derivation.
  * @param cryptographicFunctions - The cryptographic functions to use. If
@@ -37,7 +40,7 @@ type ErrorHandler = (
  * @returns The derived node.
  */
 export async function deriveChildKey(
-  { path, node, curve }: DeriveChildKeyArgs,
+  { path, node, curve, network }: DeriveChildKeyArgs,
   handleError: ErrorHandler,
   cryptographicFunctions?: CryptographicFunctions,
 ): Promise<SLIP10Node> {
@@ -53,6 +56,7 @@ export async function deriveChildKey(
     parentFingerprint: node.fingerprint,
     masterFingerprint: node.masterFingerprint,
     curve,
+    network,
   };
 
   if (node.privateKeyBytes) {
@@ -115,6 +119,7 @@ type BaseDeriveNodeArgs = {
   parentFingerprint: number;
   masterFingerprint?: number | undefined;
   curve: Curve;
+  network?: Network | undefined;
 };
 
 type DerivePrivateKeyArgs = BaseDeriveNodeArgs & {
@@ -170,6 +175,7 @@ async function deriveNode(
     parentFingerprint,
     masterFingerprint,
     curve,
+    network,
   } = options;
 
   try {
@@ -184,6 +190,7 @@ async function deriveNode(
           childIndex,
           isHardened,
           curve,
+          network,
         },
         cryptographicFunctions,
       );
@@ -198,6 +205,7 @@ async function deriveNode(
         parentFingerprint,
         childIndex,
         curve,
+        network,
       },
       cryptographicFunctions,
     );
@@ -305,6 +313,7 @@ type DerivePrivateChildKeyArgs = {
   childIndex: number;
   isHardened: boolean;
   curve: Curve;
+  network?: Network | undefined;
 };
 
 /**
@@ -319,6 +328,8 @@ type DerivePrivateChildKeyArgs = {
  * @param args.childIndex - The child index to derive.
  * @param args.isHardened - Whether the child index is hardened.
  * @param args.curve - The curve to use for derivation.
+ * @param args.network - The network for the node. This is only used for
+ * extended keys, and defaults to `mainnet`.
  * @param cryptographicFunctions - The cryptographic functions to use. If
  * provided, these will be used instead of the built-in implementations.
  * @returns The derived {@link SLIP10Node}.
@@ -333,6 +344,7 @@ async function derivePrivateChildKey(
     childIndex,
     isHardened,
     curve,
+    network,
   }: DerivePrivateChildKeyArgs,
   cryptographicFunctions?: CryptographicFunctions,
 ): Promise<SLIP10Node> {
@@ -355,6 +367,7 @@ async function derivePrivateChildKey(
       parentFingerprint,
       index: actualChildIndex,
       curve: curve.name,
+      network,
     },
     cryptographicFunctions,
   );
@@ -400,6 +413,7 @@ type DerivePublicChildKeyArgs = {
   parentFingerprint: number;
   childIndex: number;
   curve: Curve;
+  network?: Network | undefined;
 };
 
 /**
@@ -413,6 +427,8 @@ type DerivePublicChildKeyArgs = {
  * @param args.parentFingerprint - The fingerprint of the parent node.
  * @param args.childIndex - The child index to derive.
  * @param args.curve - The curve to use for derivation.
+ * @param args.network - The network for the node. This is only used for
+ * extended keys, and defaults to `mainnet`.
  * @param cryptographicFunctions - The cryptographic functions to use. If
  * provided, these will be used instead of the built-in implementations.
  * @returns The derived {@link SLIP10Node}.
@@ -426,6 +442,7 @@ export async function derivePublicChildKey(
     parentFingerprint,
     childIndex,
     curve,
+    network,
   }: DerivePublicChildKeyArgs,
   cryptographicFunctions?: CryptographicFunctions,
 ): Promise<SLIP10Node> {
@@ -445,6 +462,7 @@ export async function derivePublicChildKey(
       parentFingerprint,
       index: childIndex,
       curve: curve.name,
+      network,
     },
     cryptographicFunctions,
   );

--- a/src/derivers/slip10.test.ts
+++ b/src/derivers/slip10.test.ts
@@ -25,17 +25,18 @@ describe('deriveChildKey', () => {
 
     expect(childNode.index).toBe(BIP_32_HARDENED_OFFSET);
     expect(childNode).toMatchInlineSnapshot(`
-        Object {
-          "chainCode": "0x69c58a9e53bb674d1bbeb871975f01adce5e058cdcba89f8930225341a75b439",
-          "curve": "secp256k1",
-          "depth": 1,
-          "index": 2147483648,
-          "masterFingerprint": 3293725253,
-          "parentFingerprint": 3293725253,
-          "privateKey": "0xb9dbe9cda5d858df377ab6c6a9b3efef99269142e390d24aaceb49c547b9fcad",
-          "publicKey": "0x0422a2beb2a0c800ef19200db9161a3a7ee5645ccf67c05e18e7055a73cb1e1451f2c85f9aaac274bd16ea9a77f102feef3aba3f37ed6ac6e0961fb569011e42cf",
-        }
-      `);
+      Object {
+        "chainCode": "0x69c58a9e53bb674d1bbeb871975f01adce5e058cdcba89f8930225341a75b439",
+        "curve": "secp256k1",
+        "depth": 1,
+        "index": 2147483648,
+        "masterFingerprint": 3293725253,
+        "network": "mainnet",
+        "parentFingerprint": 3293725253,
+        "privateKey": "0xb9dbe9cda5d858df377ab6c6a9b3efef99269142e390d24aaceb49c547b9fcad",
+        "publicKey": "0x0422a2beb2a0c800ef19200db9161a3a7ee5645ccf67c05e18e7055a73cb1e1451f2c85f9aaac274bd16ea9a77f102feef3aba3f37ed6ac6e0961fb569011e42cf",
+      }
+    `);
   });
 
   it.each(fixtures.errorHandling.slip10.keys)(
@@ -95,16 +96,17 @@ describe('deriveChildKey', () => {
 
     expect(childNode.index).toBe(0);
     expect(childNode).toMatchInlineSnapshot(`
-        Object {
-          "chainCode": "0x03eebbe4707329e7da4aef868adb65f21bdc8712a86567b17a15ee4c3f01a57a",
-          "curve": "secp256k1",
-          "depth": 1,
-          "index": 0,
-          "masterFingerprint": 3293725253,
-          "parentFingerprint": 3293725253,
-          "privateKey": undefined,
-          "publicKey": "0x04bc28203026c9fda2030f00ca592bdbe25392a106afae5205fa07dc4d77ecc61d21fa7a4bf21920abb52f56ae87f2d7b10d5db8d51229dea9c98c6b7982d514f9",
-        }
-      `);
+      Object {
+        "chainCode": "0x03eebbe4707329e7da4aef868adb65f21bdc8712a86567b17a15ee4c3f01a57a",
+        "curve": "secp256k1",
+        "depth": 1,
+        "index": 0,
+        "masterFingerprint": 3293725253,
+        "network": "mainnet",
+        "parentFingerprint": 3293725253,
+        "privateKey": undefined,
+        "publicKey": "0x04bc28203026c9fda2030f00ca592bdbe25392a106afae5205fa07dc4d77ecc61d21fa7a4bf21920abb52f56ae87f2d7b10d5db8d51229dea9c98c6b7982d514f9",
+      }
+    `);
   });
 });

--- a/src/extended-keys.test.ts
+++ b/src/extended-keys.test.ts
@@ -1,30 +1,45 @@
 import { hexToBytes } from '@metamask/utils';
 
 import type { ExtendedKey } from './extended-keys';
-import {
-  decodeExtendedKey,
-  encodeExtendedKey,
-  PRIVATE_KEY_VERSION,
-  PUBLIC_KEY_VERSION,
-} from './extended-keys';
+import { decodeExtendedKey, encodeExtendedKey } from './extended-keys';
 import { hexStringToBytes } from './utils';
 
 describe('decodeExtendedKey', () => {
-  it('decodes an extended public key', () => {
+  it('decodes an extended public key (mainnet)', () => {
     const extendedKey =
       'xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8';
 
     expect(decodeExtendedKey(extendedKey)).toStrictEqual({
+      type: 'public',
       depth: 0,
       parentFingerprint: 0,
       index: 0,
+      network: 'mainnet',
       chainCode: hexToBytes(
         '873dff81c02f525623fd1fe5167eac3a55a049de3d314bb42ee227ffed37d508',
       ),
       publicKey: hexToBytes(
         '0439a36013301597daef41fbe593a02cc513d0b55527ec2df1050e2e8ff49c85c23cbe7ded0e7ce6a594896b8f62888fdbc5c8821305e2ea42bf01e37300116281',
       ),
-      version: PUBLIC_KEY_VERSION,
+    });
+  });
+
+  it('decodes an extended public key (testnet)', () => {
+    const extendedKey =
+      'tpubD6NzVbkrYhZ4XgiXtGrdW5XDAPFCL9h7we1vwNCpn8tGbBcgfVYjXyhWo4E1xkh56hjod1RhGjxbaTLV3X4FyWuejifB9jusQ46QzG87VKp';
+
+    expect(decodeExtendedKey(extendedKey)).toStrictEqual({
+      type: 'public',
+      depth: 0,
+      parentFingerprint: 0,
+      index: 0,
+      network: 'testnet',
+      chainCode: hexToBytes(
+        '873dff81c02f525623fd1fe5167eac3a55a049de3d314bb42ee227ffed37d508',
+      ),
+      publicKey: hexToBytes(
+        '0439a36013301597daef41fbe593a02cc513d0b55527ec2df1050e2e8ff49c85c23cbe7ded0e7ce6a594896b8f62888fdbc5c8821305e2ea42bf01e37300116281',
+      ),
     });
   });
 
@@ -33,16 +48,36 @@ describe('decodeExtendedKey', () => {
       'xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi';
 
     expect(decodeExtendedKey(extendedKey)).toStrictEqual({
+      type: 'private',
       depth: 0,
       parentFingerprint: 0,
       index: 0,
+      network: 'mainnet',
       chainCode: hexStringToBytes(
         '873dff81c02f525623fd1fe5167eac3a55a049de3d314bb42ee227ffed37d508',
       ),
       privateKey: hexStringToBytes(
         'e8f32e723decf4051aefac8e2c93c9c5b214313817cdb01a1494b917c8436b35',
       ),
-      version: PRIVATE_KEY_VERSION,
+    });
+  });
+
+  it('decodes an extended private key (testnet)', () => {
+    const extendedKey =
+      'tprv8ZgxMBicQKsPeDgjzdC36fs6bMjGApWDNLR9erAXMs5skhMv36j9MV5ecvfavji5khqjWaWSFhN3YcCUUdiKH6isR4Pwy3U5y5egddBr16m';
+
+    expect(decodeExtendedKey(extendedKey)).toStrictEqual({
+      type: 'private',
+      depth: 0,
+      parentFingerprint: 0,
+      index: 0,
+      network: 'testnet',
+      chainCode: hexStringToBytes(
+        '873dff81c02f525623fd1fe5167eac3a55a049de3d314bb42ee227ffed37d508',
+      ),
+      privateKey: hexStringToBytes(
+        'e8f32e723decf4051aefac8e2c93c9c5b214313817cdb01a1494b917c8436b35',
+      ),
     });
   });
 
@@ -110,18 +145,19 @@ describe('decodeExtendedKey', () => {
 });
 
 describe('encodeExtendedKey', () => {
-  it('encodes an extended public key', () => {
+  it('encodes an extended public key (mainnet)', () => {
     const extendedKey: ExtendedKey = {
+      type: 'public',
       depth: 0,
       parentFingerprint: 0,
       index: 0,
+      network: 'mainnet',
       chainCode: hexStringToBytes(
         '873dff81c02f525623fd1fe5167eac3a55a049de3d314bb42ee227ffed37d508',
       ),
       publicKey: hexStringToBytes(
         '0439a36013301597daef41fbe593a02cc513d0b55527ec2df1050e2e8ff49c85c23cbe7ded0e7ce6a594896b8f62888fdbc5c8821305e2ea42bf01e37300116281',
       ),
-      version: PUBLIC_KEY_VERSION,
     };
 
     expect(encodeExtendedKey(extendedKey)).toBe(
@@ -129,22 +165,84 @@ describe('encodeExtendedKey', () => {
     );
   });
 
-  it('encodes an extended private key', () => {
+  it('encodes an extended public key (testnet)', () => {
     const extendedKey: ExtendedKey = {
+      type: 'public',
       depth: 0,
       parentFingerprint: 0,
       index: 0,
+      network: 'testnet',
+      chainCode: hexStringToBytes(
+        '873dff81c02f525623fd1fe5167eac3a55a049de3d314bb42ee227ffed37d508',
+      ),
+      publicKey: hexStringToBytes(
+        '0439a36013301597daef41fbe593a02cc513d0b55527ec2df1050e2e8ff49c85c23cbe7ded0e7ce6a594896b8f62888fdbc5c8821305e2ea42bf01e37300116281',
+      ),
+    };
+
+    expect(encodeExtendedKey(extendedKey)).toBe(
+      'tpubD6NzVbkrYhZ4XgiXtGrdW5XDAPFCL9h7we1vwNCpn8tGbBcgfVYjXyhWo4E1xkh56hjod1RhGjxbaTLV3X4FyWuejifB9jusQ46QzG87VKp',
+    );
+  });
+
+  it('encodes an extended private key (mainnet)', () => {
+    const extendedKey: ExtendedKey = {
+      type: 'private',
+      depth: 0,
+      parentFingerprint: 0,
+      index: 0,
+      network: 'mainnet',
       chainCode: hexStringToBytes(
         '873dff81c02f525623fd1fe5167eac3a55a049de3d314bb42ee227ffed37d508',
       ),
       privateKey: hexStringToBytes(
         'e8f32e723decf4051aefac8e2c93c9c5b214313817cdb01a1494b917c8436b35',
       ),
-      version: PRIVATE_KEY_VERSION,
     };
 
     expect(encodeExtendedKey(extendedKey)).toBe(
       'xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi',
+    );
+  });
+
+  it('encodes an extended private key (testnet)', () => {
+    const extendedKey: ExtendedKey = {
+      type: 'private',
+      depth: 0,
+      parentFingerprint: 0,
+      index: 0,
+      network: 'testnet',
+      chainCode: hexStringToBytes(
+        '873dff81c02f525623fd1fe5167eac3a55a049de3d314bb42ee227ffed37d508',
+      ),
+      privateKey: hexStringToBytes(
+        'e8f32e723decf4051aefac8e2c93c9c5b214313817cdb01a1494b917c8436b35',
+      ),
+    };
+
+    expect(encodeExtendedKey(extendedKey)).toBe(
+      'tprv8ZgxMBicQKsPeDgjzdC36fs6bMjGApWDNLR9erAXMs5skhMv36j9MV5ecvfavji5khqjWaWSFhN3YcCUUdiKH6isR4Pwy3U5y5egddBr16m',
+    );
+  });
+
+  it('throws if the network is invalid', () => {
+    const extendedKey: ExtendedKey = {
+      type: 'public',
+      depth: 0,
+      parentFingerprint: 0,
+      index: 0,
+      // @ts-expect-error - Invalid network.
+      network: 'invalid',
+      chainCode: hexStringToBytes(
+        '873dff81c02f525623fd1fe5167eac3a55a049de3d314bb42ee227ffed37d508',
+      ),
+      publicKey: hexStringToBytes(
+        '0439a36013301597daef41fbe593a02cc513d0b55527ec2df1050e2e8ff49c85c23cbe7ded0e7ce6a594896b8f62888fdbc5c8821305e2ea42bf01e37300116281',
+      ),
+    };
+
+    expect(() => encodeExtendedKey(extendedKey)).toThrow(
+      'Invalid branch reached. Should be detected during compilation.',
     );
   });
 });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -23,6 +23,7 @@ import {
   mnemonicPhraseToBytes,
   getBytesUnsafe,
   isValidBIP32PathSegment,
+  validateNetwork,
 } from './utils';
 import fixtures from '../test/fixtures';
 
@@ -430,4 +431,24 @@ describe('mnemonicPhraseToBytes', () => {
       );
     },
   );
+});
+
+describe('validateNetwork', () => {
+  it('does not throw if the network is valid', () => {
+    expect(() => validateNetwork('mainnet')).not.toThrow();
+    expect(() => validateNetwork('testnet')).not.toThrow();
+    expect(() => validateNetwork(undefined)).not.toThrow();
+  });
+
+  it('throws if the network is not a string', () => {
+    expect(() => validateNetwork(1)).toThrow(
+      'Invalid network: Must be a string if specified.',
+    );
+  });
+
+  it('throws if the network is not a valid string', () => {
+    expect(() => validateNetwork('foo')).toThrow(
+      'Invalid network: Must be either "mainnet" or "testnet" if specified.',
+    );
+  });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,7 @@ import type {
   CoinTypeHDPathString,
   CoinTypeToAddressTuple,
   HardenedBIP32Node,
+  Network,
   UnhardenedBIP32Node,
   UnprefixedNode,
 } from './constants';
@@ -464,4 +465,30 @@ export function numberToUint32(
  */
 export function isWebCryptoSupported(): boolean {
   return Boolean(globalThis.crypto?.subtle);
+}
+
+/**
+ * Validate the network. If the network is specified, it must be either
+ * "mainnet" or "testnet". This function throws an error if the network is
+ * invalid.
+ *
+ * @param network - The network to validate.
+ * @throws An error if the network is invalid.
+ */
+export function validateNetwork(
+  network: unknown,
+): asserts network is Network | undefined {
+  if (network === undefined) {
+    return;
+  }
+
+  if (typeof network !== 'string') {
+    throw new Error('Invalid network: Must be a string if specified.');
+  }
+
+  if (!['mainnet', 'testnet'].includes(network)) {
+    throw new Error(
+      `Invalid network: Must be either "mainnet" or "testnet" if specified.`,
+    );
+  }
 }

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -458,6 +458,7 @@ export default {
           masterFingerprint: 1247889873,
           parentFingerprint: 0,
           index: 0,
+          network: 'mainnet',
           curve: 'ed25519Bip32',
           privateKey:
             '0xc065afd2832cd8b087c4d9ab7011f481ee1e0721e78ea5dd609f3ab3f156d245d176bd8fd4ec60b4731c3918a2a72a0226c0cd119ec35b47e4d55884667f552a',
@@ -473,6 +474,7 @@ export default {
           masterFingerprint: 1247889873,
           parentFingerprint: 1247889873,
           index: 2147485500,
+          network: 'mainnet',
           curve: 'ed25519Bip32',
           privateKey:
             '0x98f25c3313e03b7843072514c5f024782072406b37569403423d2361f356d2459ecc73a09adb2aa37e9f8530fd1e6745eee1ea248a85417a700e774182c7fa3d',
@@ -486,6 +488,7 @@ export default {
           masterFingerprint: 1247889873,
           parentFingerprint: 186342781,
           index: 2147485463,
+          network: 'mainnet',
           curve: 'ed25519Bip32',
           privateKey:
             '0x504e9dc3ed6d22231a0e43cd250fcda7757b42aa9affae5f20dea1fef956d2450cc3d2abd5b6a6626d73d789a6ad77cd0e5d92e093dc5a1484c71e4f996f495e',
@@ -499,6 +502,7 @@ export default {
           masterFingerprint: 1247889873,
           parentFingerprint: 1372272135,
           index: 2147483648,
+          network: 'mainnet',
           curve: 'ed25519Bip32',
           privateKey:
             '0xf80081fa05eece83236e612463aafad20d6b92eee67479a1977959540057d2452173fe9a0fccf61cf2cc7c52638f2ded6c08002a71424ca5b93681ee7a385828',
@@ -512,6 +516,7 @@ export default {
           masterFingerprint: 1247889873,
           parentFingerprint: 3705424019,
           index: 0,
+          network: 'mainnet',
           curve: 'ed25519Bip32',
           privateKey:
             '0x00b5105515ee89a7718c0bdbe05c9613a17a5907f5943dacfde9802f0157d2458bddfc042979fb8b30cb13437edc7ec7c1836676e063780d5db0b8ae84babe4e',
@@ -525,6 +530,7 @@ export default {
           masterFingerprint: 1247889873,
           parentFingerprint: 3669962052,
           index: 0,
+          network: 'mainnet',
           curve: 'ed25519Bip32',
           privateKey:
             '0x00df3ecf0e02979dd9ee569d09412c1f370f476054aaa1ef3cf5a08c0557d245a6ad0fe81ab55e36178f5866dc8f83cf57239fdeee35c737ef887964aae20500',
@@ -566,6 +572,7 @@ export default {
           masterFingerprint: 2293781934,
           parentFingerprint: 2293781934,
           index: 2147485500,
+          network: 'mainnet',
           curve: 'ed25519Bip32',
           privateKey:
             '0x305c7df2d77b116892dd47019a0913ad0769216e16b73d0fca6088dd748c774843861f9f2a07aff8e51c7807d92bc6ee432154a992227c0df2821d96c3a2763d',
@@ -579,6 +586,7 @@ export default {
           masterFingerprint: 2293781934,
           parentFingerprint: 2022252320,
           index: 2147485463,
+          network: 'mainnet',
           curve: 'ed25519Bip32',
           privateKey:
             '0xd08b653d6f960079db25f38e8428f7f2891bd1c92b63ad7e0015265c768c77485bf55f8ccbb0a7188ebafcbd30219300ce3b86f54b11e236961efc814688810e',
@@ -592,6 +600,7 @@ export default {
           masterFingerprint: 2293781934,
           parentFingerprint: 3388798503,
           index: 2147483648,
+          network: 'mainnet',
           curve: 'ed25519Bip32',
           privateKey:
             '0xe81381a5e59e98dc7eaffecc83d918ad8331938eedf3429d7d29dbfa768c774899268aba2b299d9513de3a33c134fedd19d209701456fe86757c9f64230c010f',
@@ -605,6 +614,7 @@ export default {
           masterFingerprint: 2293781934,
           parentFingerprint: 2105312604,
           index: 0,
+          network: 'mainnet',
           curve: 'ed25519Bip32',
           privateKey:
             '0x5049005d5a97d5ea60753fb511460079a56b9981bc2e75f05e40dd46788c7748d664152bff95f76efdd0052643eb096eea6f18b6793365563bcaa12b3aa04fed',
@@ -618,6 +628,7 @@ export default {
           masterFingerprint: 2293781934,
           parentFingerprint: 2627281642,
           index: 0,
+          network: 'mainnet',
           curve: 'ed25519Bip32',
           privateKey:
             '0xf0e6e40de5b8ae0d9c48f8ce7f829231aff420d792ff995dc56040f97b8c7748377ede2ad5468ce8103d2f3af977bb081c3c6aba76b36b72e56a7ba38559224d',


### PR DESCRIPTION
BIP-32 specifies four different "versions" for extended keys. Public and private, but also mainnet and testnet. Previously we just assumed mainnet, because that's what's used for Ethereum, but to support other networks (such as Bitcoin), I've added a network field (i.e., `mainnet` or `testnet`), which determines which BIP-32 extended key version to use.