### PR TITLE
Update workflows to use `MetaMask/action-checkout-and-setup`

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -11,20 +11,12 @@ jobs:
       matrix:
         node-version: [18.x, 20.x, 22.x]
     steps:
-      - uses: actions/checkout@v4
-      - name: Install Corepack via Node
-        uses: actions/setup-node@v4
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
         with:
-          node-version-file: '.nvmrc'
-      - name: Install Yarn
-        run: corepack enable
-      - name: Install Node.js ${{ matrix.node-version }} and restore Yarn cache
-        uses: actions/setup-node@v4
-        with:
+          is-high-risk-environment: false
           node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
-      - name: Install dependencies via Yarn
-        run: yarn --immutable
+          cache-node-modules: ${{ matrix.node-version == '22.x' }}
 
   build:
     name: Build
@@ -34,20 +26,11 @@ jobs:
       matrix:
         node-version: [22.x]
     steps:
-      - uses: actions/checkout@v4
-      - name: Install Corepack via Node
-        uses: actions/setup-node@v4
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
         with:
-          node-version-file: '.nvmrc'
-      - name: Install Yarn
-        run: corepack enable
-      - name: Install Node.js ${{ matrix.node-version }} and restore Yarn cache
-        uses: actions/setup-node@v4
-        with:
+          is-high-risk-environment: false
           node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
-      - name: Install dependencies via Yarn
-        run: yarn --immutable --immutable-cache
       - run: yarn build
       - name: Require clean working directory
         shell: bash
@@ -65,20 +48,11 @@ jobs:
       matrix:
         node-version: [22.x]
     steps:
-      - uses: actions/checkout@v4
-      - name: Install Corepack via Node
-        uses: actions/setup-node@v4
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
         with:
-          node-version-file: '.nvmrc'
-      - name: Install Yarn
-        run: corepack enable
-      - name: Install Node.js ${{ matrix.node-version }} and restore Yarn cache
-        uses: actions/setup-node@v4
-        with:
+          is-high-risk-environment: false
           node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
-      - name: Install dependencies via Yarn
-        run: yarn --immutable --immutable-cache
       - run: yarn lint
       - name: Validate RC changelog
         if: ${{ startsWith(github.head_ref, 'release/') }}
@@ -102,20 +76,11 @@ jobs:
       matrix:
         node-version: [18.x, 20.x, 22.x]
     steps:
-      - uses: actions/checkout@v4
-      - name: Install Corepack via Node
-        uses: actions/setup-node@v4
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
         with:
-          node-version-file: '.nvmrc'
-      - name: Install Yarn
-        run: corepack enable
-      - name: Install Node.js ${{ matrix.node-version }} and restore Yarn cache
-        uses: actions/setup-node@v4
-        with:
+          is-high-risk-environment: false
           node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
-      - name: Install dependencies via Yarn
-        run: yarn --immutable --immutable-cache
       - run: yarn test
       - name: Require clean working directory
         shell: bash
@@ -133,18 +98,11 @@ jobs:
       matrix:
         node-version: [18.x, 20.x, 22.x]
     steps:
-      - uses: actions/checkout@v4
-      - name: Install Corepack via Node
-        uses: actions/setup-node@v4
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
         with:
-          node-version-file: '.nvmrc'
-      - name: Install Yarn
-        run: corepack enable
-      - name: Install Node.js ${{ matrix.node-version }} and restore Yarn cache
-        uses: actions/setup-node@v4
-        with:
+          is-high-risk-environment: false
           node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
       - name: Install dependencies via Yarn
         run: rm yarn.lock && YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn
       - run: yarn test

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -21,18 +21,19 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
         with:
-          # This is to guarantee that the most recent tag is fetched.
-          # This can be configured to a more reasonable value by consumers.
+          is-high-risk-environment: true
+
+          # This is to guarantee that the most recent tag is fetched. This can
+          # be configured to a more reasonable value by consumers.
           fetch-depth: 0
+
           # We check out the specified branch, which will be used as the base
           # branch for all git operations and the release PR.
           ref: ${{ github.event.inputs.base-branch }}
-      - name: Install Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
+
       - uses: MetaMask/action-create-release-pr@v4
         with:
           release-type: ${{ github.event.inputs.release-type }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,10 @@ jobs:
     name: Check workflows
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
+        with:
+          is-high-risk-environment: false
       - name: Download actionlint
         id: download-actionlint
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/7fdc9630cc360ea1a469eed64ac6d78caeda1234/scripts/download-actionlint.bash) 1.6.23
@@ -18,6 +21,18 @@ jobs:
       - name: Check workflow files
         run: ${{ steps.download-actionlint.outputs.executable }} -color
         shell: bash
