### PR TITLE
chore: Update codeowners to `MetaMask/core-platform`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
 
-*                                    @MetaMask/snaps-devs
+* @MetaMask/core-platform


### PR DESCRIPTION
Replaces `snaps-devs` with `core-platform`.

We need to give `core-platform` write access before merging this.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Governance-only change with no runtime code impact; main risk is merge timing if the new team lacks repo permissions.
> 
> **Overview**
> Updates the repository-wide **CODEOWNERS** default (`*`) from `@MetaMask/snaps-devs` to `@MetaMask/core-platform`, so that team becomes the default review/ownership gate for all paths.
> 
> Merging should wait until **`core-platform` has write access** on the repo, as noted in the PR description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca381b4c03bdac2123348f61bbcc4e0a140d9451. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->