### PR TITLE
perf: Tweak precompute window size for ed25519

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@metamask/scure-bip39": "^2.1.1",
     "@metamask/utils": "^11.0.1",
-    "@noble/curves": "^1.2.0",
+    "@noble/curves": "^1.8.1",
     "@noble/hashes": "^1.3.2",
     "@scure/base": "^1.0.0"
   },

--- a/src/curves/ed25519.ts
+++ b/src/curves/ed25519.ts
@@ -18,7 +18,10 @@ export const deriveUnhardenedKeys = false;
 
 export const publicKeyLength = 33;
 
-const getGetPublicKey = (): ((privateKey: Uint8Array) => Uint8Array) => {
+const getGetPublicKey = (): ((
+  privateKey: Uint8Array,
+  _compressed?: boolean,
+) => Uint8Array) => {
   let hasSetWindowSize = false;
 
   const getPublicKey = (

--- a/src/curves/ed25519.ts
+++ b/src/curves/ed25519.ts
@@ -18,7 +18,6 @@ export const deriveUnhardenedKeys = false;
 
 export const publicKeyLength = 33;
 
-// @ts-expect-error Missing types.
 ed25519.ExtendedPoint.BASE._setWindowSize(4);
 
 export const getPublicKey = (

--- a/src/curves/ed25519.ts
+++ b/src/curves/ed25519.ts
@@ -18,15 +18,25 @@ export const deriveUnhardenedKeys = false;
 
 export const publicKeyLength = 33;
 
-ed25519.ExtendedPoint.BASE._setWindowSize(4);
+const getGetPublicKey = (): ((privateKey: Uint8Array) => Uint8Array) => {
+  let hasSetWindowSize = false;
 
-export const getPublicKey = (
-  privateKey: Uint8Array,
-  _compressed?: boolean,
-): Uint8Array => {
-  const publicKey = ed25519.getPublicKey(privateKey);
-  return concatBytes([new Uint8Array([0]), publicKey]);
+  const getPublicKey = (
+    privateKey: Uint8Array,
+    _compressed?: boolean,
+  ): Uint8Array => {
+    if (!hasSetWindowSize) {
+      ed25519.ExtendedPoint.BASE._setWindowSize(4);
+      hasSetWindowSize = true;
+    }
+    const publicKey = ed25519.getPublicKey(privateKey);
+    return concatBytes([new Uint8Array([0]), publicKey]);
+  };
+
+  return getPublicKey;
 };
+
+export const getPublicKey = getGetPublicKey();
 
 export const publicAdd = (
   _publicKey: Uint8Array,

--- a/src/curves/ed25519.ts
+++ b/src/curves/ed25519.ts
@@ -18,6 +18,9 @@ export const deriveUnhardenedKeys = false;
 
 export const publicKeyLength = 33;
 
+// @ts-expect-error Missing types.
+ed25519.ExtendedPoint.BASE._setWindowSize(4);
+
 export const getPublicKey = (
   privateKey: Uint8Array,
   _compressed?: boolean,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1232,14 +1232,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:1.7.1":
+"@noble/hashes@npm:1.7.1, @noble/hashes@npm:^1.3.1, @noble/hashes@npm:^1.3.2":
   version: 1.7.1
   resolution: "@noble/hashes@npm:1.7.1"
   checksum: 10/ca3120da0c3e7881d6a481e9667465cc9ebbee1329124fb0de442e56d63fef9870f8cc96f264ebdb18096e0e36cebc0e6e979a872d545deb0a6fed9353f17e05
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:^1.3.1, @noble/hashes@npm:^1.3.2, @noble/hashes@npm:~1.3.0, @noble/hashes@npm:~1.3.2":
+"@noble/hashes@npm:~1.3.0, @noble/hashes@npm:~1.3.2":
   version: 1.3.2
   resolution: "@noble/hashes@npm:1.3.2"
   checksum: 10/685f59d2d44d88e738114b71011d343a9f7dce9dfb0a121f1489132f9247baa60bc985e5ec6f3213d114fbd1e1168e7294644e46cbd0ce2eba37994f28eeb51b

--- a/yarn.lock
+++ b/yarn.lock
@@ -1134,7 +1134,7 @@ __metadata:
     "@metamask/eslint-config-typescript": "npm:^14.0.0"
     "@metamask/scure-bip39": "npm:^2.1.1"
     "@metamask/utils": "npm:^11.0.1"
-    "@noble/curves": "npm:^1.2.0"
+    "@noble/curves": "npm:^1.8.1"
     "@noble/hashes": "npm:^1.3.2"
     "@scure/base": "npm:^1.0.0"
     "@ts-bridge/cli": "npm:^0.6.0"
@@ -1216,12 +1216,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/curves@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "@noble/curves@npm:1.2.0"
+"@noble/curves@npm:^1.8.1":
+  version: 1.8.1
+  resolution: "@noble/curves@npm:1.8.1"
   dependencies:
-    "@noble/hashes": "npm:1.3.2"
-  checksum: 10/94e02e9571a9fd42a3263362451849d2f54405cb3ce9fa7c45bc6b9b36dcd7d1d20e2e1e14cfded24937a13d82f1e60eefc4d7a14982ce0bc219a9fc0f51d1f9
+    "@noble/hashes": "npm:1.7.1"
+  checksum: 10/e861db372cc0734b02a4c61c0f5a6688d4a7555edca3d8a9e7c846c9aa103ca52d3c3818e8bc333a1a95b5be7f370ff344668d5d759471b11c2d14c7f24b3984
   languageName: node
   linkType: hard
 
@@ -1232,7 +1232,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:1.3.2, @noble/hashes@npm:^1.3.1, @noble/hashes@npm:^1.3.2, @noble/hashes@npm:~1.3.0, @noble/hashes@npm:~1.3.2":
+"@noble/hashes@npm:1.7.1":
+  version: 1.7.1
+  resolution: "@noble/hashes@npm:1.7.1"
+  checksum: 10/ca3120da0c3e7881d6a481e9667465cc9ebbee1329124fb0de442e56d63fef9870f8cc96f264ebdb18096e0e36cebc0e6e979a872d545deb0a6fed9353f17e05
+  languageName: node
+  linkType: hard
+
+"@noble/hashes@npm:^1.3.1, @noble/hashes@npm:^1.3.2, @noble/hashes@npm:~1.3.0, @noble/hashes@npm:~1.3.2":
   version: 1.3.2
   resolution: "@noble/hashes@npm:1.3.2"
   checksum: 10/685f59d2d44d88e738114b71011d343a9f7dce9dfb0a121f1489132f9247baa60bc985e5ec6f3213d114fbd1e1168e7294644e46cbd0ce2eba37994f28eeb51b


### PR DESCRIPTION
Tweak precompute window size for `ed25519`, reducing it from `8` to `4`, which results in a performance gain of about `-50%` on average when running under React Native.