### PR TITLE
Export `CryptographicFunctions` type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export type {
   SLIP10DerivationPathOptions,
 } from './SLIP10Node';
 export { SLIP10Node } from './SLIP10Node';
+export type { CryptographicFunctions } from './cryptography';
 export type { SupportedCurve } from './curves';
 export { secp256k1, ed25519, ed25519Bip32 } from './curves';
 export type {


### PR DESCRIPTION
In #197 we forgot to export the `CryptographicFunctions` type.