+
+  analyse-code:
+    name: Code scanner
+    needs: check-workflows
+    uses: ./.github/workflows/security-code-scanner.yml
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    secrets:
+      SECURITY_SCAN_METRICS_TOKEN: ${{ secrets.SECURITY_SCAN_METRICS_TOKEN }}
+      APPSEC_BOT_SLACK_WEBHOOK: ${{ secrets.APPSEC_BOT_SLACK_WEBHOOK }}
 
   build-lint-test:
     name: Build, lint, and test
@@ -28,6 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - check-workflows
+      - analyse-code
       - build-lint-test
     outputs:
       PASSED: ${{ steps.set-output.outputs.PASSED }}

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -21,20 +21,10 @@ jobs:
       - name: Ensure `destination_dir` is not empty
         if: ${{ inputs.destination_dir == '' }}
         run: exit 1
-      - uses: actions/checkout@v4
-      - name: Install Corepack via Node
-        uses: actions/setup-node@v4
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
         with:
-          node-version-file: '.nvmrc'
-      - name: Install Yarn
-        run: corepack enable
-      - name: Restore Yarn cache
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'yarn'
-      - name: Install dependencies via Yarn
-        run: yarn --immutable
+          is-high-risk-environment: true
       - name: Run build script
         run: yarn build:docs
       - name: Deploy to `${{ inputs.destination_dir }}` directory of `gh-pages` branch

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -23,7 +23,6 @@ jobs:
       - uses: MetaMask/action-publish-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: yarn --immutable
       - run: yarn build
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -9,66 +9,48 @@ on:
         required: true
       PUBLISH_DOCS_TOKEN:
         required: true
-
 jobs:
   publish-release:
     permissions:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
         with:
+          is-high-risk-environment: true
           ref: ${{ github.sha }}
-      - name: Install Corepack via Node
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-      - name: Install Yarn
-        run: corepack enable
-      - name: Restore Yarn cache
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'yarn'
       - uses: MetaMask/action-publish-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/cache@v3
+      - run: yarn --immutable
+      - run: yarn build
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
         with:
+          name: publish-release-artifacts-${{ github.sha }}
+          retention-days: 4
+          include-hidden-files: true
           path: |
             ./dist
             ./node_modules/.yarn-state.yml
-          key: ${{ github.sha }}
-      - run: yarn --immutable
-      - run: yarn build
 
   publish-npm-dry-run:
     needs: publish-release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
         with:
+          is-high-risk-environment: true
           ref: ${{ github.sha }}
-      - name: Install Corepack via Node
-        uses: actions/setup-node@v4
+      - name: Restore build artifacts
+        uses: actions/download-artifact@v4
         with:
-          node-version-file: '.nvmrc'
-      - name: Install Yarn
-        run: corepack enable
-      - name: Restore Yarn cache
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'yarn'
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ./dist
-            ./node_modules/.yarn-state.yml
-          key: ${{ github.sha }}
+          name: publish-release-artifacts-${{ github.sha }}
       - name: Dry Run Publish
         # omit npm-token token to perform dry run publish
-        uses: MetaMask/action-npm-publish@v4
+        uses: MetaMask/action-npm-publish@v5
         with:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           subteam: S042S7RE4AE # @metamask-npm-publishers
@@ -80,28 +62,17 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm-publish
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
         with:
+          is-high-risk-environment: true
           ref: ${{ github.sha }}
-      - name: Install Corepack via Node
-        uses: actions/setup-node@v4
+      - name: Restore build artifacts
+        uses: actions/download-artifact@v4
         with:
-          node-version-file: '.nvmrc'
-      - name: Install Yarn
-        run: corepack enable
-      - name: Restore Yarn cache
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'yarn'
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ./dist
-            ./node_modules/.yarn-state.yml
-          key: ${{ github.sha }}
+          name: publish-release-artifacts-${{ github.sha }}
       - name: Publish
-        uses: MetaMask/action-npm-publish@v2
+        uses: MetaMask/action-npm-publish@v5
         with:
           # This `NPM_TOKEN` needs to be manually set per-repository.
           # Look in the repository settings under "Environments", and set this token in the `npm-publish` environment.

--- a/.github/workflows/security-code-scanner.yml
+++ b/.github/workflows/security-code-scanner.yml
@@ -1,24 +1,25 @@
 name: MetaMask Security Code Scanner
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+  workflow_call:
+    secrets:
+      SECURITY_SCAN_METRICS_TOKEN:
+        required: false
+      APPSEC_BOT_SLACK_WEBHOOK:
+        required: false
   workflow_dispatch:
 
 jobs:
   run-security-scan:
+    name: Run security scan
     runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read
       security-events: write
     steps:
-      - name: MetaMask Security Code Scanner
-        uses: MetaMask/Security-Code-Scanner@main
+      - name: Analyse code
+        uses: MetaMask/action-security-code-scanner@v1
         with:
           repo: ${{ github.repository }}
           paths_ignored: |


### PR DESCRIPTION
This updates all workflows to use `MetaMask/action-checkout-and-setup` instead of `actions/checkout`, `actions/setup-node` and `actions/cache`.