### PR TITLE
Add `fromSeed` function to `SLIP10Node`, `BIP44Node`, `BIP44CoinTypeNode`

### DIFF
--- a/src/BIP44CoinTypeNode.ts
+++ b/src/BIP44CoinTypeNode.ts
@@ -16,6 +16,7 @@ import type { SupportedCurve } from './curves';
 import { deriveChildNode } from './SLIP10Node';
 import type { CoinTypeToAddressIndices } from './utils';
 import {
+  getBIP44CoinType,
   getBIP32NodeToken,
   getBIP44ChangePathString,
   getBIP44CoinTypePathString,
@@ -32,6 +33,12 @@ export type CoinTypeHDPathTuple = [
   HardenedBIP32Node,
 ];
 
+export type CoinTypeSeedPathTuple = [
+  Uint8Array,
+  typeof BIP44PurposeNodeToken,
+  HardenedBIP32Node,
+];
+
 export const BIP_44_COIN_TYPE_DEPTH = 2;
 
 export type JsonBIP44CoinTypeNode = JsonBIP44Node & {
@@ -42,6 +49,11 @@ export type JsonBIP44CoinTypeNode = JsonBIP44Node & {
 export type BIP44CoinTypeNodeInterface = BIP44NodeInterface & {
   readonly coin_type: number;
   readonly path: CoinTypeHDPathString;
+};
+
+export type BIP44CoinTypeSeedOptions = {
+  readonly derivationPath: CoinTypeSeedPathTuple;
+  readonly network?: Network | undefined;
 };
 
 /**
@@ -106,7 +118,7 @@ export class BIP44CoinTypeNode implements BIP44CoinTypeNodeInterface {
   }
 
   /**
-   * Constructs a BIP-44 `coin_type` node. `coin_type` is the index
+   * Construct a BIP-44 `coin_type` node. `coin_type` is the index
    * specifying the protocol for which deeper keys are intended. For the
    * authoritative list of coin types, please see
    * [SLIP-44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md).
@@ -141,14 +153,42 @@ export class BIP44CoinTypeNode implements BIP44CoinTypeNodeInterface {
       cryptographicFunctions,
     );
 
-    // Split the bip32 string token and extract the coin_type index.
-    const pathPart = derivationPath[BIP_44_COIN_TYPE_DEPTH].split(
-      ':',
-    )[1]?.replace(`'`, '');
+    const coinType = getBIP44CoinType(derivationPath);
+    return new BIP44CoinTypeNode(node, coinType);
+  }
 
-    assert(pathPart, 'Invalid derivation path.');
-    const coinType = Number.parseInt(pathPart, 10);
+  /**
+   * Create a new BIP-44 coin type node from a BIP-39 seed. The derivation path
+   * must be rooted, i.e. it must begin with a BIP-39 node, given as a
+   * `Uint8Array` of the seed bytes.
+   *
+   * All parameters are stringently validated, and an error is thrown if
+   * validation fails.
+   *
+   * @param options - The options for the new node.
+   * @param options.derivationPath - The rooted HD tree path that will be used
+   * to derive the key of this node.
+   * @param options.network - The network for the node. This is only used for
+   * extended keys, and defaults to `mainnet`.
+   * @param cryptographicFunctions - The cryptographic functions to use. If
+   * provided, these will be used instead of the built-in implementations.
+   * @returns A new BIP-44 node.
+   */
+  static async fromSeed(
+    { derivationPath, network }: BIP44CoinTypeSeedOptions,
+    cryptographicFunctions?: CryptographicFunctions,
+  ): Promise<BIP44CoinTypeNode> {
+    validateCoinTypeNodeDepth(derivationPath.length - 1);
 
+    const node = await BIP44Node.fromSeed(
+      {
+        derivationPath,
+        network,
+      },
+      cryptographicFunctions,
+    );
+
+    const coinType = getBIP44CoinType(derivationPath);
     return new BIP44CoinTypeNode(node, coinType);
   }
 

--- a/src/BIP44CoinTypeNode.ts
+++ b/src/BIP44CoinTypeNode.ts
@@ -1,5 +1,3 @@
-import { assert } from '@metamask/utils';
-
 import type { BIP44NodeInterface, JsonBIP44Node } from './BIP44Node';
 import { BIP44Node } from './BIP44Node';
 import type {

--- a/src/BIP44Node.test.ts
+++ b/src/BIP44Node.test.ts
@@ -1,4 +1,3 @@
-import { mnemonicToSeed } from '@metamask/scure-bip39';
 import { bytesToHex } from '@metamask/utils';
 
 import { BIP44Node, BIP44PurposeNodeToken, secp256k1 } from '.';

--- a/src/SLIP10Node.test.ts
+++ b/src/SLIP10Node.test.ts
@@ -5,12 +5,7 @@ import type { CryptographicFunctions } from './cryptography';
 import { pbkdf2Sha512, hmacSha512 } from './cryptography';
 import { ed25519, secp256k1 } from './curves';
 import { compressPublicKey } from './curves/secp256k1';
-import {
-  createBip39KeyFromSeed,
-  deriveChildKey,
-  mnemonicToSeed,
-  multipathToBip39Mnemonic,
-} from './derivers/bip39';
+import { createBip39KeyFromSeed, deriveChildKey } from './derivers/bip39';
 import { encodeExtendedKey } from './extended-keys';
 import { SLIP10Node } from './SLIP10Node';
 import { hexStringToBytes, mnemonicPhraseToBytes } from './utils';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -178,6 +178,11 @@ export type RootedSLIP10PathTuple = readonly [
   ...(BIP32Node[] | SLIP10PathNode[] | CIP3PathNode[]),
 ];
 
+export type RootedSLIP10SeedPathTuple = readonly [
+  Uint8Array,
+  ...(BIP32Node[] | SLIP10PathNode[] | CIP3PathNode[]),
+];
+
 export type SLIP10PathTuple =
   | readonly BIP32Node[]
   | readonly SLIP10PathNode[]

--- a/src/derivers/bip39.ts
+++ b/src/derivers/bip39.ts
@@ -166,7 +166,7 @@ export async function getDerivationPathWithSeed(
 
     /* istanbul ignore next */
     default:
-      assertExhaustive(curve);
+      return assertExhaustive(curve);
   }
 }
 

--- a/src/derivers/bip39.ts
+++ b/src/derivers/bip39.ts
@@ -174,7 +174,8 @@ export async function getDerivationPathWithSeed(
  * Create a {@link SLIP10Node} from a BIP-39 seed.
  *
  * @param options - The options for creating the node.
- * @param options.path - The multi path.
+ * @param options.path - The multi path. This is expected to be the BIP-39 seed,
+ * or the entropy in the case of CIP-3, not the mnemonic phrase itself.
  * @param options.curve - The curve to use for derivation.
  * @param options.network - The network for the node. This is only used for
  * extended keys, and defaults to `mainnet`.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,11 @@ import { assert, createDataView, hexToBytes } from '@metamask/utils';
 import { base58check as scureBase58check } from '@scure/base';
 
 import type {
+  CoinTypeHDPathTuple,
+  CoinTypeSeedPathTuple,
+} from './BIP44CoinTypeNode';
+import { BIP_44_COIN_TYPE_DEPTH } from './BIP44CoinTypeNode';
+import type {
   BIP32Node,
   ChangeHDPathString,
   CoinTypeHDPathString,
@@ -491,4 +496,32 @@ export function validateNetwork(
       `Invalid network: Must be either "mainnet" or "testnet" if specified.`,
     );
   }
+}
+
+/**
+ * Get the BIP-44 coin type from a {@link CoinTypeHDPathTuple} or
+ * {@link CoinTypeSeedPathTuple}.
+ *
+ * This function does not validate the derivation path, and assumes that the
+ * derivation path is valid.
+ *
+ * @param derivationPath - The derivation path to get the BIP-44 coin type from.
+ * @returns The BIP-44 coin type.
+ */
+export function getBIP44CoinType(
+  derivationPath: CoinTypeHDPathTuple | CoinTypeSeedPathTuple,
+): number {
+  const pathPart = derivationPath[BIP_44_COIN_TYPE_DEPTH].split(
+    ':',
+  )[1]?.replace(`'`, '');
+
+  assert(pathPart, 'Invalid derivation path: Coin type is not specified.');
+
+  const value = Number.parseInt(pathPart, 10);
+  assert(
+    isValidInteger(value),
+    'Invalid derivation path: Coin type is not a valid integer.',
+  );
+
+  return value;
 }

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1,8 +1,15 @@
+import { mnemonicToSeedSync } from '@metamask/scure-bip39';
+import { wordlist } from '@metamask/scure-bip39/dist/wordlists/english';
+
 export default {
   // Fixtures defined and used in this package
   local: {
     mnemonic:
       'romance hurry grit huge rifle ordinary loud toss sound congress upset twist',
+    seed: mnemonicToSeedSync(
+      'romance hurry grit huge rifle ordinary loud toss sound congress upset twist',
+      wordlist,
+    ),
     addresses: [
       '0x5df603999c3d5ca2ab828339a9883585b1bce11b',
       '0x441c07e32a609afd319ffbb66432b424058bcfe9',

--- a/test/reference-implementations.test.ts
+++ b/test/reference-implementations.test.ts
@@ -6,7 +6,10 @@ import type { SLIP10Node, HDPathTuple } from '../src';
 import { BIP44Node, BIP44PurposeNodeToken } from '../src';
 import { ed25519, secp256k1 } from '../src/curves';
 import { deriveKeyFromPath } from '../src/derivation';
-import { createBip39KeyFromSeed } from '../src/derivers/bip39';
+import {
+  createBip39KeyFromSeed,
+  getDerivationPathWithSeed,
+} from '../src/derivers/bip39';
 import {
   getBIP44CoinTypeToAddressPathTuple,
   hexStringToBytes,
@@ -53,7 +56,10 @@ describe('reference implementation tests', () => {
         it('derives the expected keys', async () => {
           // Ethereum coin type key
           const node = await deriveKeyFromPath({
-            path: [mnemonicBip39Node, BIP44PurposeNodeToken, `bip32:60'`],
+            path: await getDerivationPathWithSeed({
+              path: [mnemonicBip39Node, BIP44PurposeNodeToken, `bip32:60'`],
+              curve: 'secp256k1',
+            }),
             curve: 'secp256k1',
           });
 
@@ -133,7 +139,10 @@ describe('reference implementation tests', () => {
         it('derives the same keys as the reference implementation', async () => {
           // Ethereum coin type key
           const node = await deriveKeyFromPath({
-            path: [mnemonicBip39Node, BIP44PurposeNodeToken, `bip32:60'`],
+            path: await getDerivationPathWithSeed({
+              path: [mnemonicBip39Node, BIP44PurposeNodeToken, `bip32:60'`],
+              curve: 'secp256k1',
+            }),
             curve: 'secp256k1',
           });
 
@@ -367,7 +376,10 @@ describe('reference implementation tests', () => {
         it('derives the expected keys', async () => {
           // Ethereum coin type key
           const node = await deriveKeyFromPath({
-            path: [mnemonicBip39Node, BIP44PurposeNodeToken, `bip32:60'`],
+            path: await getDerivationPathWithSeed({
+              path: [mnemonicBip39Node, BIP44PurposeNodeToken, `bip32:60'`],
+              curve: 'secp256k1',
+            }),
             curve: 'secp256k1',
           });
 
@@ -447,7 +459,10 @@ describe('reference implementation tests', () => {
         it('derives the same keys as the reference implementation', async () => {
           // Ethereum coin type key
           const node = await deriveKeyFromPath({
-            path: [mnemonicBip39Node, BIP44PurposeNodeToken, `bip32:60'`],
+            path: await getDerivationPathWithSeed({
+              path: [mnemonicBip39Node, BIP44PurposeNodeToken, `bip32:60'`],
+              curve: 'secp256k1',
+            }),
             curve: 'secp256k1',
           });
 


### PR DESCRIPTION
This adds a new function to initialise a `key-tree` node from a BIP-39 seed. This can be used to skip the step from mnemonic phrase to seed, and can improve performance if the seed is already available.

This function is only supported for `secp256k1` and `ed25519` for now. `ed25519Bip32` may be added in the future.

Closes https://github.com/MetaMask/key-tree/issues/210