### PR TITLE
feat: use @metamask/native utils

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -22,7 +22,7 @@ module.exports = {
   collectCoverage: true,
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
-  collectCoverageFrom: ['./src/**/*.ts'],
+  collectCoverageFrom: ['./src/**/*.ts', '!./src/**/*.native.ts'],
 
   // The directory where Jest should output its coverage files
   coverageDirectory: 'coverage',

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@metamask/eslint-config-jest": "^14.0.0",
     "@metamask/eslint-config-nodejs": "^14.0.0",
     "@metamask/eslint-config-typescript": "^14.0.0",
+    "@metamask/native-utils": "^0.7.0",
     "@ts-bridge/cli": "^0.6.0",
     "@types/jest": "^28.1.6",
     "@types/node": "^18.18",
@@ -81,11 +82,24 @@
     "jest-it-up": "^2.0.2",
     "prettier": "^3.3.3",
     "prettier-plugin-packagejson": "^2.3.0",
+    "react-native-quick-crypto": "^0.7.17",
     "ts-jest": "^28.0.7",
     "ts-node": "^10.9.1",
     "typedoc": "^0.26.11",
     "typescript": "~5.4.5",
     "typescript-eslint": "^8.6.0"
+  },
+  "peerDependencies": {
+    "@metamask/native-utils": "*",
+    "react-native-quick-crypto": "*"
+  },
+  "peerDependenciesMeta": {
+    "@metamask/native-utils": {
+      "optional": true
+    },
+    "react-native-quick-crypto": {
+      "optional": true
+    }
   },
   "packageManager": "yarn@4.1.1",
   "engines": {

--- a/src/SLIP10Node.ts
+++ b/src/SLIP10Node.ts
@@ -9,6 +9,7 @@ import type {
   SLIP10PathTuple,
 } from './constants';
 import type { CryptographicFunctions } from './cryptography';
+import { getPublicKeyForCurve } from './cryptography';
 import type { SupportedCurve } from './curves';
 import { getCurveByName } from './curves';
 import { deriveKeyFromPath } from './derivation';
@@ -587,7 +588,8 @@ export class SLIP10Node implements SLIP10NodeInterface {
       'Either a private key or public key is required.',
     );
 
-    this.#publicKeyBytes = getCurveByName(this.curve).getPublicKey(
+    this.#publicKeyBytes = getPublicKeyForCurve(
+      this.curve,
       this.privateKeyBytes,
     );
 
@@ -609,13 +611,16 @@ export class SLIP10Node implements SLIP10NodeInterface {
       );
     }
 
-    return bytesToHex(publicKeyToEthAddress(this.publicKeyBytes));
+    return bytesToHex(
+      publicKeyToEthAddress(this.publicKeyBytes, this.#cryptographicFunctions),
+    );
   }
 
   public get fingerprint(): number {
     return getFingerprint(
       this.compressedPublicKeyBytes,
       getCurveByName(this.curve).compressedPublicKeyLength,
+      this.#cryptographicFunctions,
     );
   }
 

--- a/src/cryptography/cryptography.native.ts
+++ b/src/cryptography/cryptography.native.ts
@@ -1,0 +1,134 @@
+import {
+  getPublicKey as nativeGetPublicKeySecp256k1,
+  getPublicKeyEd25519 as nativeGetPublicKeyEd25519,
+  hmacSha512 as nativeHmacSha512,
+  keccak256 as nativeKeccak256,
+} from '@metamask/native-utils';
+import { ripemd160 as nobleRipemd160 } from '@noble/hashes/ripemd160';
+import * as quickCrypto from 'react-native-quick-crypto';
+
+import type { CryptographicFunctionsBase } from './cryptography.types';
+import type { SupportedCurve } from '../curves';
+import * as ed25519Bip32Curve from '../curves/ed25519Bip32';
+
+/**
+ * Compute the HMAC-SHA-512 of the given data using the given key.
+ *
+ * This function uses the native implementation from @metamask/native-utils.
+ *
+ * @param key - The key to use.
+ * @param data - The data to hash.
+ * @returns The HMAC-SHA-512 of the data.
+ */
+export async function hmacSha512(
+  key: Uint8Array,
+  data: Uint8Array,
+): Promise<Uint8Array> {
+  return Promise.resolve(nativeHmacSha512(key, data));
+}
+
+/**
+ * Compute the Keccak-256 of the given data synchronously.
+ *
+ * This function uses the native implementation from @metamask/native-utils.
+ *
+ * @param data - The data to hash.
+ * @returns The Keccak-256 of the data.
+ */
+export function keccak256(data: Uint8Array): Uint8Array {
+  return nativeKeccak256(data);
+}
+
+/**
+ * Compute the PBKDF2 of the given password, salt, iterations, and key length.
+ * The hash function used is SHA-512.
+ *
+ * @param password - The password to hash.
+ * @param salt - The salt to use.
+ * @param iterations - The number of iterations.
+ * @param keyLength - The desired key length.
+ * @returns The PBKDF2 of the password.
+ */
+export async function pbkdf2Sha512(
+  password: Uint8Array,
+  salt: Uint8Array,
+  iterations: number,
+  keyLength: number,
+): Promise<Uint8Array> {
+  const derivedKey = quickCrypto.default.pbkdf2Sync(
+    password,
+    salt,
+    iterations,
+    keyLength,
+    'sha512',
+  );
+  return Promise.resolve(new Uint8Array(derivedKey));
+}
+
+/**
+ * Compute the RIPEMD-160 of the given data.
+ *
+ * Right now this is just a wrapper around `ripemd160` from the `@noble/hashes`
+ * package, but it's here in case we want to change the implementation in the
+ * future to allow for asynchronous hashing.
+ *
+ * @param data - The data to hash.
+ * @returns The RIPEMD-160 of the data.
+ */
+export function ripemd160(data: Uint8Array): Uint8Array {
+  return nobleRipemd160(data);
+}
+
+/**
+ * Compute the SHA-256 of the given data synchronously.
+ *
+ * This function uses `createHash` from `react-native-quick-crypto`.
+ *
+ * @param data - The data to hash.
+ * @returns The SHA-256 of the data.
+ */
+export function sha256(data: Uint8Array): Uint8Array {
+  const hash = quickCrypto.default.createHash('sha256');
+  // Convert Uint8Array to ArrayBuffer for hash.update()
+  const arrayBuffer = new Uint8Array(data).buffer;
+  hash.update(arrayBuffer);
+  return new Uint8Array(hash.digest());
+}
+
+/**
+ * Get the public key for a given private key using the specified curve.
+ *
+ * This function uses the native implementations from @metamask/native-utils.
+ *
+ * @param curveName - The name of the curve to use ('ed25519' or 'secp256k1').
+ * @param privateKey - The private key.
+ * @param compressed - Whether the public key should be compressed (only applies to secp256k1).
+ * @returns The public key.
+ */
+export function getPublicKeyForCurve(
+  curveName: SupportedCurve,
+  privateKey: Uint8Array,
+  compressed?: boolean,
+): Uint8Array {
+  switch (curveName) {
+    case 'ed25519':
+      return nativeGetPublicKeyEd25519(privateKey);
+    case 'secp256k1':
+      return nativeGetPublicKeySecp256k1(privateKey, compressed);
+    case 'ed25519Bip32':
+      return ed25519Bip32Curve.getPublicKey(privateKey);
+    default:
+      // eslint-disable-next-line
+      curveName as never;
+      throw new Error(`Unsupported curve: ${String(curveName)}`);
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const _cryptographicFunctions: CryptographicFunctionsBase = {
+  hmacSha512,
+  pbkdf2Sha512,
+  sha256,
+  keccak256,
+  getPublicKeyForCurve,
+};

--- a/src/cryptography/cryptography.test.ts
+++ b/src/cryptography/cryptography.test.ts
@@ -3,13 +3,14 @@ import { bytesToHex } from '@metamask/utils';
 import { webcrypto } from 'crypto';
 
 import {
+  getPublicKeyForCurve,
   hmacSha512,
   keccak256,
   pbkdf2Sha512,
   ripemd160,
   sha256,
-} from './cryptography';
-import * as utils from './utils';
+} from '.';
+import * as utils from '../utils';
 
 // Node.js <20 doesn't have `globalThis.crypto`, so we need to define it.
 // TODO: Remove this once we drop support for Node.js <20.
@@ -132,5 +133,40 @@ describe('sha256', () => {
     expect(bytesToHex(hash)).toBe(
       '0x72cd6e8422c407fb6d098690f1130b7ded7ec2f7f5e1d30bd9d521f015363793',
     );
+  });
+});
+
+describe('getPublicKeyForCurve', () => {
+  const privateKey = new Uint8Array(32).fill(1);
+
+  it('returns the public key for ed25519', () => {
+    const publicKey = getPublicKeyForCurve('ed25519', privateKey);
+    expect(publicKey).toBeInstanceOf(Uint8Array);
+    expect(publicKey).toHaveLength(33);
+  });
+
+  it('returns the public key for secp256k1', () => {
+    const publicKey = getPublicKeyForCurve('secp256k1', privateKey);
+    expect(publicKey).toBeInstanceOf(Uint8Array);
+    expect(publicKey).toHaveLength(65);
+  });
+
+  it('returns the compressed public key for secp256k1', () => {
+    const publicKey = getPublicKeyForCurve('secp256k1', privateKey, true);
+    expect(publicKey).toBeInstanceOf(Uint8Array);
+    expect(publicKey).toHaveLength(33);
+  });
+
+  it('returns the public key for ed25519Bip32', () => {
+    const publicKey = getPublicKeyForCurve('ed25519Bip32', privateKey);
+    expect(publicKey).toBeInstanceOf(Uint8Array);
+    expect(publicKey).toHaveLength(32);
+  });
+
+  it('throws for unsupported curves', () => {
+    expect(() =>
+      // @ts-expect-error Testing invalid curve
+      getPublicKeyForCurve('unsupported', privateKey),
+    ).toThrow('Unsupported curve: unsupported');
   });
 });

