### PR TITLE
Optimise performance of getting public keys

### DIFF
--- a/src/SLIP10Node.test.ts
+++ b/src/SLIP10Node.test.ts
@@ -875,23 +875,23 @@ describe('SLIP10Node', () => {
       });
 
       // getter
-      expect(() => (node.privateKey = 'foo')).toThrow(
-        /^Cannot set property privateKey of .+ which has only a getter/iu,
-      );
+      ['privateKey', 'publicKeyBytes'].forEach((property) => {
+        expect(() => (node[property] = 'foo')).toThrow(
+          /^Cannot set property .+ of .+ which has only a getter/iu,
+        );
+      });
 
       // frozen / readonly
-      ['depth', 'privateKeyBytes', 'publicKeyBytes', 'chainCodeBytes'].forEach(
-        (property) => {
-          expect(() => (node[property] = new Uint8Array(64).fill(1))).toThrow(
-            expect.objectContaining({
-              name: 'TypeError',
-              message: expect.stringMatching(
-                `Cannot assign to read only property '${property}' of object`,
-              ),
-            }),
-          );
-        },
-      );
+      ['depth', 'privateKeyBytes', 'chainCodeBytes'].forEach((property) => {
+        expect(() => (node[property] = new Uint8Array(64).fill(1))).toThrow(
+          expect.objectContaining({
+            name: 'TypeError',
+            message: expect.stringMatching(
+              `Cannot assign to read only property '${property}' of object`,
+            ),
+          }),
+        );
+      });
     });
 
     it('throws an error if no curve is specified', async () => {

--- a/src/SLIP10Node.ts
+++ b/src/SLIP10Node.ts
@@ -2,7 +2,7 @@ import { assert, bytesToHex } from '@metamask/utils';
 
 import type { BIP44CoinTypeNode } from './BIP44CoinTypeNode';
 import type { BIP44Node } from './BIP44Node';
-import { BYTES_KEY_LENGTH, PUBLIC_KEY_GUARD } from './constants';
+import { BYTES_KEY_LENGTH } from './constants';
 import type {
   Network,
   RootedSLIP10PathTuple,
@@ -15,6 +15,7 @@ import { deriveKeyFromPath } from './derivation';
 import { publicKeyToEthAddress } from './derivers/bip32';
 import { getDerivationPathWithSeed } from './derivers/bip39';
 import { decodeExtendedKey, encodeExtendedKey } from './extended-keys';
+import { PUBLIC_KEY_GUARD } from './guard';
 import {
   getBytes,
   getBytesUnsafe,
@@ -328,7 +329,10 @@ export class SLIP10Node implements SLIP10NodeInterface {
 
       const trustedPublicKey =
         guard === PUBLIC_KEY_GUARD && publicKey
-          ? getBytes(publicKey, curveObject.publicKeyLength)
+          ? // `publicKey` is typed as `string | Uint8Array`, but we know it's
+            // a `Uint8Array` because of the guard. We use `getBytes` to ensure
+            // the type is correct.
+            getBytes(publicKey, curveObject.publicKeyLength)
           : undefined;
 
       return new SLIP10Node(

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,6 +6,14 @@ export const MAX_BIP_44_DEPTH = 5;
 export const MAX_UNHARDENED_BIP_32_INDEX = 0x7fffffff; // 2^31 - 1
 export const MAX_BIP_32_INDEX = 0xffffffff; // 2^32 - 1
 
+/**
+ * A guard symbol to prevent untrusted public keys from being passed to
+ * `SLIP10Node` constructors.
+ */
+export const PUBLIC_KEY_GUARD = Symbol(
+  'Public key guard. Do not export this from the module.',
+);
+
 export type MinBIP44Depth = typeof MIN_BIP_44_DEPTH;
 export type MaxBIP44Depth = typeof MAX_BIP_44_DEPTH;
 export type BIP44Depth = MinBIP44Depth | 1 | 2 | 3 | 4 | MaxBIP44Depth;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,14 +6,6 @@ export const MAX_BIP_44_DEPTH = 5;
 export const MAX_UNHARDENED_BIP_32_INDEX = 0x7fffffff; // 2^31 - 1
 export const MAX_BIP_32_INDEX = 0xffffffff; // 2^32 - 1
 
-/**
- * A guard symbol to prevent untrusted public keys from being passed to
- * `SLIP10Node` constructors.
- */
-export const PUBLIC_KEY_GUARD = Symbol(
-  'Public key guard. Do not export this from the module.',
-);
-
 export type MinBIP44Depth = typeof MIN_BIP_44_DEPTH;
 export type MaxBIP44Depth = typeof MAX_BIP_44_DEPTH;
 export type BIP44Depth = MinBIP44Depth | 1 | 2 | 3 | 4 | MaxBIP44Depth;

--- a/src/curves/curve.ts
+++ b/src/curves/curve.ts
@@ -27,10 +27,7 @@ export type Curve = {
   curve: {
     n: bigint;
   };
-  getPublicKey: (
-    privateKey: Uint8Array,
-    compressed?: boolean,
-  ) => Uint8Array | Promise<Uint8Array>;
+  getPublicKey: (privateKey: Uint8Array, compressed?: boolean) => Uint8Array;
   isValidPrivateKey: (privateKey: Uint8Array) => boolean;
   publicAdd: (publicKey: Uint8Array, tweak: Uint8Array) => Uint8Array;
   compressPublicKey: (publicKey: Uint8Array) => Uint8Array;

--- a/src/curves/ed25519Bip32.test.ts
+++ b/src/curves/ed25519Bip32.test.ts
@@ -13,8 +13,8 @@ import fixtures from '../../test/fixtures';
 describe('getPublicKey', () => {
   fixtures.cip3.forEach((fixture) => {
     Object.values(fixture.nodes).forEach((node) => {
-      it('returns correct public key from private key', async () => {
-        const publicKey = await ed25519Bip32.getPublicKey(
+      it('returns correct public key from private key', () => {
+        const publicKey = ed25519Bip32.getPublicKey(
           hexToBytes(node.privateKey),
         );
 

--- a/src/curves/ed25519Bip32.ts
+++ b/src/curves/ed25519Bip32.ts
@@ -99,10 +99,10 @@ export const multiplyWithBase = (key: Uint8Array): Uint8Array => {
  * @param _compressed - Optional parameter to indicate if the public key should be compressed.
  * @returns The public key.
  */
-export const getPublicKey = async (
+export const getPublicKey = (
   privateKey: Uint8Array,
   _compressed?: boolean,
-): Promise<Uint8Array> => {
+): Uint8Array => {
   return multiplyWithBase(privateKey.slice(0, 32));
 };
 

--- a/src/derivers/bip32.ts
+++ b/src/derivers/bip32.ts
@@ -96,14 +96,15 @@ async function handleError(
   options: DeriveNodeArgs,
   cryptographicFunctions?: CryptographicFunctions,
 ): Promise<DeriveNodeArgs> {
-  const { childIndex, privateKey, publicKey, isHardened, chainCode } = options;
+  const { childIndex, privateKey, publicKey, isHardened, chainCode, curve } =
+    options;
 
   validateBIP32Index(childIndex + 1);
 
   if (privateKey) {
     const secretExtension = await deriveSecretExtension({
       privateKey,
-      publicKey,
+      publicKey: curve.compressPublicKey(publicKey),
       childIndex: childIndex + 1,
       isHardened,
     });

--- a/src/derivers/bip32.ts
+++ b/src/derivers/bip32.ts
@@ -96,17 +96,16 @@ async function handleError(
   options: DeriveNodeArgs,
   cryptographicFunctions?: CryptographicFunctions,
 ): Promise<DeriveNodeArgs> {
-  const { childIndex, privateKey, publicKey, isHardened, curve, chainCode } =
-    options;
+  const { childIndex, privateKey, publicKey, isHardened, chainCode } = options;
 
   validateBIP32Index(childIndex + 1);
 
   if (privateKey) {
     const secretExtension = await deriveSecretExtension({
       privateKey,
+      publicKey,
       childIndex: childIndex + 1,
       isHardened,
-      curve,
     });
 
     const newEntropy = await generateEntropy(

--- a/src/derivers/bip32.ts
+++ b/src/derivers/bip32.ts
@@ -107,6 +107,7 @@ async function handleError(
       publicKey: curve.compressPublicKey(publicKey),
       childIndex: childIndex + 1,
       isHardened,
+      curve,
     });
 
     const newEntropy = await generateEntropy(

--- a/src/derivers/bip39.ts
+++ b/src/derivers/bip39.ts
@@ -314,14 +314,16 @@ export async function entropyToCip3MasterNode(
 
   assert(curve.isValidPrivateKey(privateKey), 'Invalid private key.');
 
+  const publicKey = curve.getPublicKey(privateKey, false);
   const masterFingerprint = getFingerprint(
-    curve.getPublicKey(privateKey),
+    curve.compressPublicKey(publicKey),
     curve.compressedPublicKeyLength,
   );
 
   return SLIP10Node.fromExtendedKey(
     {
       privateKey,
+      publicKey,
       chainCode,
       masterFingerprint,
       network,
@@ -329,6 +331,7 @@ export async function entropyToCip3MasterNode(
       parentFingerprint: 0,
       index: 0,
       curve: curve.name,
+      guard: PUBLIC_KEY_GUARD,
     },
     cryptographicFunctions,
   );

--- a/src/derivers/bip39.ts
+++ b/src/derivers/bip39.ts
@@ -10,11 +10,12 @@ import type {
   RootedSLIP10PathTuple,
   RootedSLIP10SeedPathTuple,
 } from '../constants';
-import { BYTES_KEY_LENGTH, PUBLIC_KEY_GUARD } from '../constants';
+import { BYTES_KEY_LENGTH } from '../constants';
 import type { CryptographicFunctions } from '../cryptography';
 import { hmacSha512, pbkdf2Sha512 } from '../cryptography';
 import type { Curve, SupportedCurve } from '../curves';
 import { getCurveByName } from '../curves';
+import { PUBLIC_KEY_GUARD } from '../guard';
 import { SLIP10Node } from '../SLIP10Node';
 import { getFingerprint } from '../utils';
 

--- a/src/derivers/cip3.ts
+++ b/src/derivers/cip3.ts
@@ -302,7 +302,7 @@ export const derivePublicKey = async (
   const zl = entropy.slice(0, 32);
 
   // right = [8ZL] * B
-  const right = await curve.getPublicKey(
+  const right = curve.getPublicKey(
     // [8ZL]
     trunc28Mul8(zl),
   );

--- a/src/derivers/shared.ts
+++ b/src/derivers/shared.ts
@@ -17,7 +17,7 @@ import { hmacSha512 } from '../cryptography';
 import type { Curve } from '../curves';
 import { mod } from '../curves';
 import { SLIP10Node } from '../SLIP10Node';
-import { isValidBytesKey, numberToUint32 } from '../utils';
+import { isValidBytesKey, numberToUint32, validateBytes } from '../utils';
 
 type ErrorHandler = (
   error: unknown,
@@ -69,6 +69,7 @@ export async function deriveChildKey(
       publicKey: node.compressedPublicKeyBytes,
       childIndex,
       isHardened,
+      curve,
     });
 
     const entropy = await generateEntropy(
@@ -144,6 +145,7 @@ type DeriveSecretExtensionArgs = {
   publicKey: Uint8Array;
   childIndex: number;
   isHardened: boolean;
+  curve: Curve;
 };
 
 /**
@@ -231,6 +233,7 @@ async function deriveNode(
  * @param options.publicKey - The parent public key bytes.
  * @param options.childIndex - The child index to derive.
  * @param options.isHardened - Whether the child index is hardened.
+ * @param options.curve - The curve to use for derivation.
  * @returns The secret extension bytes.
  */
 export async function deriveSecretExtension({
@@ -238,6 +241,7 @@ export async function deriveSecretExtension({
   publicKey,
   childIndex,
   isHardened,
+  curve,
 }: DeriveSecretExtensionArgs): Promise<Uint8Array> {
   if (isHardened) {
     // Hardened child
@@ -249,6 +253,7 @@ export async function deriveSecretExtension({
   }
 
   // Normal child
+  validateBytes(publicKey, curve.compressedPublicKeyLength);
   return derivePublicExtension({ parentPublicKey: publicKey, childIndex });
 }
 

--- a/src/derivers/shared.ts
+++ b/src/derivers/shared.ts
@@ -7,15 +7,12 @@ import {
 
 import type { DeriveChildKeyArgs, DerivedKeys } from '.';
 import type { Network } from '../constants';
-import {
-  BIP_32_HARDENED_OFFSET,
-  PUBLIC_KEY_GUARD,
-  UNPREFIXED_PATH_REGEX,
-} from '../constants';
+import { BIP_32_HARDENED_OFFSET, UNPREFIXED_PATH_REGEX } from '../constants';
 import type { CryptographicFunctions } from '../cryptography';
 import { hmacSha512 } from '../cryptography';
 import type { Curve } from '../curves';
 import { mod } from '../curves';
+import { PUBLIC_KEY_GUARD } from '../guard';
 import { SLIP10Node } from '../SLIP10Node';
 import { isValidBytesKey, numberToUint32, validateBytes } from '../utils';
 

--- a/src/derivers/shared.ts
+++ b/src/derivers/shared.ts
@@ -227,7 +227,7 @@ async function deriveNode(
  *
  * @param options - The options for deriving a secret extension.
  * @param options.privateKey - The parent private key bytes.
- * @param options.publicKey - The parent public key bytes.
+ * @param options.publicKey - The parent compressed public key bytes.
  * @param options.childIndex - The child index to derive.
  * @param options.isHardened - Whether the child index is hardened.
  * @param options.curve - The curve to use for derivation.

--- a/src/guard.ts
+++ b/src/guard.ts
@@ -1,0 +1,9 @@
+/**
+ * A guard symbol to prevent untrusted public keys from being passed to
+ * `SLIP10Node` constructors.
+ *
+ * This is a private symbol and should not be exported from the module.
+ */
+export const PUBLIC_KEY_GUARD = Symbol(
+  'Public key guard. Do not export this from the module.',
+);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -11,6 +11,8 @@ import {
   getBIP44CoinTypeToAddressPathTuple,
   mnemonicToSeed,
 } from '.';
+import * as index from '.';
+import * as guard from './guard';
 
 // This is purely for coverage shenanigans
 describe('index', () => {
@@ -27,5 +29,9 @@ describe('index', () => {
     expect(mnemonicPhraseToBytes).toBeDefined();
     expect(getBIP44CoinTypeToAddressPathTuple).toBeDefined();
     expect(mnemonicToSeed).toBeDefined();
+  });
+
+  it.each(Object.keys(guard))('does not export %s', (property) => {
+    expect(index).not.toHaveProperty(property);
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -348,7 +348,7 @@ export function getBytesUnsafe(value: unknown, length: number): Uint8Array {
  * @param length - The length to validate the `Uint8Array` against.
  * @throws An error if the `Uint8Array` is empty or has the wrong length.
  */
-function validateBytes(
+export function validateBytes(
   bytes: Uint8Array,
   length: number,
 ): asserts bytes is Uint8Array {


### PR DESCRIPTION
This optimises the performance of getting public keys in a couple of different ways:

- The `Curve.getPublicKey` function was changed to always return the public key synchronously. Every curve was already doing public key computations synchronously, so this lets us remove redundant `await`s and async functions.
- In cases where we need to compute the public key (to get the fingerprint for example), that public key is now re-used when possible, to avoid computing it twice.
- If a public key is not provided to `SLIP10Node`, it's now lazily computed, and cached. This avoids computing it unnecessarily when it's not used.

Closes #211.