### PR TITLE
perf: Tweak precompute window size for secp256k1

### DIFF
--- a/src/curves/secp256k1.ts
+++ b/src/curves/secp256k1.ts
@@ -39,7 +39,6 @@ const getGetPublicKey = (): ((
   return getPublicKey;
 };
 
-
 export const getPublicKey = getGetPublicKey();
 
 export const publicAdd = (

--- a/src/curves/secp256k1.ts
+++ b/src/curves/secp256k1.ts
@@ -19,10 +19,28 @@ export const isValidPrivateKey = (privateKey: Uint8Array): boolean => {
   return secp256k1.utils.isValidPrivateKey(privateKey);
 };
 
-export const getPublicKey = (
+const getGetPublicKey = (): ((
   privateKey: Uint8Array,
-  compressed = false,
-): Uint8Array => secp256k1.getPublicKey(privateKey, compressed);
+  compressed?: boolean,
+) => Uint8Array) => {
+  let hasSetWindowSize = false;
+
+  const getPublicKey = (
+    privateKey: Uint8Array,
+    compressed = false,
+  ): Uint8Array => {
+    if (!hasSetWindowSize) {
+      secp256k1.ProjectivePoint.BASE._setWindowSize(4);
+      hasSetWindowSize = true;
+    }
+    return secp256k1.getPublicKey(privateKey, compressed);
+  };
+
+  return getPublicKey;
+};
+
+
+export const getPublicKey = getGetPublicKey();
 
 export const publicAdd = (
   publicKey: Uint8Array,


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

Tweak the precompute window for `secp256k1` for improved performance on mobile.