--- a/src/cryptography/cryptography.ts
+++ b/src/cryptography/cryptography.ts
@@ -5,35 +5,15 @@ import { sha256 as nobleSha256 } from '@noble/hashes/sha256';
 import { keccak_256 as nobleKeccak256 } from '@noble/hashes/sha3';
 import { sha512 as nobleSha512 } from '@noble/hashes/sha512';
 
-import { isWebCryptoSupported } from './utils';
-
-export type CryptographicFunctions = {
-  /**
-   * Compute the HMAC-SHA-512 of the given data using the given key.
-   *
-   * @param key - The key to use.
-   * @param data - The data to hash.
-   * @returns The HMAC-SHA-512 of the data.
-   */
-  hmacSha512?: (key: Uint8Array, data: Uint8Array) => Promise<Uint8Array>;
-
-  /**
-   * Compute the PBKDF2 of the given password, salt, iterations, and key length.
-   * The hash function used is SHA-512.
-   *
-   * @param password - The password to hash.
-   * @param salt - The salt to use.
-   * @param iterations - The number of iterations.
-   * @param keyLength - The desired key length in bytes.
-   * @returns The PBKDF2 of the password.
-   */
-  pbkdf2Sha512?: (
-    password: Uint8Array,
-    salt: Uint8Array,
-    iterations: number,
-    keyLength: number,
-  ) => Promise<Uint8Array>;
-};
+import type {
+  CryptographicFunctionsBase,
+  CryptographicFunctions,
+} from './cryptography.types';
+import type { SupportedCurve } from '../curves/curve';
+import * as ed25519Curve from '../curves/ed25519';
+import * as ed25519Bip32Curve from '../curves/ed25519Bip32';
+import * as secp256k1Curve from '../curves/secp256k1';
+import { isWebCryptoSupported } from '../utils';
 
 /**
  * Compute the HMAC-SHA-512 of the given data using the given key.
@@ -57,7 +37,6 @@ export async function hmacSha512(
   }
 
   if (isWebCryptoSupported()) {
-    /* eslint-disable no-restricted-globals */
     const subtleKey = await crypto.subtle.importKey(
       'raw',
       key,
@@ -68,7 +47,6 @@ export async function hmacSha512(
 
     const result = await crypto.subtle.sign('HMAC', subtleKey, data);
     return new Uint8Array(result);
-    /* eslint-enable no-restricted-globals */
   }
 
   return nobleHmac(nobleSha512, key, data);
@@ -117,7 +95,6 @@ export async function pbkdf2Sha512(
   }
 
   if (isWebCryptoSupported()) {
-    /* eslint-disable no-restricted-globals */
     const key = await crypto.subtle.importKey(
       'raw',
       password,
@@ -140,7 +117,6 @@ export async function pbkdf2Sha512(
     );
 
     return new Uint8Array(derivedBits);
-    /* eslint-enable no-restricted-globals */
   }
 
   return await noblePbkdf2(nobleSha512, password, salt, {
@@ -176,3 +152,39 @@ export function ripemd160(data: Uint8Array): Uint8Array {
 export function sha256(data: Uint8Array): Uint8Array {
   return nobleSha256(data);
 }
+
+/**
+ * Get the public key for a given private key using the specified curve.
+ *
+ * @param curveName - The name of the curve to use ('ed25519' or 'secp256k1').
+ * @param privateKey - The private key.
+ * @param compressed - Whether the public key should be compressed (only applies to secp256k1).
+ * @returns The public key.
+ */
+export function getPublicKeyForCurve(
+  curveName: SupportedCurve,
+  privateKey: Uint8Array,
+  compressed?: boolean,
+): Uint8Array {
+  switch (curveName) {
+    case 'ed25519':
+      return ed25519Curve.getPublicKey(privateKey);
+    case 'secp256k1':
+      return secp256k1Curve.getPublicKey(privateKey, compressed);
+    case 'ed25519Bip32':
+      return ed25519Bip32Curve.getPublicKey(privateKey);
+    default:
+      // eslint-disable-next-line
+      curveName as never;
+      throw new Error(`Unsupported curve: ${String(curveName)}`);
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const _cryptographicFunctions: CryptographicFunctionsBase = {
+  hmacSha512,
+  pbkdf2Sha512,
+  sha256,
+  keccak256,
+  getPublicKeyForCurve,
+};

--- a/src/cryptography/cryptography.types.ts
+++ b/src/cryptography/cryptography.types.ts
@@ -1,0 +1,66 @@
+import type { SupportedCurve } from '../curves/curve';
+
+export type CryptographicFunctionsBase = {
+  /**
+   * Compute the HMAC-SHA-512 of the given data using the given key.
+   *
+   * @param key - The key to use.
+   * @param data - The data to hash.
+   * @returns The HMAC-SHA-512 of the data.
+   */
+  hmacSha512: (key: Uint8Array, data: Uint8Array) => Promise<Uint8Array>;
+
+  /**
+   * Compute the PBKDF2 of the given password, salt, iterations, and key length.
+   * The hash function used is SHA-512.
+   *
+   * @param password - The password to hash.
+   * @param salt - The salt to use.
+   * @param iterations - The number of iterations.
+   * @param keyLength - The desired key length in bytes.
+   * @returns The PBKDF2 of the password.
+   */
+  pbkdf2Sha512: (
+    password: Uint8Array,
+    salt: Uint8Array,
+    iterations: number,
+    keyLength: number,
+  ) => Promise<Uint8Array>;
+
+  /**
+   * Compute the SHA-256 of the given data.
+   *
+   * @param data - The data to hash.
+   * @returns The SHA-256 of the data.
+   */
+  sha256: (data: Uint8Array) => Uint8Array;
+
+  /**
+   * Compute the Keccak-256 of the given data.
+   *
+   * @param data - The data to hash.
+   * @returns The Keccak-256 of the data.
+   */
+  keccak256: (data: Uint8Array) => Uint8Array;
+
+  /**
+   * Compute the public key of the given private key using the secp256k1 curve.
+   *
+   * @param curveName - The name of the curve to use ('ed25519', 'secp256k1', or 'ed25519Bip32').
+   * @param privateKey - The private key.
+   * @param compressed - Whether the public key should be compressed (only applies to secp256k1).
+   * @returns The public key.
+   */
+  getPublicKeyForCurve: (
+    curveName: SupportedCurve,
+    privateKey: Uint8Array,
+    compressed?: boolean,
+  ) => Uint8Array;
+};
+
+/**
+ * Cryptographic functions that supports the override of the built-in implementations by the user.
+ */
+export type CryptographicFunctions = Partial<
+  Pick<CryptographicFunctionsBase, 'hmacSha512' | 'pbkdf2Sha512'>
+>;

--- a/src/cryptography/index.ts
+++ b/src/cryptography/index.ts
@@ -1,0 +1,9 @@
+export {
+  hmacSha512,
+  keccak256,
+  pbkdf2Sha512,
+  ripemd160,
+  sha256,
+  getPublicKeyForCurve,
+} from './cryptography';
+export type { CryptographicFunctions } from './cryptography.types';

--- a/src/derivers/bip32.ts
+++ b/src/derivers/bip32.ts
@@ -10,7 +10,7 @@ import {
 } from './shared';
 import { BYTES_KEY_LENGTH } from '../constants';
 import type { CryptographicFunctions } from '../cryptography';
-import { keccak256 } from '../cryptography';
+import { getPublicKeyForCurve, keccak256 } from '../cryptography';
 import { secp256k1 } from '../curves';
 import type { SLIP10Node } from '../SLIP10Node';
 import { isValidBytesKey, validateBIP32Index } from '../utils';
@@ -32,7 +32,7 @@ export function privateKeyToEthAddress(key: Uint8Array): Uint8Array {
     'Invalid key: The key must be a 32-byte, non-zero Uint8Array.',
   );
 
-  const publicKey = secp256k1.getPublicKey(key, false);
+  const publicKey = getPublicKeyForCurve('secp256k1', key, false);
   return publicKeyToEthAddress(publicKey);
 }
 
@@ -45,9 +45,14 @@ export function privateKeyToEthAddress(key: Uint8Array): Uint8Array {
  *
  * @param key - The `address_index` public key bytes to convert to an Ethereum
  * address.
+ * @param _cryptographicFunctions - Optional cryptographic functions (unused,
+ * kept for API consistency).
  * @returns The Ethereum address corresponding to the given key.
  */
-export function publicKeyToEthAddress(key: Uint8Array): Uint8Array {
+export function publicKeyToEthAddress(
+  key: Uint8Array,
+  _cryptographicFunctions?: CryptographicFunctions,
+): Uint8Array {
   assert(
     key instanceof Uint8Array &&
       isValidBytesKey(key, secp256k1.publicKeyLength),

--- a/src/derivers/bip39.ts
+++ b/src/derivers/bip39.ts
@@ -12,7 +12,11 @@ import type {
 } from '../constants';
 import { BYTES_KEY_LENGTH } from '../constants';
 import type { CryptographicFunctions } from '../cryptography';
-import { hmacSha512, pbkdf2Sha512 } from '../cryptography';
+import {
+  getPublicKeyForCurve,
+  hmacSha512,
+  pbkdf2Sha512,
+} from '../cryptography';
 import type { Curve, SupportedCurve } from '../curves';
 import { getCurveByName } from '../curves';
 import { PUBLIC_KEY_GUARD } from '../guard';
@@ -245,7 +249,7 @@ export async function createBip39KeyFromSeed(
     'Invalid private key: The private key must greater than 0 and less than the curve order.',
   );
 
-  const publicKey = curve.getPublicKey(privateKey, false);
+  const publicKey = getPublicKeyForCurve(curve.name, privateKey, false);
   const masterFingerprint = getFingerprint(
     curve.compressPublicKey(publicKey),
     curve.compressedPublicKeyLength,
@@ -314,7 +318,7 @@ export async function entropyToCip3MasterNode(
 
   assert(curve.isValidPrivateKey(privateKey), 'Invalid private key.');
 
-  const publicKey = curve.getPublicKey(privateKey, false);
+  const publicKey = getPublicKeyForCurve(curve.name, privateKey, false);
   const masterFingerprint = getFingerprint(
     curve.compressPublicKey(publicKey),
     curve.compressedPublicKeyLength,

--- a/src/derivers/cip3.ts
+++ b/src/derivers/cip3.ts
@@ -4,6 +4,7 @@ import type { DeriveChildKeyArgs } from '.';
 import { generateEntropy, getValidatedPath, validateNode } from './shared';
 import { BIP_32_HARDENED_OFFSET } from '../constants';
 import type { CryptographicFunctions } from '../cryptography';
+import { getPublicKeyForCurve } from '../cryptography';
 import { type Curve, mod } from '../curves';
 import { SLIP10Node } from '../SLIP10Node';
 import { numberToUint32 } from '../utils';
@@ -302,7 +303,8 @@ export const derivePublicKey = async (
   const zl = entropy.slice(0, 32);
 
   // right = [8ZL] * B
-  const right = curve.getPublicKey(
+  const right = getPublicKeyForCurve(
+    curve.name,
     // [8ZL]
     trunc28Mul8(zl),
   );

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -10,6 +10,12 @@ import {
   ed25519Bip32,
   getBIP44CoinTypeToAddressPathTuple,
   mnemonicToSeed,
+  hmacSha512,
+  keccak256,
+  pbkdf2Sha512,
+  ripemd160,
+  sha256,
+  getPublicKeyForCurve,
 } from '.';
 import * as index from '.';
 import * as guard from './guard';
@@ -29,6 +35,12 @@ describe('index', () => {
     expect(mnemonicPhraseToBytes).toBeDefined();
     expect(getBIP44CoinTypeToAddressPathTuple).toBeDefined();
     expect(mnemonicToSeed).toBeDefined();
+    expect(hmacSha512).toBeDefined();
+    expect(keccak256).toBeDefined();
+    expect(pbkdf2Sha512).toBeDefined();
+    expect(ripemd160).toBeDefined();
+    expect(sha256).toBeDefined();
+    expect(getPublicKeyForCurve).toBeDefined();
   });
 
   it.each(Object.keys(guard))('does not export %s', (property) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,14 @@ export type {
 } from './SLIP10Node';
 export { SLIP10Node } from './SLIP10Node';
 export type { CryptographicFunctions } from './cryptography';
+export {
+  hmacSha512,
+  keccak256,
+  pbkdf2Sha512,
+  ripemd160,
+  sha256,
+  getPublicKeyForCurve,
+} from './cryptography';
 export type { SupportedCurve } from './curves';
 export { secp256k1, ed25519, ed25519Bip32 } from './curves';
 export type {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,6 +23,7 @@ import {
   MAX_UNHARDENED_BIP_32_INDEX,
   UNPREFIXED_BIP_32_PATH_REGEX,
 } from './constants';
+import type { CryptographicFunctions } from './cryptography';
 import { ripemd160, sha256 } from './cryptography';
 import type { SupportedCurve } from './curves';
 import { curves } from './curves';
@@ -382,11 +383,14 @@ export const encodeBase58check = (value: Uint8Array): string => {
  *
  * @param publicKey - The compressed public key to get the fingerprint for.
  * @param compressedPublicKeyLength - The length of the compressed public key.
+ * @param _cryptographicFunctions - Optional cryptographic functions (unused,
+ * kept for API consistency).
  * @returns The fingerprint of the public key.
  */
 export const getFingerprint = (
   publicKey: Uint8Array,
   compressedPublicKeyLength: number,
+  _cryptographicFunctions: CryptographicFunctions = {},
 ): number => {
   if (!isValidBytesKey(publicKey, compressedPublicKeyLength)) {
     throw new Error(

--- a/yarn.lock
+++ b/yarn.lock
@@ -461,6 +461,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@craftzdog/react-native-buffer@npm:^6.0.5":
+  version: 6.1.1
+  resolution: "@craftzdog/react-native-buffer@npm:6.1.1"
+  dependencies:
+    ieee754: "npm:^1.2.1"
+    react-native-quick-base64: "npm:^2.2.2"
+  checksum: 10/a78a74d8c63597f601b79e3b14e809508d481a407b35041bd46e50a245f4c98382af574d2e9f01adaa77e26a5683ec2c47c7bf2392b49afeabdc37a1a5bfbac5
+  languageName: node
+  linkType: hard
+
 "@cspotcode/source-map-support@npm:^0.8.0":
   version: 0.8.1
   resolution: "@cspotcode/source-map-support@npm:0.8.1"
@@ -1132,6 +1142,7 @@ __metadata:
     "@metamask/eslint-config-jest": "npm:^14.0.0"
     "@metamask/eslint-config-nodejs": "npm:^14.0.0"
     "@metamask/eslint-config-typescript": "npm:^14.0.0"
+    "@metamask/native-utils": "npm:^0.7.0"
     "@metamask/scure-bip39": "npm:^2.1.1"
     "@metamask/utils": "npm:^11.0.1"
     "@noble/curves": "npm:^1.8.1"
@@ -1156,13 +1167,33 @@ __metadata:
     jest-it-up: "npm:^2.0.2"
     prettier: "npm:^3.3.3"
     prettier-plugin-packagejson: "npm:^2.3.0"
+    react-native-quick-crypto: "npm:^0.7.17"
     ts-jest: "npm:^28.0.7"
     ts-node: "npm:^10.9.1"
     typedoc: "npm:^0.26.11"
     typescript: "npm:~5.4.5"
     typescript-eslint: "npm:^8.6.0"
+  peerDependencies:
+    "@metamask/native-utils": "*"
+    react-native-quick-crypto: "*"
+  peerDependenciesMeta:
+    "@metamask/native-utils":
+      optional: true
+    react-native-quick-crypto:
+      optional: true
   languageName: unknown
   linkType: soft
+
+"@metamask/native-utils@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "@metamask/native-utils@npm:0.7.0"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+    react-native-nitro-modules: ^0.29.4
+  checksum: 10/82d04ae112ed7a70f75c1afce26390e7fbc51e2e6d07f13b2e8700865ba33314fc0c584b826aab06a51149bb4b59c7391b831588c720deb3725f42165e2750b3
+  languageName: node
+  linkType: hard
 
 "@metamask/scure-bip39@npm:^2.1.1":
   version: 2.1.1
@@ -2004,6 +2035,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"abort-controller@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "abort-controller@npm:3.0.0"
+  dependencies:
+    event-target-shim: "npm:^5.0.0"
+  checksum: 10/ed84af329f1828327798229578b4fe03a4dd2596ba304083ebd2252666bdc1d7647d66d0b18704477e1f8aa315f055944aa6e859afebd341f12d0a53c37b4b40
+  languageName: node
+  linkType: hard
+
 "acorn-jsx@npm:^5.3.2":
   version: 5.3.2
   resolution: "acorn-jsx@npm:5.3.2"
@@ -2286,10 +2326,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"async-function@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "async-function@npm:1.0.0"
+  checksum: 10/1a09379937d846f0ce7614e75071c12826945d4e417db634156bf0e4673c495989302f52186dfa9767a1d9181794554717badd193ca2bbab046ef1da741d8efd
+  languageName: node
+  linkType: hard
+
+"async-generator-function@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "async-generator-function@npm:1.0.0"
+  checksum: 10/3d49e7acbeee9e84537f4cb0e0f91893df8eba976759875ae8ee9e3d3c82f6ecdebdb347c2fad9926b92596d93cdfc78ecc988bcdf407e40433e8e8e6fe5d78e
+  languageName: node
+  linkType: hard
+
 "available-typed-arrays@npm:^1.0.5":
   version: 1.0.5
   resolution: "available-typed-arrays@npm:1.0.5"
   checksum: 10/4d4d5e86ea0425696f40717882f66a570647b94ac8d273ddc7549a9b61e5da099e149bf431530ccbd776bd74e02039eb8b5edf426e3e2211ee61af16698a9064
+  languageName: node
+  linkType: hard
+
+"available-typed-arrays@npm:^1.0.7":
+  version: 1.0.7
+  resolution: "available-typed-arrays@npm:1.0.7"
+  dependencies:
+    possible-typed-array-names: "npm:^1.0.0"
+  checksum: 10/6c9da3a66caddd83c875010a1ca8ef11eac02ba15fb592dc9418b2b5e7b77b645fa7729380a92d9835c2f05f2ca1b6251f39b993e0feb3f1517c74fa1af02cab
   languageName: node
   linkType: hard
 
@@ -2373,6 +2436,13 @@ __metadata:
   version: 1.0.2
   resolution: "balanced-match@npm:1.0.2"
   checksum: 10/9706c088a283058a8a99e0bf91b0a2f75497f185980d9ffa8b304de1d9e58ebda7c72c07ebf01dadedaac5b2907b2c6f566f660d62bd336c3468e960403b9d65
+  languageName: node
+  linkType: hard
+
+"base64-js@npm:^1.3.1":
+  version: 1.5.1
+  resolution: "base64-js@npm:1.5.1"
+  checksum: 10/669632eb3745404c2f822a18fc3a0122d2f9a7a13f7fb8b5823ee19d1d2ff9ee5b52c53367176ea4ad093c332fd5ab4bd0ebae5a8e27917a4105a4cfc86b1005
   languageName: node
   linkType: hard
 
@@ -2478,6 +2548,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"buffer@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "buffer@npm:6.0.3"
+  dependencies:
+    base64-js: "npm:^1.3.1"
+    ieee754: "npm:^1.2.1"
+  checksum: 10/b6bc68237ebf29bdacae48ce60e5e28fc53ae886301f2ad9496618efac49427ed79096750033e7eab1897a4f26ae374ace49106a5758f38fb70c78c9fda2c3b1
+  languageName: node
+  linkType: hard
+
 "bundle-name@npm:^3.0.0":
   version: 3.0.0
   resolution: "bundle-name@npm:3.0.0"
@@ -2533,6 +2613,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"call-bind-apply-helpers@npm:^1.0.0, call-bind-apply-helpers@npm:^1.0.1, call-bind-apply-helpers@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "call-bind-apply-helpers@npm:1.0.2"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+    function-bind: "npm:^1.1.2"
+  checksum: 10/00482c1f6aa7cfb30fb1dbeb13873edf81cfac7c29ed67a5957d60635a56b2a4a480f1016ddbdb3395cc37900d46037fb965043a51c5c789ffeab4fc535d18b5
+  languageName: node
+  linkType: hard
+
 "call-bind@npm:^1.0.0, call-bind@npm:^1.0.2, call-bind@npm:^1.0.4, call-bind@npm:^1.0.5":
   version: 1.0.5
   resolution: "call-bind@npm:1.0.5"
@@ -2541,6 +2631,28 @@ __metadata:
     get-intrinsic: "npm:^1.2.1"
     set-function-length: "npm:^1.1.1"
   checksum: 10/246d44db6ef9bbd418828dbd5337f80b46be4398d522eded015f31554cbb2ea33025b0203b75c7ab05a1a255b56ef218880cca1743e4121e306729f9e414da39
+  languageName: node
+  linkType: hard
+
+"call-bind@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "call-bind@npm:1.0.8"
+  dependencies:
+    call-bind-apply-helpers: "npm:^1.0.0"
+    es-define-property: "npm:^1.0.0"
+    get-intrinsic: "npm:^1.2.4"
+    set-function-length: "npm:^1.2.2"
+  checksum: 10/659b03c79bbfccf0cde3a79e7d52570724d7290209823e1ca5088f94b52192dc1836b82a324d0144612f816abb2f1734447438e38d9dafe0b3f82c2a1b9e3bce
+  languageName: node
+  linkType: hard
+
+"call-bound@npm:^1.0.2, call-bound@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "call-bound@npm:1.0.4"
+  dependencies:
+    call-bind-apply-helpers: "npm:^1.0.2"
+    get-intrinsic: "npm:^1.3.0"
+  checksum: 10/ef2b96e126ec0e58a7ff694db43f4d0d44f80e641370c21549ed911fecbdbc2df3ebc9bddad918d6bbdefeafb60bb3337902006d5176d72bcd2da74820991af7
   languageName: node
   linkType: hard
 
@@ -2977,6 +3089,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"define-data-property@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "define-data-property@npm:1.1.4"
+  dependencies:
+    es-define-property: "npm:^1.0.0"
+    es-errors: "npm:^1.3.0"
+    gopd: "npm:^1.0.1"
+  checksum: 10/abdcb2505d80a53524ba871273e5da75e77e52af9e15b3aa65d8aad82b8a3a424dad7aee2cc0b71470ac7acf501e08defac362e8b6a73cdb4309f028061df4ae
+  languageName: node
+  linkType: hard
+
 "define-lazy-prop@npm:^3.0.0":
   version: 3.0.0
   resolution: "define-lazy-prop@npm:3.0.0"
@@ -3133,6 +3256,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dunder-proto@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "dunder-proto@npm:1.0.1"
+  dependencies:
+    call-bind-apply-helpers: "npm:^1.0.1"
+    es-errors: "npm:^1.3.0"
+    gopd: "npm:^1.2.0"
+  checksum: 10/5add88a3d68d42d6e6130a0cac450b7c2edbe73364bbd2fc334564418569bea97c6943a8fcd70e27130bf32afc236f30982fc4905039b703f23e9e0433c29934
+  languageName: node
+  linkType: hard
+
 "eastasianwidth@npm:^0.2.0":
   version: 0.2.0
   resolution: "eastasianwidth@npm:0.2.0"
@@ -3285,10 +3419,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-define-property@npm:^1.0.0, es-define-property@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "es-define-property@npm:1.0.1"
+  checksum: 10/f8dc9e660d90919f11084db0a893128f3592b781ce967e4fccfb8f3106cb83e400a4032c559184ec52ee1dbd4b01e7776c7cd0b3327b1961b1a4a7008920fe78
+  languageName: node
+  linkType: hard
+
+"es-errors@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "es-errors@npm:1.3.0"
+  checksum: 10/96e65d640156f91b707517e8cdc454dd7d47c32833aa3e85d79f24f9eb7ea85f39b63e36216ef0114996581969b59fe609a94e30316b08f5f4df1d44134cf8d5
+  languageName: node
+  linkType: hard
+
 "es-module-lexer@npm:^1.5.3":
   version: 1.5.4
   resolution: "es-module-lexer@npm:1.5.4"
   checksum: 10/f29c7c97a58eb17640dcbd71bd6ef754ad4f58f95c3073894573d29dae2cad43ecd2060d97ed5b866dfb7804d5590fb7de1d2c5339a5fceae8bd60b580387fc5
+  languageName: node
+  linkType: hard
+
+"es-object-atoms@npm:^1.0.0, es-object-atoms@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "es-object-atoms@npm:1.1.1"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+  checksum: 10/54fe77de288451dae51c37bfbfe3ec86732dc3778f98f3eb3bdb4bf48063b2c0b8f9c93542656986149d08aa5be3204286e2276053d19582b76753f1a2728867
   languageName: node
   linkType: hard
 
@@ -3708,6 +3865,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"event-target-shim@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "event-target-shim@npm:5.0.1"
+  checksum: 10/49ff46c3a7facbad3decb31f597063e761785d7fdb3920d4989d7b08c97a61c2f51183e2f3a03130c9088df88d4b489b1b79ab632219901f184f85158508f4c8
+  languageName: node
+  linkType: hard
+
+"events@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "events@npm:3.3.0"
+  checksum: 10/a3d47e285e28d324d7180f1e493961a2bbb4cad6412090e4dec114f4db1f5b560c7696ee8e758f55e23913ede856e3689cd3aa9ae13c56b5d8314cd3b3ddd1be
+  languageName: node
+  linkType: hard
+
 "execa@npm:^5.0.0, execa@npm:^5.1.1":
   version: 5.1.1
   resolution: "execa@npm:5.1.1"
@@ -3899,6 +4070,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"for-each@npm:^0.3.5":
+  version: 0.3.5
+  resolution: "for-each@npm:0.3.5"
+  dependencies:
+    is-callable: "npm:^1.2.7"
+  checksum: 10/330cc2439f85c94f4609de3ee1d32c5693ae15cdd7fe3d112c4fd9efd4ce7143f2c64ef6c2c9e0cfdb0058437f33ef05b5bdae5b98fcc903fb2143fbaf0fea0f
+  languageName: node
+  linkType: hard
+
 "foreground-child@npm:^3.1.0":
   version: 3.1.1
   resolution: "foreground-child@npm:3.1.1"
@@ -3995,6 +4175,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"generator-function@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "generator-function@npm:2.0.1"
+  checksum: 10/eb7e7eb896c5433f3d40982b2ccacdb3dd990dd3499f14040e002b5d54572476513be8a2e6f9609f6e41ab29f2c4469307611ddbfc37ff4e46b765c326663805
+  languageName: node
+  linkType: hard
+
 "gensync@npm:^1.0.0-beta.2":
   version: 1.0.0-beta.2
   resolution: "gensync@npm:1.0.0-beta.2"
@@ -4021,10 +4208,41 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-intrinsic@npm:^1.2.4, get-intrinsic@npm:^1.3.0":
+  version: 1.3.1
+  resolution: "get-intrinsic@npm:1.3.1"
+  dependencies:
+    async-function: "npm:^1.0.0"
+    async-generator-function: "npm:^1.0.0"
+    call-bind-apply-helpers: "npm:^1.0.2"
+    es-define-property: "npm:^1.0.1"
+    es-errors: "npm:^1.3.0"
+    es-object-atoms: "npm:^1.1.1"
+    function-bind: "npm:^1.1.2"
+    generator-function: "npm:^2.0.0"
+    get-proto: "npm:^1.0.1"
+    gopd: "npm:^1.2.0"
+    has-symbols: "npm:^1.1.0"
+    hasown: "npm:^2.0.2"
+    math-intrinsics: "npm:^1.1.0"
+  checksum: 10/bb579dda84caa4a3a41611bdd483dade7f00f246f2a7992eb143c5861155290df3fdb48a8406efa3dfb0b434e2c8fafa4eebd469e409d0439247f85fc3fa2cc1
+  languageName: node
+  linkType: hard
+
 "get-package-type@npm:^0.1.0":
   version: 0.1.0
   resolution: "get-package-type@npm:0.1.0"
   checksum: 10/bba0811116d11e56d702682ddef7c73ba3481f114590e705fc549f4d868972263896af313c57a25c076e3c0d567e11d919a64ba1b30c879be985fc9d44f96148
+  languageName: node
+  linkType: hard
+
+"get-proto@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "get-proto@npm:1.0.1"
+  dependencies:
+    dunder-proto: "npm:^1.0.1"
+    es-object-atoms: "npm:^1.0.0"
+  checksum: 10/4fc96afdb58ced9a67558698b91433e6b037aaa6f1493af77498d7c85b141382cf223c0e5946f334fb328ee85dfe6edd06d218eaf09556f4bc4ec6005d7f5f7b
   languageName: node
   linkType: hard
 
@@ -4181,6 +4399,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"gopd@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "gopd@npm:1.2.0"
+  checksum: 10/94e296d69f92dc1c0768fcfeecfb3855582ab59a7c75e969d5f96ce50c3d201fd86d5a2857c22565764d5bb8a816c7b1e58f133ec318cd56274da36c5e3fb1a1
+  languageName: node
+  linkType: hard
+
 "graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
@@ -4225,6 +4450,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"has-property-descriptors@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "has-property-descriptors@npm:1.0.2"
+  dependencies:
+    es-define-property: "npm:^1.0.0"
+  checksum: 10/2d8c9ab8cebb572e3362f7d06139a4592105983d4317e68f7adba320fe6ddfc8874581e0971e899e633fd5f72e262830edce36d5a0bc863dad17ad20572484b2
+  languageName: node
+  linkType: hard
+
 "has-proto@npm:^1.0.1":
   version: 1.0.1
   resolution: "has-proto@npm:1.0.1"
@@ -4239,12 +4473,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"has-symbols@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "has-symbols@npm:1.1.0"
+  checksum: 10/959385c98696ebbca51e7534e0dc723ada325efa3475350951363cce216d27373e0259b63edb599f72eb94d6cde8577b4b2375f080b303947e560f85692834fa
+  languageName: node
+  linkType: hard
+
 "has-tostringtag@npm:^1.0.0":
   version: 1.0.0
   resolution: "has-tostringtag@npm:1.0.0"
   dependencies:
     has-symbols: "npm:^1.0.2"
   checksum: 10/95546e7132efc895a9ae64a8a7cf52588601fc3d52e0304ed228f336992cdf0baaba6f3519d2655e560467db35a1ed79f6420c286cc91a13aa0647a31ed92570
+  languageName: node
+  linkType: hard
+
+"has-tostringtag@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "has-tostringtag@npm:1.0.2"
+  dependencies:
+    has-symbols: "npm:^1.0.3"
+  checksum: 10/c74c5f5ceee3c8a5b8bc37719840dc3749f5b0306d818974141dda2471a1a2ca6c8e46b9d6ac222c5345df7a901c9b6f350b1e6d62763fec877e26609a401bfe
   languageName: node
   linkType: hard
 
@@ -4270,6 +4520,15 @@ __metadata:
   dependencies:
     function-bind: "npm:^1.1.2"
   checksum: 10/c330f8d93f9d23fe632c719d4db3d698ef7d7c367d51548b836069e06a90fa9151e868c8e67353cfe98d67865bf7354855db28fa36eb1b18fa5d4a3f4e7f1c90
+  languageName: node
+  linkType: hard
+
+"hasown@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "hasown@npm:2.0.2"
+  dependencies:
+    function-bind: "npm:^1.1.2"
+  checksum: 10/7898a9c1788b2862cf0f9c345a6bec77ba4a0c0983c7f19d610c382343d4f98fa260686b225dfb1f88393a66679d2ec58ee310c1d6868c081eda7918f32cc70a
   languageName: node
   linkType: hard
 
@@ -4411,6 +4670,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ieee754@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "ieee754@npm:1.2.1"
+  checksum: 10/d9f2557a59036f16c282aaeb107832dc957a93d73397d89bbad4eb1130560560eb695060145e8e6b3b498b15ab95510226649a0b8f52ae06583575419fe10fc4
+  languageName: node
+  linkType: hard
+
 "ignore@npm:^5.1.8, ignore@npm:^5.2.0, ignore@npm:^5.2.4, ignore@npm:^5.3.1, ignore@npm:^5.3.2":
   version: 5.3.2
   resolution: "ignore@npm:5.3.2"
@@ -4519,6 +4785,16 @@ __metadata:
     jsbn: "npm:1.1.0"
     sprintf-js: "npm:^1.1.3"
   checksum: 10/1ed81e06721af012306329b31f532b5e24e00cb537be18ddc905a84f19fe8f83a09a1699862bf3a1ec4b9dea93c55a3fa5faf8b5ea380431469df540f38b092c
+  languageName: node
+  linkType: hard
+
+"is-arguments@npm:^1.0.4":
+  version: 1.2.0
+  resolution: "is-arguments@npm:1.2.0"
+  dependencies:
+    call-bound: "npm:^1.0.2"
+    has-tostringtag: "npm:^1.0.2"
+  checksum: 10/471a8ef631b8ee8829c43a8ab05c081700c0e25180c73d19f3bf819c1a8448c426a9e8e601f278973eca68966384b16ceb78b8c63af795b099cd199ea5afc457
   languageName: node
   linkType: hard
 
@@ -4641,6 +4917,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-generator-function@npm:^1.0.7":
+  version: 1.1.2
+  resolution: "is-generator-function@npm:1.1.2"
+  dependencies:
+    call-bound: "npm:^1.0.4"
+    generator-function: "npm:^2.0.0"
+    get-proto: "npm:^1.0.1"
+    has-tostringtag: "npm:^1.0.2"
+    safe-regex-test: "npm:^1.1.0"
+  checksum: 10/cc50fa01034356bdfda26983c5457103240f201f4663c0de1257802714e40d36bcff7aee21091d37bbba4be962fa5c6475ce7ddbc0abfa86d6bef466e41e50a5
+  languageName: node
+  linkType: hard
+
 "is-glob@npm:^4.0.0, is-glob@npm:^4.0.1, is-glob@npm:^4.0.3, is-glob@npm:~4.0.1":
   version: 4.0.3
   resolution: "is-glob@npm:4.0.3"
@@ -4708,6 +4997,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-regex@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "is-regex@npm:1.2.1"
+  dependencies:
+    call-bound: "npm:^1.0.2"
+    gopd: "npm:^1.2.0"
+    has-tostringtag: "npm:^1.0.2"
+    hasown: "npm:^2.0.2"
+  checksum: 10/c42b7efc5868a5c9a4d8e6d3e9816e8815c611b09535c00fead18a1138455c5cb5e1887f0023a467ad3f9c419d62ba4dc3d9ba8bafe55053914d6d6454a945d2
+  languageName: node
+  linkType: hard
+
 "is-shared-array-buffer@npm:^1.0.2":
   version: 1.0.2
   resolution: "is-shared-array-buffer@npm:1.0.2"
@@ -4755,6 +5056,15 @@ __metadata:
   dependencies:
     which-typed-array: "npm:^1.1.11"
   checksum: 10/d953adfd3c41618d5e01b2a10f21817e4cdc9572772fa17211100aebb3811b6e3c2e308a0558cc87d218a30504cb90154b833013437776551bfb70606fb088ca
+  languageName: node
+  linkType: hard
+
+"is-typed-array@npm:^1.1.3":
+  version: 1.1.15
+  resolution: "is-typed-array@npm:1.1.15"
+  dependencies:
+    which-typed-array: "npm:^1.1.16"
+  checksum: 10/e8cf60b9ea85667097a6ad68c209c9722cfe8c8edf04d6218366469e51944c5cc25bae45ffb845c23f811d262e4314d3b0168748eb16711aa34d12724cdf0735
   languageName: node
   linkType: hard
 
@@ -5671,6 +5981,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"math-intrinsics@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "math-intrinsics@npm:1.1.0"
+  checksum: 10/11df2eda46d092a6035479632e1ec865b8134bdfc4bd9e571a656f4191525404f13a283a515938c3a8de934dbfd9c09674d9da9fa831e6eb7e22b50b197d2edd
+  languageName: node
+  linkType: hard
+
 "mdast-util-to-hast@npm:^13.0.0":
   version: 13.2.0
   resolution: "mdast-util-to-hast@npm:13.2.0"
@@ -6496,6 +6813,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"possible-typed-array-names@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "possible-typed-array-names@npm:1.1.0"
+  checksum: 10/2f44137b8d3dd35f4a7ba7469eec1cd9cfbb46ec164b93a5bc1f4c3d68599c9910ee3b91da1d28b4560e9cc8414c3cd56fedc07259c67e52cc774476270d3302
+  languageName: node
+  linkType: hard
+
 "postcss@npm:^8.1.10":
   version: 8.4.31
   resolution: "postcss@npm:8.4.31"
@@ -6563,6 +6887,13 @@ __metadata:
   version: 4.2.0
   resolution: "proc-log@npm:4.2.0"
   checksum: 10/4e1394491b717f6c1ade15c570ecd4c2b681698474d3ae2d303c1e4b6ab9455bd5a81566211e82890d5a5ae9859718cc6954d5150bb18b09b72ecb297beae90a
+  languageName: node
+  linkType: hard
+
+"process@npm:^0.11.10":
+  version: 0.11.10
+  resolution: "process@npm:0.11.10"
+  checksum: 10/dbaa7e8d1d5cf375c36963ff43116772a989ef2bb47c9bdee20f38fd8fc061119cf38140631cf90c781aca4d3f0f0d2c834711952b728953f04fd7d238f59f5b
   languageName: node
   linkType: hard
 
@@ -6638,6 +6969,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-native-quick-base64@npm:^2.2.2":
+  version: 2.2.2
+  resolution: "react-native-quick-base64@npm:2.2.2"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 10/aeebf6f520830dc042201e2a72a381fb29d1376fe0acdf9e266c8a7e3499f45534b11b27b2241bf6cf007ff82874b6def9fa52d62f0027953fc2e6f8d0009266
+  languageName: node
+  linkType: hard
+
+"react-native-quick-crypto@npm:^0.7.17":
+  version: 0.7.17
+  resolution: "react-native-quick-crypto@npm:0.7.17"
+  dependencies:
+    "@craftzdog/react-native-buffer": "npm:^6.0.5"
+    events: "npm:^3.3.0"
+    readable-stream: "npm:^4.5.2"
+    string_decoder: "npm:^1.3.0"
+    util: "npm:^0.12.5"
+  checksum: 10/3a51c4cdee05c2906f12be28f983873598325284e0f06d5248000b49cd57afe53de318ad53fec0e10923b31540a7506ca57764eca7869f0948996165a990d6a6
+  languageName: node
+  linkType: hard
+
 "read-cmd-shim@npm:^4.0.0":
   version: 4.0.0
   resolution: "read-cmd-shim@npm:4.0.0"
@@ -6653,6 +7007,19 @@ __metadata:
     string_decoder: "npm:^1.1.1"
     util-deprecate: "npm:^1.0.1"
   checksum: 10/b80b3e6a7fafb1c79de7db541de357f4a5ee73bd70c21672f5a7c840d27bb27bdb0151e7ba2fd82c4a888df22ce0c501b0d9f3e4dfe51688876701c437d59536
+  languageName: node
+  linkType: hard
+
+"readable-stream@npm:^4.5.2":
+  version: 4.7.0
+  resolution: "readable-stream@npm:4.7.0"
+  dependencies:
+    abort-controller: "npm:^3.0.0"
+    buffer: "npm:^6.0.3"
+    events: "npm:^3.3.0"
+    process: "npm:^0.11.10"
+    string_decoder: "npm:^1.3.0"
+  checksum: 10/bdf096c8ff59452ce5d08f13da9597f9fcfe400b4facfaa88e74ec057e5ad1fdfa140ffe28e5ed806cf4d2055f0b812806e962bca91dce31bc4cef08e53be3a4
   languageName: node
   linkType: hard
 
@@ -6865,6 +7232,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"safe-regex-test@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "safe-regex-test@npm:1.1.0"
+  dependencies:
+    call-bound: "npm:^1.0.2"
+    es-errors: "npm:^1.3.0"
+    is-regex: "npm:^1.2.1"
+  checksum: 10/ebdb61f305bf4756a5b023ad86067df5a11b26898573afe9e52a548a63c3bd594825d9b0e2dde2eb3c94e57e0e04ac9929d4107c394f7b8e56a4613bed46c69a
+  languageName: node
+  linkType: hard
+
 "safer-buffer@npm:>= 2.1.2 < 3.0.0":
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
@@ -6936,6 +7314,20 @@ __metadata:
     gopd: "npm:^1.0.1"
     has-property-descriptors: "npm:^1.0.0"
   checksum: 10/745ed1d7dc69a6185e0820082fe73838ab3dfd01e75cce83a41e4c1d68bbf34bc5fb38f32ded542ae0b557536b5d2781594499b5dcd19e7db138e06292a76c7b
+  languageName: node
+  linkType: hard
+
+"set-function-length@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "set-function-length@npm:1.2.2"
+  dependencies:
+    define-data-property: "npm:^1.1.4"
+    es-errors: "npm:^1.3.0"
+    function-bind: "npm:^1.1.2"
+    get-intrinsic: "npm:^1.2.4"
+    gopd: "npm:^1.0.1"
+    has-property-descriptors: "npm:^1.0.2"
+  checksum: 10/505d62b8e088468917ca4e3f8f39d0e29f9a563b97dbebf92f4bd2c3172ccfb3c5b8e4566d5fcd00784a00433900e7cb8fbc404e2dbd8c3818ba05bb9d4a8a6d
   languageName: node
   linkType: hard
 
@@ -7293,7 +7685,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string_decoder@npm:^1.1.1":
+"string_decoder@npm:^1.1.1, string_decoder@npm:^1.3.0":
   version: 1.3.0
   resolution: "string_decoder@npm:1.3.0"
   dependencies:
@@ -7939,6 +8331,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"util@npm:^0.12.5":
+  version: 0.12.5
+  resolution: "util@npm:0.12.5"
+  dependencies:
+    inherits: "npm:^2.0.3"
+    is-arguments: "npm:^1.0.4"
+    is-generator-function: "npm:^1.0.7"
+    is-typed-array: "npm:^1.1.3"
+    which-typed-array: "npm:^1.1.2"
+  checksum: 10/61a10de7753353dd4d744c917f74cdd7d21b8b46379c1e48e1c4fd8e83f8190e6bd9978fc4e5102ab6a10ebda6019d1b36572fa4a325e175ec8b789a121f6147
+  languageName: node
+  linkType: hard
+
 "uuid@npm:^9.0.1":
   version: 9.0.1
   resolution: "uuid@npm:9.0.1"
@@ -8035,6 +8440,21 @@ __metadata:
     gopd: "npm:^1.0.1"
     has-tostringtag: "npm:^1.0.0"
   checksum: 10/605e3e10b7118af904a0e79d0d50b95275102f06ec902734024989cd71354929f7acee50de43529d3baf5858e2e4eb32c75e6ebd226c888ad976d8140e4a3e71
+  languageName: node
+  linkType: hard
+
+"which-typed-array@npm:^1.1.16, which-typed-array@npm:^1.1.2":
+  version: 1.1.19
+  resolution: "which-typed-array@npm:1.1.19"
+  dependencies:
+    available-typed-arrays: "npm:^1.0.7"
+    call-bind: "npm:^1.0.8"
+    call-bound: "npm:^1.0.4"
+    for-each: "npm:^0.3.5"
+    get-proto: "npm:^1.0.1"
+    gopd: "npm:^1.2.0"
+    has-tostringtag: "npm:^1.0.2"
+  checksum: 10/12be30fb88567f9863186bee1777f11bea09dd59ed8b3ce4afa7dd5cade75e2f4cc56191a2da165113cc7cf79987ba021dac1e22b5b62aa7e5c56949f2469a68
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds support for using faster native functions in mobile app environments for cryptographic functions. It's relying on RN Metro bundler internal mechanism where it automatically prefer files with `.native.ts` suffix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces React Native native cryptography implementations and a unified getPublicKeyForCurve API, refactoring key/address derivation to use it and updating exports, tests, coverage, and peer deps.
> 
> - **Cryptography (Core/API)**:
>   - Add `src/cryptography/cryptography.native.ts` with native `hmacSha512`, `keccak256`, `pbkdf2Sha512`, `sha256`, `ripemd160`, and `getPublicKeyForCurve` using `@metamask/native-utils`/`react-native-quick-crypto`.
>   - Introduce `getPublicKeyForCurve` in `src/cryptography/cryptography.ts` and export via `src/cryptography/index.ts` and root `src/index.ts`.
>   - Add `src/cryptography/cryptography.types.ts` with typed override surface.
> - **Derivation Refactors**:
>   - Replace curve-specific public key derivations with `getPublicKeyForCurve` in `SLIP10Node`, `derivers/bip39.ts`, `derivers/cip3.ts`, and `derivers/bip32.ts`.
>   - Update `publicKeyToEthAddress` signature to accept optional `CryptographicFunctions`; propagate in `SLIP10Node.address`.
>   - Update `getFingerprint` to accept optional `CryptographicFunctions` and wire in `SLIP10Node.fingerprint`.
> - **Exports/Tests**:
>   - Export new cryptography functions from package root and add tests for hashing functions and `getPublicKeyForCurve`; update index export coverage tests.
> - **Tooling/Config**:
>   - Jest: exclude `*.native.ts` from coverage collection.
>   - Add dev/peer deps: `@metamask/native-utils`, `react-native-quick-crypto` with optional peer metadata.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 430bb77e96ba425487703a92abc9436c1b06d9ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->